### PR TITLE
add div wrapper to attachments for the correct work of text-overflow in classic

### DIFF
--- a/program/js/app.js
+++ b/program/js/app.js
@@ -3441,7 +3441,7 @@ function rcube_webmail()
 
       if (this.env.loadingicon)
         content = '<img src="'+this.env.loadingicon+'" alt="" class="uploading" />'+content;
-      content = '<a title="'+this.get_label('cancel')+'" onclick="return rcmail.cancel_attachment_upload(\''+ts+'\', \''+frame_name+'\');" href="#cancelupload" class="cancelupload">'
+      content = '<div class=deletewrap><a title="'+this.get_label('cancel')+'" onclick="return rcmail.cancel_attachment_upload(\''+ts+'\', \''+frame_name+'\');" href="#cancelupload" class="cancelupload"></div>'
         + (this.env.cancelicon ? '<img src="'+this.env.cancelicon+'" alt="" />' : this.get_label('cancel')) + '</a>' + content;
 
       this.add2attachment_list(ts, { name:'', html:content, classname:'uploading', complete:false });

--- a/program/steps/mail/attachments.inc
+++ b/program/steps/mail/attachments.inc
@@ -125,12 +125,13 @@ if (is_array($_FILES['_attachments']['tmp_name'])) {
         $button = Q(rcube_label('delete'));
       }
 
-      $content = html::a(array(
+      $content = html::div(array('class'=>'deletewrap'),
+      html::a(array(
         'href' => "#delete",
         'onclick' => sprintf("return %s.command('remove-attachment','rcmfile%s', this)", JS_OBJECT_NAME, $id),
         'title' => rcube_label('delete'),
         'class' => 'delete',
-      ), $button);
+      ), $button));
 
       $content .= Q($attachment['name']);
 

--- a/program/steps/mail/compose.inc
+++ b/program/steps/mail/compose.inc
@@ -1294,12 +1294,13 @@ function rcmail_compose_attachment_list($attrib)
         continue;
 
       $out .= html::tag('li', array('id' => 'rcmfile'.$id, 'class' => rcmail_filetype2classname($a_prop['mimetype'], $a_prop['name'])),
+        html::div(array('class'=>'deletewrap'),
         html::a(array(
             'href' => "#delete",
             'title' => rcube_label('delete'),
             'onclick' => sprintf("return %s.command('remove-attachment','rcmfile%s', this)", JS_OBJECT_NAME, $id),
             'class' => 'delete'),
-          $button) . Q($a_prop['name']));
+          $button)) . Q($a_prop['name']));
 
         $jslist['rcmfile'.$id] = array('name' => $a_prop['name'], 'complete' => true, 'mimetype' => $a_prop['mimetype']);
     }

--- a/skins/classic/mail.css
+++ b/skins/classic/mail.css
@@ -1462,7 +1462,7 @@ input.from_address
 {
   height: 18px;
   font-size: 11px;
-  padding-left: 2px;
+  padding-left: 20px;
   padding-top: 2px;
   padding-right: 4px;
   border-bottom: 1px solid #EBEBEB;
@@ -1474,6 +1474,7 @@ input.from_address
 
 #compose-attachments li a
 {
+  position: absolute;
   text-indent: -5000px;
   width: 17px;
   height: 16px;
@@ -1485,6 +1486,11 @@ input.from_address
 #compose-attachments li img
 {
   vertical-align: middle;
+}
+
+#compose-attachments li .deletewrap {
+  position: relative;
+  left: -18px;
 }
 
 #compose-attachments li a.delete,


### PR DESCRIPTION
backport for release 0.8
http://images.nestormedia.com/roundcube-text-overflow.png
patch add wrapper to html tag "a" to remove it from the stream. Then text-overflow work correctly on text
