### PR TITLE
Adding toggle for attachments on compose view

### DIFF
--- a/skins/larry/mail.css
+++ b/skins/larry/mail.css
@@ -1492,6 +1492,10 @@ div.message-partheaders .headers-table td.header {
 	bottom: 0;
 }
 
+#composebodycontainer.fullwidth {
+	right:22px;	
+}
+
 #composebodycontainer.buttons {
 	bottom: 42px;
 }
@@ -1535,6 +1539,10 @@ div.message-partheaders .headers-table td.header {
 	border-width: 1px;
 	padding: 8px;
 	overflow: auto;
+}
+
+#compose-attachments.reduced {
+	width:2px;
 }
 
 #compose-attachments.droptarget {

--- a/skins/larry/templates/compose.html
+++ b/skins/larry/templates/compose.html
@@ -155,10 +155,11 @@
 
 <!-- message compose body -->
 <div id="composeview-bottom">
-	<div id="composebodycontainer">
+	<div id="composebodycontainer" class="fullwidth">
 		<roundcube:object name="composeBody" id="composebody" form="form" cols="70" rows="20" tabindex="9" />
 	</div>
-	<div id="compose-attachments" class="rightcol">
+	<div id="compose-attachments" class="rightcol reduced">
+		<a style="cusor: pointer;" href="#attachments" id="composeattachmenttoggle" class="moreheaderstoggle remove"><span class="iconlink" title="<roundcube:label name='attachments' />"></span></a>
 		<div style="text-align:center; margin-bottom:20px">
 			<roundcube:button name="addattachment" type="input" class="button" classSel="button pressed" label="addattachment" onclick="UI.show_uploadform();return false" />
 		</div>

--- a/skins/larry/ui.js
+++ b/skins/larry/ui.js
@@ -133,6 +133,14 @@ function rcube_mail_ui()
           return false;
         }).css('cursor', 'pointer');
 
+        $('#composeattachmenttoggle').click(function(){
+          $('#composeattachmenttoggle').toggleClass('remove');
+          $('#composebodycontainer').toggleClass('fullwidth');
+          $('#compose-attachments').toggleClass('reduced');
+          layout_composeview();
+          return false;
+        }).css('cursor', 'pointer');
+
         // toggle compose options if opened in new window and they were visible before
         var opener_rc = rcmail.opener();
         if (opener_rc && opener_rc.env.action == 'compose' && $('#composeoptionstoggle', opener.document).hasClass('remove'))


### PR DESCRIPTION
Hi,

In order to have more width in the composer, I added a toggle for the attachments.
I set this toggle reduced by default but it can be easily changed.
The impact of the modification is (logically) small, just changing the width of two elements.

Hope it could be useful.

Kind regards,
Jerome @ Obsidev
