### PR TITLE
use in parse_host HTTP_HOST for %d 

### DIFF
--- a/config/main.inc.php.dist
+++ b/config/main.inc.php.dist
@@ -68,10 +68,11 @@ $rcmail_config['smtp_debug'] = false;
 // to display a pulldown menu or set one host as string.
 // To use SSL/TLS connection, enter hostname with prefix ssl:// or tls://
 // Supported replacement variables:
-// %n - http hostname ($_SERVER['SERVER_NAME'])
-// %d - domain (http hostname without the first part)
+// %n - hostname ($_SERVER['SERVER_NAME'])
+// %t - hostname without the first part
+// %d - domain (http hostname $_SERVER['HTTP_HOST'] without the first part)
 // %s - domain name after the '@' from e-mail address provided at login screen
-// For example %n = mail.domain.tld, %d = domain.tld
+// For example %n = mail.domain.tld, %t = domain.tld
 $rcmail_config['default_host'] = '';
 
 // TCP port used for IMAP connections
@@ -135,10 +136,11 @@ $rcmail_config['messages_cache'] = false;
 // If left blank, the PHP mail() function is used
 // Supported replacement variables:
 // %h - user's IMAP hostname
-// %n - http hostname ($_SERVER['SERVER_NAME'])
-// %d - domain (http hostname without the first part)
+// %n - hostname ($_SERVER['SERVER_NAME'])
+// %t - hostname without the first part
+// %d - domain (http hostname $_SERVER['HTTP_HOST'] without the first part)
 // %z - IMAP domain (IMAP hostname without the first part)
-// For example %n = mail.domain.tld, %d = domain.tld
+// For example %n = mail.domain.tld, %t = domain.tld
 $rcmail_config['smtp_server'] = '';
 
 // SMTP port (default is 25; use 587 for STARTTLS or 465 for the
@@ -267,10 +269,11 @@ $rcmail_config['des_key'] = 'rcmail-!24ByteDESkey*Str';
 // Specify an array with 'host' => 'domain' values to support multiple hosts
 // Supported replacement variables:
 // %h - user's IMAP hostname
-// %n - http hostname ($_SERVER['SERVER_NAME'])
-// %d - domain (http hostname without the first part)
+// %n - hostname ($_SERVER['SERVER_NAME'])
+// %t - hostname without the first part
+// %d - domain (http hostname $_SERVER['HTTP_HOST'] without the first part)
 // %z - IMAP domain (IMAP hostname without the first part)
-// For example %n = mail.domain.tld, %d = domain.tld
+// For example %n = mail.domain.tld, %t = domain.tld
 $rcmail_config['username_domain'] = '';
 
 // This domain will be used to form e-mail addresses of new users
@@ -280,7 +283,7 @@ $rcmail_config['username_domain'] = '';
 // %n - http hostname ($_SERVER['SERVER_NAME'])
 // %d - domain (http hostname without the first part)
 // %z - IMAP domain (IMAP hostname without the first part)
-// For example %n = mail.domain.tld, %d = domain.tld
+// For example %n = mail.domain.tld, %t = domain.tld
 $rcmail_config['mail_domain'] = '';
 
 // Password charset.
@@ -532,10 +535,11 @@ $rcmail_config['ldap_public']['Verisign'] = array(
   'name'          => 'Verisign.com',
   // Replacement variables supported in host names:
   // %h - user's IMAP hostname
-  // %n - http hostname ($_SERVER['SERVER_NAME'])
-  // %d - domain (http hostname without the first part)
+  // %n - hostname ($_SERVER['SERVER_NAME'])
+  // %t - hostname without the first part
+  // %d - domain (http hostname $_SERVER['HTTP_HOST'] without the first part)
   // %z - IMAP domain (IMAP hostname without the first part)
-  // For example %n = mail.domain.tld, %d = domain.tld
+  // For example %n = mail.domain.tld, %t = domain.tld
   'hosts'         => array('directory.verisign.com'),
   'port'          => 389,
   'use_tls'	      => false,

--- a/program/include/rcube_utils.php
+++ b/program/include/rcube_utils.php
@@ -616,8 +616,10 @@ class rcube_utils
     {
         // %n - host
         $n = preg_replace('/:\d+$/', '', $_SERVER['SERVER_NAME']);
-        // %d - domain name without first part, e.g. %n=mail.domain.tld, %d=domain.tld
-        $d = preg_replace('/^[^\.]+\./', '', $n);
+        // %t - host name without first part, e.g. %n=mail.domain.tld, %t=domain.tld
+	$t = preg_replace('/^[^\.]+\./', '', $n);
+	// %d - domain name without first part
+        $d = preg_replace('/^[^\.]+\./', '', $_SERVER['HTTP_HOST']);
         // %h - IMAP host
         $h = $_SESSION['storage_host'] ? $_SESSION['storage_host'] : $host;
         // %z - IMAP domain without first part, e.g. %h=imap.domain.tld, %z=domain.tld
@@ -632,7 +634,7 @@ class rcube_utils
             }
         }
 
-        $name = str_replace(array('%n', '%d', '%h', '%z', '%s'), array($n, $d, $h, $z, $s[2]), $name);
+        $name = str_replace(array('%n', '%t', '%d', '%h', '%z', '%s'), array($n, $t, $d, $h, $z, $s[2]), $name);
         return $name;
     }
 


### PR DESCRIPTION
Use in parse_host function for domain resolve HTTP_HOST not hostname.
add %t for hostname without first part
For example roundcube box backend (rc.somedomain.tld) for reverse proxy on real domain (mail.example.com)
