### PR TITLE
Recommendation Set the cache-control directive to no-cache and no-store.

### DIFF
--- a/program/lib/Roundcube/rcube_output.php
+++ b/program/lib/Roundcube/rcube_output.php
@@ -162,7 +162,7 @@ abstract class rcube_output
             header("Cache-Control: private, must-revalidate");
         }
         else {
-            header("Cache-Control: private, no-cache, must-revalidate, post-check=0, pre-check=0");
+            header("Cache-Control: private, no-cache, no-store, must-revalidate, post-check=0, pre-check=0");
             header("Pragma: no-cache");
         }
     }


### PR DESCRIPTION
- fixed: ModSecurity: Warning. AppDefect: Cache-Control Response Header Missing 'no-store' flag. http://websecuritytool.codeplex.com/wikipage?title=Checks#http-cache-control-header-no-store
