### PR TITLE
re-add lost group_delete js event

### DIFF
--- a/program/js/app.js
+++ b/program/js/app.js
@@ -5048,6 +5048,7 @@ function rcube_webmail()
   {
     var key = 'G'+prop.source+prop.id;
     if (this.treelist.remove(key)) {
+      this.triggerEvent('group_delete', { source:prop.source, id:prop.id });
       delete this.env.contactfolders[key];
       delete this.env.contactgroups[key];
     }


### PR DESCRIPTION
There used to be a js event called group_delete, a while ago this went missing while the events group_insert and group_update remain.

I found the old event here https://github.com/roundcube/roundcubemail/blob/c8a714cca4978395292e82ed1971fbf92fa78487/program/js/app.js#L4496 but cannot find exactly which commit removed it.
