### PR TITLE
Active Directory encodage support

### DIFF
--- a/plugins/password/drivers/ldap.php
+++ b/plugins/password/drivers/ldap.php
@@ -268,6 +268,10 @@ class rcube_ldap_password
                 return FALSE; //Your PHP install does not have the mhash() function. Cannot do SHA hashes.
             }
             break;
+            
+        case 'adir':
+            $cryptedPassword = rcube_charset::convert('"' . $passwordClear . '"', RCUBE_CHARSET, 'UTF-16LE');
+            break;
 
         case 'samba':
             if (function_exists('hash')) {

--- a/plugins/password/drivers/ldap_simple.php
+++ b/plugins/password/drivers/ldap_simple.php
@@ -247,6 +247,9 @@ class rcube_ldap_simple_password
                 return false;
             }
             break;
+        case 'adir':
+            $crypted_password = rcube_charset::convert('"' . $password_clear . '"', RCUBE_CHARSET, 'UTF-16LE');
+            break;
         case 'clear':
         default:
             $crypted_password = $password_clear;


### PR DESCRIPTION
Simple fix to allow `password` plugin `ldap` drivers to "encrypt" password in AD compatible way. More info in [this post](http://www.roundcubeforum.net/index.php/topic,10355.msg48895.html#msg48895).
