### PR TITLE
need to reset shift_start on control select

### DIFF
--- a/program/js/list.js
+++ b/program/js/list.js
@@ -790,8 +790,10 @@ select_row: function(id, mod_key, with_mouse)
         break;
 
       case CONTROL_KEY:
-        if (with_mouse)
+        if (with_mouse) {
+          this.shift_start = id;
           this.highlight_row(id, true);
+        }
         break;
 
       case CONTROL_SHIFT_KEY:


### PR DESCRIPTION
reproduce steps: shift-select some messages, hold down control and
select another message.  hold down shift+control and select more
messages - desired behavior, two separate ranges of selected messages.
(consistent with outlook/thunderbird/windows explorer)
