### PR TITLE
BUGFIX: Using Dovecot with MDBOX format of mailbox, if you delete a box with one or more sub-boxes, the dovecot can't remove the dir of parent box.

### DIFF
--- a/program/lib/Roundcube/rcube_imap.php
+++ b/program/lib/Roundcube/rcube_imap.php
@@ -3029,22 +3029,24 @@ class rcube_imap extends rcube_storage
             $sub_mboxes = $this->list_folders();
         }
 
+        foreach ($sub_mboxes as $c_mbox) {
+            if (strpos($c_mbox, $folder.$delm) === 0) {
+                $this->conn->unsubscribe($c_mbox);
+                if ($this->conn->deleteFolder($c_mbox)) {
+                    $this->clear_message_cache($c_mbox);
+                }
+                else {
+                    return false;
+                }
+            }
+        }
+
         // send delete command to server
         $result = $this->conn->deleteFolder($folder);
 
         if ($result) {
             // unsubscribe folder
             $this->conn->unsubscribe($folder);
-
-            foreach ($sub_mboxes as $c_mbox) {
-                if (strpos($c_mbox, $folder.$delm) === 0) {
-                    $this->conn->unsubscribe($c_mbox);
-                    if ($this->conn->deleteFolder($c_mbox)) {
-                        $this->clear_message_cache($c_mbox);
-                    }
-                }
-            }
-
             // clear folder-related cache
             $this->clear_message_cache($folder);
             $this->clear_cache('mailboxes', true);


### PR DESCRIPTION
PROBLEM: Using Dovecot with MDBOX format of mailbox, if you delete a folder with one or more sub-folders, the dovecot can't remove the dir of parent folder.

If the back-end use dovecot with MAILDIR, the DELETE action in mailbox, remove the parent and all children folders because the structure of files and folders is different of MDBOX ( I dont see the code, but I should look like a "rm -rf" on folder).

MAILDIR:

parent_folder
  |_cur
  |_new
  |_tmp
  |_child-folder
               |_cur
               |_new
               |_tmp

MDBOX:

parent-folder
   |_dirs_boxes
   |_child-folder
             |_dirs_boxes

To fix in roundcube:
I change the order of DELETE Boxes, first the remove the children folders after remove parent folder.
