### PR TITLE
Add support for using single Roundcube installation from multiple httpd servers on one host.

### DIFF
--- a/config/main.inc.php.dist
+++ b/config/main.inc.php.dist
@@ -184,6 +184,19 @@ $rcmail_config['smtp_timeout'] = 0;
 // ONLY ENABLE IT IF YOU'RE REALLY SURE WHAT YOU'RE DOING!
 $rcmail_config['enable_installer'] = false;
 
+// If this option set, all directories (log_dir, temp_dir, config dir for DB
+// and host configs and others) will be relative to $_SERVER['DOCUMENT_ROOT']
+// with this option appended.
+//
+// For example, when this option is set to '../rcube/', all additional
+// configuration files and all created files (logs, temp files, etc.) will be
+// placed into '$_SERVER['DOCUMENT_ROOT']/../rcube/'
+//
+// Also, if this set, main.inc.php will be loaded second time from
+// specified directory. It allows have global config
+// with only this option set.
+$rcmail_config['use_document_root'] = null;
+
 // don't allow these settings to be overriden by the user
 $rcmail_config['dont_override'] = array();
 

--- a/installer/index.php
+++ b/installer/index.php
@@ -41,7 +41,8 @@ ini_set('display_errors', 1);
 
 define('INSTALL_PATH', realpath(dirname(__FILE__) . '/../').'/');
 define('RCUBE_INSTALL_PATH', INSTALL_PATH);
-define('RCUBE_CONFIG_DIR', INSTALL_PATH . 'config/');
+define('RCUBE_BASE_CONFIG_DIR', INSTALL_PATH . 'config/');
+define('RCUBE_CONFIG_DIR', RCUBE_BASE_CONFIG_DIR);
 
 $include_path  = INSTALL_PATH . 'program/lib' . PATH_SEPARATOR;
 $include_path .= INSTALL_PATH . 'program/include' . PATH_SEPARATOR;

--- a/program/include/iniset.php
+++ b/program/include/iniset.php
@@ -37,8 +37,7 @@ if (!defined('RCUBE_LOCALIZATION_DIR')) {
 }
 
 define('RCUBE_INSTALL_PATH', INSTALL_PATH);
-define('RCUBE_CONFIG_DIR',  RCMAIL_CONFIG_DIR.'/');
-
+define('RCUBE_BASE_CONFIG_DIR',  RCMAIL_CONFIG_DIR.'/');
 
 // RC include folders MUST be included FIRST to avoid other
 // possible not compatible libraries (i.e PEAR) to be included

--- a/program/lib/Roundcube/bootstrap.php
+++ b/program/lib/Roundcube/bootstrap.php
@@ -65,8 +65,8 @@ if (!defined('RCUBE_INSTALL_PATH')) {
     define('RCUBE_INSTALL_PATH', RCUBE_LIB_DIR);
 }
 
