### PR TITLE
adds admin-defined fallback skin

### DIFF
--- a/config/main.inc.php.dist
+++ b/config/main.inc.php.dist
@@ -723,6 +723,9 @@ $rcmail_config['default_charset'] = 'ISO-8859-1';
 // skin name: folder from skins/
 $rcmail_config['skin'] = 'larry';
 
+// default/fallback skin name: folder from skins/
+$rcmail_config['skin'] = 'larry';
+
 // show up to X items in messages list view
 $rcmail_config['mail_pagesize'] = 50;
 

--- a/program/include/rcmail_output_html.php
+++ b/program/include/rcmail_output_html.php
@@ -158,11 +158,20 @@ class rcmail_output_html extends rcmail_output
             $valid = true;
         }
         else {
-            $skin_path = $this->config->get('skin_path');
-            if (!$skin_path) {
-                $skin_path = 'skins/' . rcube_config::DEFAULT_SKIN;
+            $rcube = rcube::get_instance();
+            $default_skin = $rcube->config->get('default_skin');
+
+            if (!empty($default_skin) && is_dir('skins/'.$default_skin) && is_readable('skins/'.$default_skin)) {
+                $skin_path = 'skins/'.$default_skin;
+                $valid = !$skin;
             }
-            $valid = !$skin;
+            else {
+              $skin_path = $this->config->get('skin_path');
+              if (!$skin_path) {
+                  $skin_path = 'skins/' . rcube_config::DEFAULT_SKIN;
+              }
+              $valid = !$skin;
+            }
         }
 
         $this->config->set('skin_path', $skin_path);


### PR DESCRIPTION
This fixes the following situation:
Site deploys with 'larry' as skin.
User logs in, has preferences written, with 'larry' as skin.
Admin replaces 'larry' with 'myskin', both the folder and the 'skin' setting in the config
User gets 501 error.

The problem comes from a few angles, and this is a little bit bandaid-ish.

The config gets overwritten (rather than supplemented by) user preferences, so pulling out the original skin setting can't happen. The new 'default_skin' setting allows access to an admin-set config.

'larry' is a constant hard-coded into the html output class, so if it's ever replaced, the fallback as defined in rcmail_output_html->set_skin() falls apart.

This adds a check for the admin-defined default skin before defaulting to 'larry'.
