### PR TITLE
Accept contacts without an email address

### DIFF
--- a/program/lib/Roundcube/rcube_contacts.php
+++ b/program/lib/Roundcube/rcube_contacts.php
@@ -580,29 +580,6 @@ class rcube_contacts extends rcube_addressbook
 
 
     /**
-     * Check the given data before saving.
-     * If input not valid, the message to display can be fetched using get_error()
-     *
-     * @param array Assoziative array with data to save
-     * @param boolean Try to fix/complete record automatically
-     * @return boolean True if input is valid, False if not.
-     */
-    public function validate(&$save_data, $autofix = false)
-    {
-        // validate e-mail addresses
-        $valid = parent::validate($save_data, $autofix);
-
-        // require at least one e-mail address (syntax check is already done)
-        if ($valid && !array_filter($this->get_col_values('email', $save_data, true))) {
-            $this->set_error(self::ERROR_VALIDATE, 'noemailwarning');
-            $valid = false;
-        }
-
-        return $valid;
-    }
-
-
-    /**
      * Create a new contact record
      *
      * @param array Associative array with save data


### PR DESCRIPTION
In order to use Roundcube as a real address book, there should be no required fields except those used as unique key.

This myroundcube issue is closely related: https://code.google.com/p/myroundcube/issues/detail?id=534
The difference is that I'm not using carddav, but importing from a vcf file.
