### PR TITLE
Add hook "message_check_safe"

### DIFF
--- a/program/steps/mail/func.inc
+++ b/program/steps/mail/func.inc
@@ -608,6 +608,8 @@ function rcmail_check_safe(&$message)
             $message->set_safe(true);
           }
         }
+
+        $RCMAIL->plugins->exec_hook('message_check_safe', array('message' => $message));
         break;
 
       case 2: // always


### PR DESCRIPTION
This hook can be used by https://github.com/JohnDoh/Roundcube-Plugin-Global-Address-Book to mark messages as safe whose sender exists in the global address book
