### PR TITLE
Add link to inbox on the logo (#1488703) 

### DIFF
--- a/skins/larry/includes/header.html
+++ b/skins/larry/includes/header.html
@@ -19,7 +19,7 @@
 	<roundcube:container name="taskbar" id="taskbar" />
 	<roundcube:button command="settings" label="settings" class="button-settings" classSel="button-settings button-selected" innerClass="button-inner" />
 	</div>
-	<roundcube:object name="logo" src="/images/roundcube_logo.png" id="toplogo" border="0" alt="Logo" />
+	<roundcube:object name="logo" src="/images/roundcube_logo.png" id="toplogo" border="0" alt="Logo" onclick="rcmail.command('switch-task','mail');return false;" />
 </div>
 
 <br style="clear:both" />

--- a/skins/larry/styles.css
+++ b/skins/larry/styles.css
@@ -536,6 +536,7 @@ a.iconlink.upload {
 
 #toplogo {
 	padding-top: 2px;
+	cursor: pointer;
 }
 
 .topleft {


### PR DESCRIPTION
Link logo to inbox in manner that also works with $rcmail_config['skin_logo'].  This is consistent with behavior of the 'classic' theme (#1488703)
