### PR TITLE
Add option to define IMAP hosts that support password changes

### DIFF
--- a/plugins/password/config.inc.php.dist
+++ b/plugins/password/config.inc.php.dist
@@ -1,5 +1,14 @@
 <?php
 
+// Supported hosts
+// -----------------------
+// Array of hosts that support password changing.
+// Default is NULL. Supported hosts will feature
+// a Password option in Settings; others will not.
+// Example:
+//$rcmail_config['password_supported_hosts'] = array( 'mail.example.com', 'mail2.example.org' );
+$rcmail_config['password_supported_hosts'] = NULL;
+
 // Password Plugin options
 // -----------------------
 // A driver to use for password change. Default: "sql".

--- a/plugins/password/password.php
+++ b/plugins/password/password.php
@@ -55,6 +55,12 @@ class password extends rcube_plugin
         $rcmail = rcmail::get_instance();
 
         $this->load_config();
+        
+        $host = isset( $_SESSION['imap_host'] ) ? $_SESSION['imap_host'] : NULL;
+        $hosts = $rcmail->config->get( 'password_supported_hosts' );
+        if ( !empty( $hosts ) and !in_array( $host, $hosts ) {
+            return;
+        }
 
         // Exceptions list
         if ($exceptions = $rcmail->config->get('password_login_exceptions')) {

--- a/plugins/password/password.php
+++ b/plugins/password/password.php
@@ -3,7 +3,7 @@
 /*
  +-------------------------------------------------------------------------+
  | Password Plugin for Roundcube                                           |
- | @version @package_version@                                                             |
+ | @version @package_version@                                              |
  |                                                                         |
  | Copyright (C) 2009-2010, Roundcube Dev.                                 |
  |                                                                         |
@@ -58,7 +58,7 @@ class password extends rcube_plugin
         
         $host = isset( $_SESSION['imap_host'] ) ? $_SESSION['imap_host'] : NULL;
         $hosts = $rcmail->config->get( 'password_supported_hosts' );
-        if ( !empty( $hosts ) and !in_array( $host, $hosts ) {
+        if ( !empty( $hosts ) and !in_array( $host, $hosts ) ) {
             return;
         }
 


### PR DESCRIPTION
This patch adds the ability to define IMAP hosts in Roundcube that support password changes, i.e. the Password option is only displayed for supported hosts.
