### PR TITLE
Prevent mandatory inclusion of 'anyone' and 'anonymous' in ACL configuration

### DIFF
--- a/plugins/acl/acl.php
+++ b/plugins/acl/acl.php
@@ -148,6 +148,7 @@ class acl extends rcube_plugin
 
         // Load localization and include scripts
         $this->load_config();
+        $this->specials = $this->rc->config->get('acl_specials', $this->specials);
         $this->add_texts('localization/', array('deleteconfirm', 'norights',
             'nouser', 'deleting', 'saving'));
         $this->include_script('acl.js');

--- a/plugins/acl/config.inc.php.dist
+++ b/plugins/acl/config.inc.php.dist
@@ -16,4 +16,6 @@ $rcmail_config['acl_users_field'] = 'mail';
 // The LDAP search filter will be &'d with search queries
 $rcmail_config['acl_users_filter'] = '';
 
+$rcmail_config['acl_specials'] = array();
+
 ?>

--- a/plugins/acl/config.inc.php.dist
+++ b/plugins/acl/config.inc.php.dist
@@ -16,6 +16,10 @@ $rcmail_config['acl_users_field'] = 'mail';
 // The LDAP search filter will be &'d with search queries
 $rcmail_config['acl_users_filter'] = '';
 
-$rcmail_config['acl_specials'] = array();
+// Include the following 'special' access control subjects in the ACL dialog;
+// Defaults to array('anyone', 'anonymous') (not when set to an empty array)
+// Example: array('anyone') to exclude 'anonymous'.
+// Set to an empty array to exclude all special aci subjects.
+$rcmail_config['acl_specials'] = array('anyone', 'anonymous');
 
 ?>


### PR DESCRIPTION
...mous' from the ACL configuration dialog
