### PR TITLE
Support Alias-to-User lookup with virtuser_query

### DIFF
--- a/plugins/virtuser_query/virtuser_query.php
+++ b/plugins/virtuser_query/virtuser_query.php
@@ -12,7 +12,7 @@
  * The email query could optionally select identity data columns in specified order:
  *    name, organization, reply-to, bcc, signature, html_signature
  *
- * $rcmail_config['virtuser_query'] = array('email' => '', 'user' => '', 'host' => '');
+ * $rcmail_config['virtuser_query'] = array('email' => '', 'user' => '', 'host' => '', 'alias' => '');
  *
  * The email query can return more than one record to create more identities.
  * This requires identities_level option to be set to value less than 2.
@@ -23,6 +23,7 @@
  * @version @package_version@
  * @author Aleksander Machniak <alec@alec.pl>
  * @author Steffen Vogel
+ * @author Tim Gerundt
  */
 class virtuser_query extends rcube_plugin
 {
@@ -48,6 +49,9 @@ class virtuser_query extends rcube_plugin
             }
             if ($this->config['host']) {
                 $this->add_hook('authenticate', array($this, 'user2host'));
+            }
+            if ($this->config['alias']) {
+                $this->add_hook('authenticate', array($this, 'alias2user'));
             }
         }
     }
@@ -122,6 +126,22 @@ class virtuser_query extends rcube_plugin
     }
 
     /**
+     * Alias > User
+     */
+    function alias2user($p)
+    {
+        $dbh = $this->get_dbh();
+
+        $sql_result = $dbh->query(preg_replace('/%u/', $dbh->escape($p['user']), $this->config['alias']));
+
+        if ($sql_arr = $dbh->fetch_array($sql_result)) {
+            $p['user'] = $sql_arr[0];
+        }
+
+        return $p;
+    }
+
+    /**
      * Initialize database handler
      */
     function get_dbh()
@@ -142,4 +162,3 @@ class virtuser_query extends rcube_plugin
     }
 
 }
-


### PR DESCRIPTION
This changes allow the plugin virtuser_query to do a Alias-to-User lookup.

You can for example reactivate the old alias behavior from Roundcube before 0.9.0. :)

``` php
$rcmail_config['virtuser_query'] = array('alias' => "SELECT username FROM users WHERE alias = '%u'");
```
