### PR TITLE
Add show_actual_foldernames preference and configuration option.

### DIFF
--- a/config/main.inc.php.dist
+++ b/config/main.inc.php.dist
@@ -469,6 +469,9 @@ $rcmail_config['trash_mbox'] = 'Trash';
 // NOTE: Use folder names with namespace prefix (INBOX. on Courier-IMAP)
 $rcmail_config['default_folders'] = array('INBOX', 'Drafts', 'Sent', 'Junk', 'Trash');
 
+// Disable localization of the four default folder names listed above
+$rcmail_config['show_actual_foldernames'] = false;
+
 // automatically create the above listed default folders on first login
 $rcmail_config['create_default_folders'] = false;
 

--- a/config/main.inc.php.dist
+++ b/config/main.inc.php.dist
@@ -470,7 +470,7 @@ $rcmail_config['trash_mbox'] = 'Trash';
 $rcmail_config['default_folders'] = array('INBOX', 'Drafts', 'Sent', 'Junk', 'Trash');
 
 // Disable localization of the four default folder names listed above
-$rcmail_config['show_actual_foldernames'] = false;
+$rcmail_config['show_real_foldernames'] = false;
 
 // automatically create the above listed default folders on first login
 $rcmail_config['create_default_folders'] = false;

--- a/program/include/rcmail.php
+++ b/program/include/rcmail.php
@@ -1326,7 +1326,7 @@ class rcmail extends rcube
         $msgcounts = $this->storage->get_cache('messagecount');
         $collapsed = $this->config->get('collapsed_folders');
 
-        if ($this->config->get('show_actual_foldernames'))
+        if ($this->config->get('show_real_foldernames'))
             $realnames = true;
 
         $out = '';
