### PR TITLE
1489393 - fix disappearing contacts

### DIFF
--- a/program/js/list.js
+++ b/program/js/list.js
@@ -1206,16 +1206,21 @@ use_plusminus_key: function(keyCode, mod_key)
 
   if (keyCode == 32)
     keyCode = selected_row.expanded ? 109 : 61;
-  if (keyCode == 61 || keyCode == 107)
+  if (keyCode == 61 || keyCode == 107) {
+    if( this.row_children(this.last_selected).length === 0)
+      return;
     if (mod_key == CONTROL_KEY || this.multiexpand)
       this.expand_all(selected_row);
     else
      this.expand(selected_row);
-  else
+  } else {
+    if (this.find_root(this.last_selected) !== this.last_selected)
+      return;
     if (mod_key == CONTROL_KEY || this.multiexpand)
       this.collapse_all(selected_row);
     else
       this.collapse(selected_row);
+  }
 
   this.update_expando(selected_row.uid, selected_row.expanded);
 

--- a/program/js/list.js
+++ b/program/js/list.js
@@ -1214,7 +1214,7 @@ use_plusminus_key: function(keyCode, mod_key)
     else
      this.expand(selected_row);
   } else {
-    if (this.find_root(this.last_selected) !== this.last_selected)
+    if (!selected_row.expanded || this.find_root(this.last_selected) !== this.last_selected)
       return;
     if (mod_key == CONTROL_KEY || this.multiexpand)
       this.collapse_all(selected_row);


### PR DESCRIPTION
Fixes pressing the minus key in the contacts list by making sure that it only expands when it has children and only collapses when the selected message is a root (and it's expanded).  I initially tried to just put the expand/collapse thread functionality in the message list key handler in app.js, but it turned out to be a lot more changes.  Also doing it this way ensures that if if the contact list ever needs a tree structure (though I don't know why it would) it will be supported.
