### PR TITLE
Enhance .htaccess security rules

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -28,9 +28,16 @@ RewriteEngine On
 RewriteRule ^favicon\.ico$ skins/larry/images/favicon.ico
 # security rules
 RewriteRule \.git - [F]
-RewriteRule ^/?(README(.md)?|INSTALL|LICENSE|CHANGELOG|UPGRADING)$ - [F]
-RewriteRule ^/?(SQL|bin) - [F]
+RewriteRule ^/?(README(.md)?|INSTALL|LICENSE|CHANGELOG|UPGRADING)$ - [NC,F]
+RewriteRule ^/?(SQL|bin) - [NC,F]
 </IfModule>
+
+# deny access to all files not containing a "." (dot)
+# to block access to different README, ChangeLog, etc. files
+# of various skins and plugins.
+<FilesMatch "^[^\.]+$">
+Deny from all
+</FilesMatch>
 
 <IfModule mod_deflate.c>
 SetOutputFilter DEFLATE


### PR DESCRIPTION
1. Deny access to all files not containing a . (dot) to block access to different README, ChangeLog, etc. files of various skins and plugins.

I opted for the FilesMatch rule because i felt that this might carry less of a performance penalty in comparison to mod_rewrite. Feel free to update the RewriteRule instead
1. Do not check case for default README/INSTALL/LICENSE/etc. files.
   (This could also be enhanced to deny access to these files in _all_ directories and there are sometimes different file names in use, e.g. ./plugins/managesieve/Changelog)
