### PR TITLE
Fix http_authentication_host usage

### DIFF
--- a/plugins/http_authentication/http_authentication.php
+++ b/plugins/http_authentication/http_authentication.php
@@ -52,7 +52,7 @@ class http_authentication extends rcube_plugin
         $this->load_config();
 
         $host = rcmail::get_instance()->config->get('http_authentication_host');
-        if (is_string($host) && trim($host) !== '')
+        if (is_string($host) && trim($host) !== '' && empty($args['host']))
             $args['host'] = rcube_utils::idn_to_ascii(rcube_utils::parse_host($host));
 
         // Allow entering other user data in login form,


### PR DESCRIPTION
Without this fix it is impossible to use a host different from config
option "http_authentication_host" after logout (fixup aec2869).
