### PR TITLE
Add compose_list_name hook to handle special name orders

### DIFF
--- a/program/lib/Roundcube/rcube_addressbook.php
+++ b/program/lib/Roundcube/rcube_addressbook.php
@@ -515,8 +515,12 @@ abstract class rcube_addressbook
             $fn = join(' ', array($contact['surname'], $contact['firstname'], $contact['middlename']));
         else if ($compose_mode == 1)
             $fn = join(' ', array($contact['firstname'], $contact['middlename'], $contact['surname']));
-        else
+        else if ($compose_mode == 0)
             $fn = !empty($contact['name']) ? $contact['name'] : join(' ', array($contact['prefix'], $contact['firstname'], $contact['middlename'], $contact['surname'], $contact['suffix']));
+        else {
+            $plugin = rcube::get_instance()->plugins->exec_hook('compose_list_name', array('contact' => $contact));
+            $fn = $plugin['fn'];
+        }
 
         $fn = trim($fn, ', ');
 


### PR DESCRIPTION
I can modify the addressbook_name_listing variable via main config or preferences_list_hook but I have to change the rcube_addressbook class to use the modified value. Some contry use special [name orders](http://en.wikipedia.org/wiki/Personal_name#Name_order) and we can handle them with this hook.
