### PR TITLE
Update plugins/password/drivers/pam.php

### DIFF
--- a/plugins/password/drivers/pam.php
+++ b/plugins/password/drivers/pam.php
@@ -13,7 +13,7 @@ class rcube_pam_password
     {
         $user = $_SESSION['username'];
 
-        if (extension_loaded('pam')) {
+        if (extension_loaded('pam') || extension_loaded('pam_auth')) {
             if (pam_auth($user, $currpass, $error, false)) {
                 if (pam_chpass($user, $currpass, $newpass)) {
                     return PASSWORD_SUCCESS;


### PR DESCRIPTION
The Ubuntu package php5-auth-pam renames the PECL PAM extension to pam_auth, so this file should check for both.
