### PR TITLE
folder admin: omit fieldset if there is only one section

### DIFF
--- a/program/steps/settings/edit_folder.inc
+++ b/program/steps/settings/edit_folder.inc
@@ -264,8 +264,11 @@ function rcmail_folder_form($attrib)
             $content = rcmail_get_form_part($tab, $attrib);
         }
 
-        if ($content) {
+        if ($content && sizeof($form) > 1) {
             $out .= html::tag('fieldset', null, html::tag('legend', null, Q($tab['name'])) . $content) ."\n";
+        }
+        else {
+            $out .= $content ."\n";
         }
     }
 


### PR DESCRIPTION
On the edit folder screen there are two levels of titles first “Properties” and then “Location” etc. This does not match with the other screens (settings, identities) which only have one level of titles.

I guess this is because plugins can add more sections to the folder management screen. To keep the page layout consistent my suggestion is that when there is only one section the “Properties” title be omitted.
