### PR TITLE
add cookie path config option and use settings for js cookies

### DIFF
--- a/config/main.inc.php.dist
+++ b/config/main.inc.php.dist
@@ -238,6 +238,9 @@ $rcmail_config['session_domain'] = '';
 // session name. Default: 'roundcube_sessid'
 $rcmail_config['session_name'] = null;
 
+// session path: /webmail/
+$rcmail_config['session_path'] = '/';
+
 // Backend to use for session storage. Can either be 'db' (default) or 'memcache'
 // If set to memcache, a list of servers need to be specified in 'memcache_hosts'
 // Make sure the Memcache extension (http://pecl.php.net/package/memcache) version >= 2.0.0 is installed

--- a/program/include/rcube.php
+++ b/program/include/rcube.php
@@ -393,11 +393,18 @@ class rcube
         $sess_name   = $this->config->get('session_name');
         $sess_domain = $this->config->get('session_domain');
         $lifetime    = $this->config->get('session_lifetime', 0) * 60;
+        $path        = $this->config->get('session_path');
 
         // set session domain
         if ($sess_domain) {
             ini_set('session.cookie_domain', $sess_domain);
         }
+
+        // set session path
+        if ($path) {
+            ini_set('session.cookie_path', $path);
+        }
+
         // set session garbage collecting time according to session_lifetime
         if ($lifetime) {
             ini_set('session.gc_maxlifetime', $lifetime * 2);

--- a/program/include/rcube_output_html.php
+++ b/program/include/rcube_output_html.php
@@ -67,6 +67,11 @@ class rcube_output_html extends rcube_output
         $this->set_env('task', $task);
         $this->set_env('x_frame_options', $this->config->get('x_frame_options', 'sameorigin'));
 
+        // add cookie info
+        $this->set_env('cookie_domain', $this->config->get('session_domain'));
+        $this->set_env('cookie_path', $this->config->get('session_path'));
+        $this->set_env('cookie_secure', rcube_utils::https_check());
+
         // load the correct skin (in case user-defined)
         $this->set_skin($this->config->get('skin'));
 

--- a/program/js/common.js
+++ b/program/js/common.js
@@ -599,6 +599,15 @@ function rcube_mouse_is_over(ev, obj)
 // cookie functions by GoogieSpell
 function setCookie(name, value, expires, path, domain, secure)
 {
+  if (!path && rcmail.env.cookie_path)
+      path = rcmail.env.cookie_path;
+
+  if (!domain && rcmail.env.cookie_domain)
+      domain = rcmail.env.cookie_domain;
+
+  if (!secure && rcmail.env.cookie_secure)
+      secure = rcmail.env.cookie_secure;
+
   var curCookie = name + "=" + escape(value) +
       (expires ? "; expires=" + expires.toGMTString() : "") +
       (path ? "; path=" + path : "") +


### PR DESCRIPTION
1) add a config optioni to allow the setting for the cookie path. the domain and secure optoins are already configurable, path is the only option not current covered.

2) some cookies are also created by javascript, positions of splitter bars etc. they should also use the cookie options defined in the main config file
