### PR TITLE
Hide DB addressbook option

### DIFF
--- a/config/main.inc.php.dist
+++ b/config/main.inc.php.dist
@@ -514,10 +514,12 @@ $rcmail_config['undo_timeout'] = 0;
 // ----------------------------------
 
 // This indicates which type of address book to use. Possible choises:
-// 'sql' (default) and 'ldap'.
+// 'sql' (default), 'ldap' and ''.
 // If set to 'ldap' then it will look at using the first writable LDAP
 // address book as the primary address book and it will not display the
 // SQL address book in the 'Address Book' view.
+// If set to '' then no address book will be displayed or only the
+// addressbook which is created by a plugin (like CardDAV).
 $rcmail_config['address_book_type'] = 'sql';
 
 // In order to enable public ldap search, configure an array like the Verisign

--- a/program/include/rcmail.php
+++ b/program/include/rcmail.php
@@ -258,8 +258,8 @@ class rcmail extends rcube
     $autocomplete = (array) $this->config->get('autocomplete_addressbooks');
     $list = array();
 
-    // We are using the DB address book
-    if ($abook_type != 'ldap') {
+    // We are using the DB address book or a plugin address book
+    if ($abook_type != 'ldap' && $abook_type != '') {
       if (!isset($this->address_books['0']))
         $this->address_books['0'] = new rcube_contacts($this->db, $this->get_user_id());
       $list['0'] = array(


### PR DESCRIPTION
Hi,

This small diff adds the option to hide the DB addressbook, even when we dont use LDAP.

If you have a CardDAV plugin installed, then you may want to just hide the DB addressbook.
This patch gives you an option to do it :)

Thanks for the review
Jean-Louis
