### PR TITLE
Grancefully handle SSO redirections on Ajax requests

### DIFF
--- a/program/js/app.js
+++ b/program/js/app.js
@@ -6141,6 +6141,11 @@ function rcube_webmail()
     else if (request.status == 0 && status != 'abort')
       this.display_message(this.get_label('servererror') + ' (No connection)', 'error');
 
+    // redirect to url specified in location header if not empty
+    var location_url = request.getResponseHeader("Location");
+    if (location_url != '')
+      this.redirect(location_url);
+
     // re-send keep-alive requests after 30 seconds
     if (action == 'keep-alive')
       setTimeout(function(){ ref.keep_alive(); }, 30000);


### PR DESCRIPTION
On some SSO systems, when the SSO session is expired,
the system intercept HTTP requests and send a 302 "Found" HTTP code to the login page.
This patch handle this case in Roundcube Ajax requests, to redirect to the SSO login page.
Note that request.status don't have the 302 code (at least on Firefox), so we have to check the response headers for a Location field and redirect manually.
