### PR TITLE
fix #1489396 - make home/end key behavior consistent

### DIFF
--- a/program/js/list.js
+++ b/program/js/list.js
@@ -856,14 +856,8 @@ select_first: function(mod_key)
 {
   var row = this.get_first_row();
   if (row) {
-    if (mod_key) {
-      this.shift_select(row, mod_key);
-      this.triggerEvent('select');
-      this.scrollto(row);
-    }
-    else {
-      this.select(row);
-    }
+    this.select_row(row, mod_key, false);
+    this.scrollto(row);
   }
 },
 
@@ -875,14 +869,8 @@ select_last: function(mod_key)
 {
   var row = this.get_last_row();
   if (row) {
-    if (mod_key) {
-      this.shift_select(row, mod_key);
-      this.triggerEvent('select');
-      this.scrollto(row);
-    }
-    else {
-      this.select(row);
-    }
+    this.select_row(row, mod_key, false);
+    this.scrollto(row);
   }
 },
 


### PR DESCRIPTION
Makes the home/end keys behave like every other mechanism for selecting
records. Specifically fixes issue where holding ctrl and pressing Home (or end) would select all messages, which is not what should happen.
