### PR TITLE
Save new password even if it has not changed

### DIFF
--- a/plugins/password/config.inc.php.dist
+++ b/plugins/password/config.inc.php.dist
@@ -31,6 +31,10 @@ $rcmail_config['password_login_exceptions'] = null;
 //$rcmail_config['password_hosts'] = array('mail.example.com', 'mail2.example.org');
 $rcmail_config['password_hosts'] = null;
 
+// Enables saving the new password even if it matches the old password. Useful
+// for upgrading the stored passwords after the encryption scheme has changed.
+$rcmail_config['password_force_save'] = false;
+
 
 // SQL Driver options
 // ------------------

--- a/plugins/password/password.php
+++ b/plugins/password/password.php
@@ -147,7 +147,7 @@ class password extends rcube_plugin
                 $rcmail->output->command('display_message', $this->gettext('passwordweak'), 'error');
             }
             // try to save the password
-            else if (!($res = $this->_save($curpwd, $newpwd))) {
+            else if ($sespwd == $newpwd && !$rcmail->config->get('password_force_save')) {
                 $rcmail->output->command('display_message', $this->gettext('successfullysaved'), 'confirmation');
 
                 // allow additional actions after password change (e.g. reset some backends)

--- a/plugins/password/password.php
+++ b/plugins/password/password.php
@@ -146,8 +146,12 @@ class password extends rcube_plugin
             else if ($check_strength && (!preg_match("/[0-9]/", $newpwd) || !preg_match("/[^A-Za-z0-9]/", $newpwd))) {
                 $rcmail->output->command('display_message', $this->gettext('passwordweak'), 'error');
             }
-            // try to save the password
+            // password is the same as the old one, do nothing, return success
             else if ($sespwd == $newpwd && !$rcmail->config->get('password_force_save')) {
+                $rcmail->output->command('display_message', $this->gettext('successfullysaved'), 'confirmation');
+            }
+            // try to save the password
+            else if (!($res = $this->_save($curpwd, $newpwd))) {
                 $rcmail->output->command('display_message', $this->gettext('successfullysaved'), 'confirmation');
 
                 // allow additional actions after password change (e.g. reset some backends)

--- a/plugins/password/password.php
+++ b/plugins/password/password.php
@@ -146,10 +146,6 @@ class password extends rcube_plugin
             else if ($check_strength && (!preg_match("/[0-9]/", $newpwd) || !preg_match("/[^A-Za-z0-9]/", $newpwd))) {
                 $rcmail->output->command('display_message', $this->gettext('passwordweak'), 'error');
             }
-            // password is the same as the old one, do nothing, return success
-            else if ($sespwd == $newpwd) {
-                $rcmail->output->command('display_message', $this->gettext('successfullysaved'), 'confirmation');
-            }
             // try to save the password
             else if (!($res = $this->_save($curpwd, $newpwd))) {
                 $rcmail->output->command('display_message', $this->gettext('successfullysaved'), 'confirmation');


### PR DESCRIPTION
I have recently changed the password scheme of my Dovecot/Postfix/Roundcube installation. New passwords are encrypted stronger than before. It is not possible to automatically update existing passwords (because the old encryption is not so bad that I can easily crack it). But I'd like to tell my users that they can upgrade to the new password scheme by simply submitting the "change password" form with their old password in all three input fields. Currently a minor optimization prevents this. I think this minor optimization should be removed.
