### PR TITLE
Fixed small error in SQ-usercopy

### DIFF
--- a/plugins/squirrelmail_usercopy/squirrelmail_usercopy.php
+++ b/plugins/squirrelmail_usercopy/squirrelmail_usercopy.php
@@ -179,7 +179,7 @@ class squirrelmail_usercopy extends rcube_plugin
 				$rec['firstname'] = rcube_charset_convert(rtrim($sql_array['firstname']), $db_charset);
 				$rec['surname']   = rcube_charset_convert(rtrim($sql_array['lastname']), $db_charset);
 				$rec['email']     = rcube_charset_convert(rtrim($sql_array['email']), $db_charset);
-				$rec['note']      = rcube_charset_convert(rtrim($sql_array['label']), $db_charset);
+				$rec['notes']      = rcube_charset_convert(rtrim($sql_array['label']), $db_charset);
 
 				if ($rec['name'] && $rec['email'])
 					$this->abook[] = $rec;


### PR DESCRIPTION
the SQ-label field was incorrectly copied over to the "note" field. however the field expected by the abook object is "notes"
