### PR TITLE
Added new config option, session_auth_cookie_expiration, for cookie life...

### DIFF
--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -308,6 +308,11 @@ $config['session_name'] = null;
 // Session authentication cookie name. Default: 'roundcube_sessauth'
 $config['session_auth_name'] = null;
 
+// Session authentication cookie expiration. Default: 0 (expire on browser session close)
+// Always set in the future, e.g. time() + 10 * 60 // (for 10 minutes)
+// If non-zero, should be greater than or equal to session lifetime
+$rcmail_config['session_auth_cookie_expiration'] = 0;
+
 // Session path. Defaults to PHP session.cookie_path setting.
 $config['session_path'] = null;
 

--- a/program/lib/Roundcube/rcube_session.php
+++ b/program/lib/Roundcube/rcube_session.php
@@ -46,6 +46,7 @@ class rcube_session
     private $storage;
     private $memcache;
 
+    protected $auth_cookie_expiration = 0;
 
     /**
      * Default constructor
@@ -58,7 +59,12 @@ class rcube_session
         $this->logging = $config->get('log_session', false);
 
         $lifetime = $config->get('session_lifetime', 1) * 60;
+        
         $this->set_lifetime($lifetime);
+
+        if($expiration = $config->get('session_auth_cookie_expiration')) {
+            $this->auth_cookie_expiration = $expiration;
+        }
 
         // use memcache backend
         $this->storage = $config->get('session_storage', 'db');
@@ -730,7 +736,7 @@ class rcube_session
     function set_auth_cookie()
     {
         $this->cookie = $this->_mkcookie($this->now);
-        rcube_utils::setcookie($this->cookiename, $this->cookie, 0);
+        rcube_utils::setcookie($this->cookiename, $this->cookie, $this->auth_cookie_expiration);
         $_COOKIE[$this->cookiename] = $this->cookie;
     }
 


### PR DESCRIPTION
Adds a new config value for cookie expiration time, so that cookies can be set to expire at a specific time, regardless of the browser being closed. Adds to extensibility/pluggability (see https://github.com/roundcube/roundcubemail/pull/125) of sessions.
