### PR TITLE
allow plugins to be loaded before session stuff

### DIFF
--- a/plugins/managesieve/managesieve.php
+++ b/plugins/managesieve/managesieve.php
@@ -96,8 +96,8 @@ class managesieve extends rcube_plugin
         }
 
         // add 'Create filter' item to message menu
-        $this->api->add_content(html::tag('li', null, 
-            $this->api->output->button(array(
+        $this->api->app->output->add_content(html::tag('li', null, 
+            $this->api->app->output->output->button(array(
                 'command'  => 'managesieve-create',
                 'label'    => 'managesieve.filtercreate',
                 'type'     => 'link',
@@ -172,7 +172,7 @@ class managesieve extends rcube_plugin
         $this->add_texts('localization/', array('filters','managefilters'));
 
         // include main js script
-        if ($this->api->output->type == 'html') {
+        if ($this->api->app->output->output->type == 'html') {
             $this->include_script('managesieve.js');
         }
 

--- a/plugins/zipdownload/zipdownload.php
+++ b/plugins/zipdownload/zipdownload.php
@@ -44,11 +44,11 @@ class zipdownload extends rcube_plugin
 
 		if ($rcmail->config->get('zipdownload_folder', false) || $rcmail->config->get('zipdownload_selection', false)) {
 			$this->include_script('zipdownload.js');
-			$this->api->output->set_env('zipdownload_selection', $rcmail->config->get('zipdownload_selection', false));
+			$this->api->app->output->output->set_env('zipdownload_selection', $rcmail->config->get('zipdownload_selection', false));
 
 			if ($rcmail->config->get('zipdownload_folder', false) && ($rcmail->action == '' || $rcmail->action == 'show')) {
-				$zipdownload = $this->api->output->button(array('command' => 'plugin.zipdownload.zip_folder', 'type' => 'link', 'classact' => 'active', 'content' => $this->gettext('downloadfolder')));
-				$this->api->add_content(html::tag('li', array('class' => 'separator_above'), $zipdownload), 'mailboxoptions');
+				$zipdownload = $this->api->app->output->output->button(array('command' => 'plugin.zipdownload.zip_folder', 'type' => 'link', 'classact' => 'active', 'content' => $this->gettext('downloadfolder')));
+				$this->api->app->output->add_content(html::tag('li', array('class' => 'separator_above'), $zipdownload), 'mailboxoptions');
 			}
 		}
 	}

--- a/program/include/rcmail.php
+++ b/program/include/rcmail.php
@@ -92,6 +92,11 @@ class rcmail extends rcube
     if (($basename = basename($_SERVER['SCRIPT_FILENAME'])) && $basename != 'index.php')
       $this->filename = $basename;
 
+    $this->plugins->init();
+
+    // load plugins
+    $this->plugins->load_plugins((array)$this->config->get('plugins', array()), array('filesystem_attachments', 'jqueryui'));
+
     // start session
     $this->session_init();
 
@@ -119,9 +124,7 @@ class rcmail extends rcube
     else
       $GLOBALS['OUTPUT'] = $this->load_gui(!empty($_REQUEST['_framed']));
 
-    // load plugins
-    $this->plugins->init($this, $this->task);
-    $this->plugins->load_plugins((array)$this->config->get('plugins', array()), array('filesystem_attachments', 'jqueryui'));
+    $this->plugins->init_plugins();
   }
 
 

--- a/program/include/rcmail.php
+++ b/program/include/rcmail.php
@@ -92,8 +92,8 @@ class rcmail extends rcube
     if (($basename = basename($_SERVER['SCRIPT_FILENAME'])) && $basename != 'index.php')
       $this->filename = $basename;
 
-    $this->plugins->init();
-
+    $this->plugins->init($this);
+    
     // load plugins
     $this->plugins->load_plugins((array)$this->config->get('plugins', array()), array('filesystem_attachments', 'jqueryui'));
 

--- a/program/lib/Roundcube/rcube_plugin.php
+++ b/program/lib/Roundcube/rcube_plugin.php
@@ -341,7 +341,7 @@ abstract class rcube_plugin
      */
     public function add_button($p, $container)
     {
-        if ($this->api->output->type == 'html') {
+        if ($this->api->app->output->type == 'html') {
             // fix relative paths
             foreach (array('imagepas', 'imageact', 'imagesel') as $key) {
                 if ($p[$key]) {
@@ -349,7 +349,7 @@ abstract class rcube_plugin
                 }
             }
 
-            $this->api->add_content($this->api->output->button($p), $container);
+            $this->api->add_content($this->api->app->output->button($p), $container);
         }
     }
 

--- a/program/lib/Roundcube/rcube_plugin_api.php
+++ b/program/lib/Roundcube/rcube_plugin_api.php
@@ -514,7 +514,7 @@ class rcube_plugin_api
                     ." already taken by another plugin or the application itself"), true, false);
         }
         else {
-            $this->app->tasks[$task] = $owner;
+            $this->tasks[$task] = $owner;
             rcmail::$main_tasks[] = $task;
             return true;
         }
@@ -531,7 +531,7 @@ class rcube_plugin_api
      */
     public function is_plugin_task($task)
     {
-        return $this->app->tasks[$task] ? true : false;
+        return $this->tasks[$task] ? true : false;
     }
 
     /**


### PR DESCRIPTION
Currently plugins are loaded at the end of rcmail::startup() - after the session has begun (among other things). Being able to load plugins earlier in the process allows plugins to touch more functionality, for my purposes, session handling.

This change allows, and sets, plugins to load earlier, just after rcmail::init() (though I imagine it's now possible to get it even earlier by putting the plugin loading within that method).

Because plugin loading and plugin init has been separated, existing plugins should continue to function normally because they're initialized in the same sequence as before.

Plugin authors will now be able to extend the rcube_plugin::__construct() method to make changes that should happen before that init(). Naturally if rcmail task or output are not set, they will not be accessible at that time. 

Conflicts:
    program/include/rcmail.php
