### PR TITLE
Add host config option to http_authentication plugin.

### DIFF
--- a/plugins/http_authentication/config.inc.php.dist
+++ b/plugins/http_authentication/config.inc.php.dist
@@ -1,0 +1,9 @@
+<?php
+
+// HTTP Basic Authentication Plugin options
+// ----------------------------------------
+// Default mail host to log-in using user/password from HTTP Authentication.
+// This is useful if the users are free to choose arbitrary mail hosts (or
+// from a list), but have one host they usually want to log into.
+// Unlike $rcmail_config['default_host'] this must be a string!
+$rcmail_config['http_authentication_host'] = '';

--- a/plugins/http_authentication/http_authentication.php
+++ b/plugins/http_authentication/http_authentication.php
@@ -11,6 +11,8 @@
  *
  * See logout.html (in this directory) for an example how HTTP auth can be cleared.
  *
+ * For other configuration options, see config.inc.php.dist!
+ *
  * @version @package_version@
  * @license GNU GPLv3+
  * @author Thomas Bruederli
@@ -46,6 +48,13 @@ class http_authentication extends rcube_plugin
 
     function authenticate($args)
     {
+        // Load plugin's config file
+        $this->load_config();
+
+        $host = rcmail::get_instance()->config->get('http_authentication_host');
+        if (is_string($host) && trim($host) !== '')
+            $args['host'] = rcube_idn_to_ascii(rcube_parse_host($host));
+
         // Allow entering other user data in login form,
         // e.g. after log out (#1487953)
         if (!empty($args['user'])) {


### PR DESCRIPTION
This is useful if the users are free to choose arbitrary mail hosts (or
from a list), but have one host they usually want to log into.

Otherwise the username/password must always be typed in twice.

I submitted the patch to the dev mailing list some time ago, but it seems to have slipped through:
http://lists.roundcube.net/pipermail/dev/2011-May/010012.html
