### PR TITLE
fix syntax error in moduserprefs.sh

### DIFF
--- a/bin/moduserprefs.sh
+++ b/bin/moduserprefs.sh
@@ -31,7 +31,7 @@ function print_usage()
 
 
 // get arguments
-$args = rcube_utils:get_opt(array('u' => 'user', 'd' => 'delete'));
+$args = rcube_utils::get_opt(array('u' => 'user', 'd' => 'delete'));
 
 if ($_SERVER['argv'][1] == 'help') {
 	print_usage();


### PR DESCRIPTION
Added a missing colon as mentioned by Michael Heydekamp on the dev mailing list: http://lists.roundcube.net/pipermail/dev/2012-December/022031.html
