### PR TITLE
Update .htaccess and adding default font size

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -21,9 +21,6 @@ php_flag	session.auto_start	Off
 php_value	session.gc_maxlifetime	21600
 php_value	session.gc_divisor	500
 php_value	session.gc_probability	1
-
-# http://bugs.php.net/bug.php?id=30766
-php_value	mbstring.func_overload	0
 </IfModule>
 
 <IfModule mod_rewrite.c>

--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -965,8 +965,5 @@ $config['autocomplete_single'] = false;
 // Georgia, Helvetica, Impact, Tahoma, Terminal, Times New Roman, Trebuchet MS, Verdana
 $config['default_font'] = 'Verdana';
 
-// Default font size for composed HTML message.
-$config['default_font_size'] = '12px';
-
 // Enables display of email address with name instead of a name (and address in title)
 $config['message_show_email'] = false;

--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -965,5 +965,8 @@ $config['autocomplete_single'] = false;
 // Georgia, Helvetica, Impact, Tahoma, Terminal, Times New Roman, Trebuchet MS, Verdana
 $config['default_font'] = 'Verdana';
 
+// Default font size for composed HTML message.
+$config['default_font_size'] = '12px';
+
 // Enables display of email address with name instead of a name (and address in title)
 $config['message_show_email'] = false;

--- a/program/steps/mail/sendmail.inc
+++ b/program/steps/mail/sendmail.inc
@@ -472,12 +472,13 @@ $isHtml = (bool) get_input_value('_is_html', RCUBE_INPUT_POST);
 $message_body = get_input_value('_message', RCUBE_INPUT_POST, TRUE, $message_charset);
 
 if ($isHtml) {
-  $font   = rcube_fontdefs($RCMAIL->config->get('default_font'));
-  $bstyle = $font && is_string($font) ? " style='font-family: $font'" : '';
+  $font     = rcube_fontdefs($RCMAIL->config->get('default_font'));
+  $fontsize = $RCMAIL->config->get('default_font_size');
+  $bstyle   = $font && is_string($font) ? ' style="font-family: '.$font.'; font-size: '.$fontsize.';"' : 'font-size: '.$fontsize.';';
 
   // append doctype and html/body wrappers
   $message_body = '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN">' .
-    "\r\n<html><body$bstyle>\r\n" . $message_body;
+    "\r\n<html><body".$bstyle.">\r\n" . $message_body;
 }
 
 if (!$savedraft) {


### PR DESCRIPTION
htaccess: Deleted a bugfix for PHP4, because the current version requires at least PHP 5.2.1. The case thus never occurs.

The other two files I added the default font size for mails. Ticket: http://trac.roundcube.net/ticket/1489175
