### PR TITLE
Test content_id with isset instead of a true/false value

### DIFF
--- a/program/lib/Roundcube/rcube_message.php
+++ b/program/lib/Roundcube/rcube_message.php
@@ -616,7 +616,7 @@ class rcube_message
 
                 foreach ($this->inline_parts as $inline_object) {
                     $part_url = $this->get_part_url($inline_object->mime_id, true);
-                    if ($inline_object->content_id)
+                    if (isset($inline_object->content_id))
                         $a_replaces['cid:'.$inline_object->content_id] = $part_url;
                     if ($inline_object->content_location) {
                         $a_replaces[$inline_object->content_location] = $part_url;


### PR DESCRIPTION
This broke html email in which one image had Content-ID: <0>, which is a
valid value but evaulates to false in this test.
