### PR TITLE
Add new identity level: one identity with edit only signature

### DIFF
--- a/config/main.inc.php.dist
+++ b/config/main.inc.php.dist
@@ -357,6 +357,7 @@ $rcmail_config['send_format_flowed'] = true;
 // 1 - many identities with possibility to edit all params but not email address
 // 2 - one identity with possibility to edit all params
 // 3 - one identity with possibility to edit all params but not email address
+// 4 - one identity with possibility to edit only signature
 $rcmail_config['identities_level'] = 0;
 
 // Mimetypes supported by the browser.

--- a/program/steps/settings/edit_identity.inc
+++ b/program/steps/settings/edit_identity.inc
@@ -97,6 +97,13 @@ function rcube_identity_form($attrib)
     $form['addressing']['content']['email']['class'] = 'disabled';
   }
 
+  if (IDENTITIES_LEVEL == 4) {
+    foreach($form['addressing']['content'] as $formfield => $value){
+      $form['addressing']['content'][$formfield]['disabled'] = true;
+      $form['addressing']['content'][$formfield]['class'] = 'disabled';
+    }
+  }
+
   $IDENTITY_RECORD['email'] = rcube_idn_to_utf8($IDENTITY_RECORD['email']);
 
   // Allow plugins to modify identity form content

--- a/program/steps/settings/save_identity.inc
+++ b/program/steps/settings/save_identity.inc
@@ -26,7 +26,7 @@ $a_boolean_cols = array('standard', 'html_signature');
 $updated = $default_id = false;
 
 // check input
-if (empty($_POST['_name']) || (empty($_POST['_email']) && IDENTITIES_LEVEL != 1 && IDENTITIES_LEVEL != 3))
+if (IDENTITIES_LEVEL != 4 && (empty($_POST['_name']) || (empty($_POST['_email']) && IDENTITIES_LEVEL != 1 && IDENTITIES_LEVEL != 3)))
 {
   $OUTPUT->show_message('formincomplete', 'warning');
   rcmail_overwrite_action('edit-identity');

--- a/program/steps/settings/save_identity.inc
+++ b/program/steps/settings/save_identity.inc
@@ -52,8 +52,17 @@ foreach ($a_boolean_cols as $col)
 }
 
 // unset email address if user has no rights to change it
-if (IDENTITIES_LEVEL == 1 || IDENTITIES_LEVEL == 3)
+if (IDENTITIES_LEVEL == 1 || IDENTITIES_LEVEL == 3 )
   unset($save_data['email']);
+
+if (IDENTITIES_LEVEL == 4 ){
+  unset($save_data['name']);
+  unset($save_data['email']);
+  unset($save_data['organization']);
+  unset($save_data['reply-to']);
+  unset($save_data['bcc']);
+  unset($save_data['standard']);
+}
 
 // Validate e-mail addresses
 $email_checks = array(rcube_idn_to_ascii($save_data['email']));


### PR DESCRIPTION
To limit inconsistency in user identities, we added a new identity level wich allow only one identity per user and allow to edit only signature. 
Be carefull to automaticaly fill displayname field with a plugin like new_user_identity or new_user_dialog if you want it to be set because user can't modify it himself after identity creation.
