### PR TITLE
Added Luxembourgish to list of supported languages

### DIFF
--- a/program/localization/index.inc
+++ b/program/localization/index.inc
@@ -70,6 +70,7 @@ $rcube_languages = array(
   'ku'    => 'Kurdish (Kurmancî)',
   'lv_LV' => 'Latvian (Latviešu)',
   'lt_LT' => 'Lithuanian (Lietuviškai)',
+  'lb'    => 'Luxembourgish (Lëtzebuergesch)',
   'mk_MK' => 'Macedonian (Македонски)',
   'ms_MY' => 'Malay (Bahasa Melayu)',
   'ml_IN' => 'Malayalam (മലയാളം)',


### PR DESCRIPTION
Translations were already added to Transifex (except for two plugins): https://www.transifex.com/projects/p/roundcube-webmail/language/lb/
