### PR TITLE
Add temp_dir_ttl configuration option

### DIFF
--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -257,6 +257,10 @@ $config['log_dir'] = 'logs/';
 // use this folder to store temp files (must be writeable for apache user)
 $config['temp_dir'] = 'temp/';
 
+// expire files in temp_dir after 48 hours
+// possible units: s, m, h, d, w
+$config['temp_dir_ttl'] = '48h';
+
 // enforce connections over https
 // with this option enabled, all non-secure connections will be redirected.
 // set the port for the ssl connection as value of this option if it differs from the default 443

--- a/program/lib/Roundcube/rcube.php
+++ b/program/lib/Roundcube/rcube.php
@@ -498,7 +498,14 @@ class rcube
     public function gc_temp()
     {
         $tmp = unslashify($this->config->get('temp_dir'));
-        $expire = time() - 172800;  // expire in 48 hours
+
+        // expire in 48 hours by default
+        $temp_dir_ttl = $this->config->get('temp_dir_ttl', '48h');
+        $temp_dir_ttl = get_offset_sec($temp_dir_ttl);
+        if ($temp_dir_ttl < 6*3600)
+            $temp_dir_ttl = 6*3600;   // 6 hours sensible lower bound.
+
+        $expire = time() - $temp_dir_ttl;
 
         if ($tmp && ($dir = opendir($tmp))) {
             while (($fname = readdir($dir)) !== false) {


### PR DESCRIPTION
Add temp_dir_ttl configuration option to control expiry time in

  program/lib/Roundcube/rcube.php : gc_temp().

Default is 48 hours. Define hard wired minimum of 6 hours.
