### PR TITLE
fix firefox locale issue

### DIFF
--- a/program/lib/Roundcube/rcube.php
+++ b/program/lib/Roundcube/rcube.php
@@ -704,7 +704,8 @@ class rcube
             $accept_langs = explode(',', $_SERVER['HTTP_ACCEPT_LANGUAGE']);
             $lang         = str_replace('-', '_', $accept_langs[0]);
             if (strpos($lang, '_')) {
-                $lang = explode('_', $lang)[0] . '_' .  strtoupper(explode('_', $lang)[1]);
+                $lang_temp = explode('_', $lang);
+                $lang = $lang_temp[0] . '_' .  strtoupper($lang_temp[1]);
             }
         }
 

--- a/program/lib/Roundcube/rcube.php
+++ b/program/lib/Roundcube/rcube.php
@@ -702,10 +702,11 @@ class rcube
         // user HTTP_ACCEPT_LANGUAGE if no language is specified
         if (empty($lang) || $lang == 'auto') {
             $accept_langs = explode(',', $_SERVER['HTTP_ACCEPT_LANGUAGE']);
-            $lang         = str_replace('-', '_', $accept_langs[0]);
-            if (strpos($lang, '_')) {
-                $lang_temp = explode('_', $lang);
+            if (strpos($accept_langs[0], '-')) {
+                $lang_temp = explode('-', $accept_langs[0]);
                 $lang = $lang_temp[0] . '_' .  strtoupper($lang_temp[1]);
+            } else {
+                $lang = $accept_langs[0];
             }
         }
 

--- a/program/lib/Roundcube/rcube.php
+++ b/program/lib/Roundcube/rcube.php
@@ -703,6 +703,9 @@ class rcube
         if (empty($lang) || $lang == 'auto') {
             $accept_langs = explode(',', $_SERVER['HTTP_ACCEPT_LANGUAGE']);
             $lang         = str_replace('-', '_', $accept_langs[0]);
+            if (strpos($lang, '_')) {
+                $lang = explode('_', $lang)[0] . '_' .  strtoupper(explode('_', $lang)[1]);
+            }
         }
 
         if (empty($rcube_languages)) {


### PR DESCRIPTION
When using Firefox, `$_SERVER["HTTP_ACCEPT_LANGUAGE"]` is in xx-yy format like zh-tw, but not xx-YY like zh-TW, may cause missing some locales.
