### PR TITLE
Fix for failover.

### DIFF
--- a/program/lib/Roundcube/rcube_user.php
+++ b/program/lib/Roundcube/rcube_user.php
@@ -72,17 +72,11 @@ class rcube_user
         }
 
         // BUGFIX: Fix for database replication.
-        /*
-          An error occurs when, on a database replication have diferences between the data from master and slave.
-          When the master server goes down, and the slave begin to respond, if there are a diffrence in user table
-          the USER ID(master) that is storage in SESSION is not from the same user in slave, then , when the slave database is on,
-          the current user changes.
-        */
-
-        if ($sql_arr["username"]!=$_SESSION["username"]){
-            $renew_user = rcube_user::query($_SESSION["username"], $_SESSION["imap_host"]); 
-            $_SESSION['user_id'] = $renew_user->ID; // setando a nova sessao
-           $sql_arr = $renew_user->data; //
+        // Verifying if the user gotten is the same from the user SESSION
+        if ($sql_arr['username']!=$_SESSION['username']){
+            $renew_user = rcube_user::query($_SESSION['username'], $_SESSION['imap_host']); 
+            $_SESSION['user_id'] = $renew_user->ID; // setting the new session
+            $sql_arr = $renew_user->data; //
         }
 
         if (!empty($sql_arr)) {

--- a/program/lib/Roundcube/rcube_user.php
+++ b/program/lib/Roundcube/rcube_user.php
@@ -71,6 +71,20 @@ class rcube_user
             $sql_arr = $this->db->fetch_assoc($sql_result);
         }
 
+        // BUGFIX: Fix for database replication.
+        /*
+          An error occurs when, on a database replication have diferences between the data from master and slave.
+          When the master server goes down, and the slave begin to respond, if there are a diffrence in user table
+          the USER ID(master) that is storage in SESSION is not from the same user in slave, then , when the slave database is on,
+          the current user changes.
+        */
+
+        if ($sql_arr["username"]!=$_SESSION["username"]){
+            $renew_user = rcube_user::query($_SESSION["username"], $_SESSION["imap_host"]); 
+            $_SESSION['user_id'] = $renew_user->ID; // setando a nova sessao
+           $sql_arr = $renew_user->data; //
+        }
+
         if (!empty($sql_arr)) {
             $this->ID       = $sql_arr['user_id'];
             $this->data     = $sql_arr;


### PR DESCRIPTION
I got a problem using roundcube in a failover server (2 sctrutures).

The problem is that, there are some differences in data between this two structures(such as user ids), if there is a user logged, and one of structures fails.The current user could be changed for another user, because the user_id stored in SESSION.

![roundcube 1 ](https://f.cloud.github.com/assets/308606/90918/a48d2ffa-6587-11e2-9b8a-08c8c35b5cfd.png)