-if (!defined('RCUBE_CONFIG_DIR')) {
-    define('RCUBE_CONFIG_DIR', RCUBE_INSTALL_PATH . 'config/');
+if (!defined('RCUBE_BASE_CONFIG_DIR')) {
+    define('RCUBE_BASE_CONFIG_DIR', RCUBE_INSTALL_PATH . 'config/');
 }
 
 if (!defined('RCUBE_PLUGINS_DIR')) {

--- a/program/lib/Roundcube/rcube.php
+++ b/program/lib/Roundcube/rcube.php
@@ -1040,7 +1040,7 @@ class rcube
         $log_dir  = self::$instance ? self::$instance->config->get('log_dir') : null;
 
         if (empty($log_dir)) {
-            $log_dir = RCUBE_INSTALL_PATH . 'logs';
+            $log_dir = RCUBE_ROOT_PATH . 'logs';
         }
 
         // try to open specific log file for writing

--- a/program/lib/Roundcube/rcube_config.php
+++ b/program/lib/Roundcube/rcube_config.php
@@ -68,8 +68,22 @@ class rcube_config
     private function load()
     {
         // load main config file
-        if (!$this->load_from_file(RCUBE_CONFIG_DIR . 'main.inc.php'))
+        if (!$this->load_from_file(RCUBE_BASE_CONFIG_DIR . 'main.inc.php'))
             $this->errors[] = 'main.inc.php was not found.';
+
+	// Set "root" path and everything, what depends on it
+	if ($this->prop['use_document_root']) {
+	    define('RCUBE_ROOT_PATH', realpath($_SERVER['DOCUMENT_ROOT'] . '/' . $this->prop['use_document_root']) . '/');
+	    define('RCUBE_CONFIG_DIR', RCUBE_ROOT_PATH . '/config/' );
+
+	    // Load local config file
+            if (!$this->load_from_file(RCUBE_CONFIG_DIR . 'main.inc.php'))
+                $this->errors[] = 'local main.inc.php was not found.';
+	}
+	else {
+	    define('RCUBE_ROOT_PATH', RCUBE_INSTALL_PATH);
+	    define('RCUBE_CONFIG_DIR', RCUBE_BASE_CONFIG_DIR);
+	}
 
         // load database config
         if (!$this->load_from_file(RCUBE_CONFIG_DIR . 'db.inc.php'))
@@ -93,8 +107,8 @@ class rcube_config
             $this->prop['skin'] = self::DEFAULT_SKIN;
 
         // fix paths
-        $this->prop['log_dir'] = $this->prop['log_dir'] ? realpath(unslashify($this->prop['log_dir'])) : RCUBE_INSTALL_PATH . 'logs';
-        $this->prop['temp_dir'] = $this->prop['temp_dir'] ? realpath(unslashify($this->prop['temp_dir'])) : RCUBE_INSTALL_PATH . 'temp';
+        $this->prop['log_dir'] = $this->prop['log_dir'] ? realpath(unslashify($this->prop['log_dir'])) : RCUBE_ROOT_PATH . 'logs';
+        $this->prop['temp_dir'] = $this->prop['temp_dir'] ? realpath(unslashify($this->prop['temp_dir'])) : RCUBE_ROOT_PATH . 'temp';
 
         // fix default imap folders encoding
         foreach (array('drafts_mbox', 'junk_mbox', 'sent_mbox', 'trash_mbox') as $folder)

--- a/program/lib/Roundcube/rcube_mime.php
+++ b/program/lib/Roundcube/rcube_mime.php
@@ -710,7 +710,7 @@ class rcube_mime
     {
         $mime_type = null;
         $mime_magic = rcube::get_instance()->config->get('mime_magic');
-        $mime_ext = $skip_suffix ? null : @include(RCUBE_CONFIG_DIR . '/mimetypes.php');
+        $mime_ext = $skip_suffix ? null : @include(RCUBE_BASE_CONFIG_DIR . '/mimetypes.php');
 
         // use file name suffix with hard-coded mime-type map
         if (is_array($mime_ext) && $name) {
@@ -818,7 +818,7 @@ class rcube_mime
 
         // fallback to some well-known types most important for daily emails
         if (empty($mime_types)) {
-            $mime_extensions = (array) @include(RCUBE_CONFIG_DIR . '/mimetypes.php');
+            $mime_extensions = (array) @include(RCUBE_BASE_CONFIG_DIR . '/mimetypes.php');
 
             foreach ($mime_extensions as $ext => $mime) {
                 $mime_types[$mime][] = $ext;


### PR DESCRIPTION
I have shared hosting server with such config:

Each user has its own copy of Apache, running from this user's account (and serving on localhost:40${userid}). Single nginx used to multiplex all requests according to hostnames to multiple Apache servers. So, no scripts or PHP code are running from "root" or "www" account.

Some users want to use Roundcube on their hosts, and want ability to configure it without my help (and without editing system configs, which they could not do anyway).

I, as host admin, want to have only one copy of Roundcube sources on my system, under control of package manager, as it allows me to upgrade software and track vulnerabilities. I don't want to monitor each user server for installed Roundcube and force them to upgrade.

Here is problem with current Roundcube: it allows to have per-host configuration files with 'include_host_config', but all of them should live in on directory, which should not be writable by users. Also, users could add server aliases, and when new server alias is added, it should be added to main Roundcube config too (to load appropriate host config). Or every server alias should have its own host config, in non-user-writable directory. It is ugly.

With this commit I've added new configuration parameter: 'use_document_root'

If this parameter is set, it is used as suffix to $_SERVER['DOCUMENT_ROOT'], and resulting path is used as new root for configuration, temporary and log directories. main.inc.php is reloaded from new config directory, and db.inc.php and host-dependent config is looked up in this new path, too. mimetypes.php, plugins and themes are still looked up in install path (maybe, it is good idea, to add ability to use per-user plugins and themes, too, but it is not included in this commit, as Roundcube should be able to find plugins and themes in TWO places, both system-wide and user-confgured, and it is much more intrusive changes).

This patch works well on my own server like this:

(1) Roundcube installed with packet manager to /usr/local/www/roundcube. No server uses/serves this path directly.
(2) "/usr/local/www/roundcube/config/main.inc.php" contains ONLY 'use_document_root' parameter, set to '../rcube'.
(3) Each user, who wants to use Roundcube on its host(s) has:
  (a)
      Alias /mail/ /usr/local/www/roundcube/
      in its httpd.conf
  (b) "rcube" directory created in home directory
  (c) "~/rcube/config/main.inc.php" and "~/rcube/config/db.inc.php" files with settings, usually pointing to "~/rcube/rcube.sqlite" as database, and with default 'log_dir' and 'temp_dir' settings, which gives "~/rcube/logs" and "~/rcube/temp", nice and clean.

It works great!

I'm sure, this commit is not perfect, it could break tests and using Roundcube library in other applications, as I don;t understand this part of Roundcube completely. Feel free to use ideas from this commit for proper implementation of this feature.