@@ -1494,7 +1494,7 @@ class rcmail extends rcube
             if ($count > 1) {
                 for ($i = 0; $i < $count; $i++) {
                     $folder = implode($delimiter, array_slice($path, 0, -$i));
-                    if (!$this->config->get('show_actual_foldernames') &&
+                    if (!$this->config->get('show_real_foldernames') &&
                         ($folder_class = $this->folder_classname($folder))) {
                         $name = implode($delimiter, array_slice($path, $count - $i));
                         return $this->gettext($folder_class) . $delimiter . rcube_charset::convert($name, 'UTF7-IMAP');
@@ -1503,7 +1503,7 @@ class rcmail extends rcube
             }
         }
 
-        if (!$this->config->get('show_actual_foldernames') &&
+        if (!$this->config->get('show_real_foldernames') &&
             ($folder_class = $this->folder_classname($name))) {
             return $this->gettext($folder_class);
         }

--- a/program/include/rcmail.php
+++ b/program/include/rcmail.php
@@ -1326,6 +1326,9 @@ class rcmail extends rcube
         $msgcounts = $this->storage->get_cache('messagecount');
         $collapsed = $this->config->get('collapsed_folders');
 
+        if ($this->config->get('show_actual_foldernames'))
+            $realnames = true;
+
         $out = '';
         foreach ($arrFolders as $folder) {
             $title        = null;
@@ -1491,7 +1494,8 @@ class rcmail extends rcube
             if ($count > 1) {
                 for ($i = 0; $i < $count; $i++) {
                     $folder = implode($delimiter, array_slice($path, 0, -$i));
-                    if ($folder_class = $this->folder_classname($folder)) {
+                    if (!$this->config->get('show_actual_foldernames') &&
+                        ($folder_class = $this->folder_classname($folder))) {
                         $name = implode($delimiter, array_slice($path, $count - $i));
                         return $this->gettext($folder_class) . $delimiter . rcube_charset::convert($name, 'UTF7-IMAP');
                     }
@@ -1499,7 +1503,8 @@ class rcmail extends rcube
             }
         }
 
-        if ($folder_class = $this->folder_classname($name)) {
+        if (!$this->config->get('show_actual_foldernames') &&
+            ($folder_class = $this->folder_classname($name))) {
             return $this->gettext($folder_class);
         }
         else {

--- a/program/localization/en_GB/labels.inc
+++ b/program/localization/en_GB/labels.inc
@@ -37,6 +37,7 @@ $labels['drafts'] = 'Drafts';
 $labels['sent']   = 'Sent';
 $labels['trash']  = 'Deleted Items';
 $labels['junk']   = 'Junk';
+$labels['show_actual_foldernames'] = 'Show actual names for special folders';
 
 // message listing
 $labels['subject'] = 'Subject';

--- a/program/localization/en_GB/labels.inc
+++ b/program/localization/en_GB/labels.inc
@@ -37,7 +37,7 @@ $labels['drafts'] = 'Drafts';
 $labels['sent']   = 'Sent';
 $labels['trash']  = 'Deleted Items';
 $labels['junk']   = 'Junk';
-$labels['show_actual_foldernames'] = 'Show actual names for special folders';
+$labels['show_real_foldernames'] = 'Show real names for special folders';
 
 // message listing
 $labels['subject'] = 'Subject';

--- a/program/steps/settings/func.inc
+++ b/program/steps/settings/func.inc
@@ -771,16 +771,16 @@ function rcmail_user_prefs($current=null)
     );
 
 
-    if (!isset($no_override['show_actual_foldernames'])) {
-      $field_id = 'show_actual_foldernames';
-      $input_show_actual_foldernames =
-          new html_checkbox(array('name' => '_show_actual_foldernames',
+    if (!isset($no_override['show_real_foldernames'])) {
+      $field_id = 'show_real_foldernames';
+      $input_show_real_foldernames =
+          new html_checkbox(array('name' => '_show_real_foldernames',
                                   'id' => $field_id, 'value' => 1));
 
-      $blocks['main']['options']['show_actul_foldernames'] = array(
+      $blocks['main']['options']['show_real_foldernames'] = array(
         'title' => html::label($field_id,
-                               Q(rcube_label('show_actual_foldernames'))),
-        'content' => $input_show_actual_foldernames->show($config['show_actual_foldernames']?1:0),
+                               Q(rcube_label('show_real_foldernames'))),
+        'content' => $input_show_real_foldernames->show($config['show_real_foldernames']?1:0),
       );
     }
     // Configure special folders

--- a/program/steps/settings/func.inc
+++ b/program/steps/settings/func.inc
@@ -770,6 +770,19 @@ function rcmail_user_prefs($current=null)
       'main' => array('name' => Q(rcube_label('mainoptions'))),
     );
 
+
+    if (!isset($no_override['show_actual_foldernames'])) {
+      $field_id = 'show_actual_foldernames';
+      $input_show_actual_foldernames =
+          new html_checkbox(array('name' => '_show_actual_foldernames',
+                                  'id' => $field_id, 'value' => 1));
+
+      $blocks['main']['options']['show_actul_foldernames'] = array(
+        'title' => html::label($field_id,
+                               Q(rcube_label('show_actual_foldernames'))),
+        'content' => $input_show_actual_foldernames->show($config['show_actual_foldernames']?1:0),
+      );
+    }
     // Configure special folders
     if (!isset($no_override['default_folders'])) {
       // load folders list only when needed

--- a/program/steps/settings/save_prefs.inc
+++ b/program/steps/settings/save_prefs.inc
@@ -119,8 +119,8 @@ switch ($CURR_SECTION)
 
   case 'folders':
     $a_user_prefs = array(
-      'show_actual_foldernames'  =>
-      isset($_POST['_show_actual_foldernames']) ? TRUE : FALSE,
+      'show_real_foldernames'  =>
+      isset($_POST['_show_real_foldernames']) ? TRUE : FALSE,
       'drafts_mbox' => get_input_value('_drafts_mbox', RCUBE_INPUT_POST, true),
       'sent_mbox'   => get_input_value('_sent_mbox', RCUBE_INPUT_POST, true),
       'junk_mbox'   => get_input_value('_junk_mbox', RCUBE_INPUT_POST, true),

--- a/program/steps/settings/save_prefs.inc
+++ b/program/steps/settings/save_prefs.inc
@@ -119,6 +119,8 @@ switch ($CURR_SECTION)
 
   case 'folders':
     $a_user_prefs = array(
+      'show_actual_foldernames'  =>
+      isset($_POST['_show_actual_foldernames']) ? TRUE : FALSE,
       'drafts_mbox' => get_input_value('_drafts_mbox', RCUBE_INPUT_POST, true),
       'sent_mbox'   => get_input_value('_sent_mbox', RCUBE_INPUT_POST, true),
       'junk_mbox'   => get_input_value('_junk_mbox', RCUBE_INPUT_POST, true),


### PR DESCRIPTION
When enabled this setting shows actual folder names rather than
the localised verions for the four default folders:

$rcmail_config['default_folders'] =
  array('INBOX', 'Drafts', 'sent-mail', 'spam', 'Trash');
