### PR TITLE
List plugins that exist, but don't have a package.xml

### DIFF
--- a/program/steps/settings/about.inc
+++ b/program/steps/settings/about.inc
@@ -115,7 +115,7 @@ function rcube_plugin_data($name, &$plugins = array())
       }
     }
   }
-  else {
+  else if (!file_exists( INSTALL_PATH . "/plugins/$name/$name.php")) {
     unset($plugins[$name]);
   }
 }


### PR DESCRIPTION
/?_task=settings&_action=about would only list installed plugins that had a package.xml, omitting installed plugins that were successfully loaded but didn't have the package file. This caused confusion as to whether or not a plugin was successfully loaded.

Plugins that exist are now listed even if they don't have the package.xml. Plugins that don't exist are not listed.
