### PR TITLE
Don't show Hidden addressbook when you Compose Mail

### DIFF
--- a/program/steps/mail/compose.inc
+++ b/program/steps/mail/compose.inc
@@ -1602,6 +1602,9 @@ function rcmail_addressbook_list($attrib = array())
             'onclick' => "return ".JS_OBJECT_NAME.".command('list-adresses','%s',this)"), '%s'));
 
     foreach ($RCMAIL->get_address_sources() as $j => $source) {
+        if ($source['hidden'])
+            continue;
+
         $id = strval(strlen($source['id']) ? $source['id'] : $j);
         $js_id = JQ($id);
 


### PR DESCRIPTION
Don't show addressbook with parameter 'hidden' equal true
in addressbooks list when you compose Mail.
Based on the check of Addressbook page.
