### PR TITLE
Virtualmin plugin updated for current setups

### DIFF
--- a/plugins/password/config.inc.php.dist
+++ b/plugins/password/config.inc.php.dist
@@ -308,7 +308,8 @@ $rcmail_config['hmailserver_server'] = array(
 // 5: domain-username
 // 6: username_domain
 // 7: domain_username
-$rcmail_config['password_virtualmin_format'] = 0;
+// 8: username@domain; mbox.username
+$rcmail_config['password_virtualmin_format'] = 8;
 
 
 // pw_usermod Driver options

--- a/plugins/password/drivers/virtualmin.php
+++ b/plugins/password/drivers/virtualmin.php
@@ -48,6 +48,10 @@ class rcube_virtualmin_password
             $pieces = explode("_", $username);
             $domain = $pieces[0];
             break;
+		case 8: // domain taken from alias, username left as it was
+			$email = $rcmail->user->data['alias'];
+			$domain = substr(strrchr($email, "@"), 1);
+			break
         default: // username@domain
             $domain = substr(strrchr($username, "@"), 1);
         }


### PR DESCRIPTION
This time it's patched against current version.

Added a new username format in Virtualmin driver,
which works for default Virtualmin settings where
username is user.postfix and domain is taken from
email address.

Example:
email - info@goodcoffee.com
login - info.goodcof

This mode of operation has not been handled by 
 Virtualmin driver before.
