### PR TITLE
Update mail.css

### DIFF
--- a/skins/larry/mail.css
+++ b/skins/larry/mail.css
@@ -617,6 +617,10 @@ table.messagelist.fixedcopy {
 	background-position: -24px -997px;
 }
 
+.messagelist thead tr td.priority span.priority {
+	background-position: 0 -1056px;
+}
+
 .messagelist tbody tr td.attachment span.report {
 	background-position: -24px -1116px;
 }


### PR DESCRIPTION
Bugfix for missing priority Icon.
Ticket: http://trac.roundcube.net/ticket/1489234

Is it the right Icon for it or missing the icon completely?
