### PR TITLE
Load plugin config file from any configured path

### DIFF
--- a/program/lib/Roundcube/rcube_plugin.php
+++ b/program/lib/Roundcube/rcube_plugin.php
@@ -131,6 +131,16 @@ abstract class rcube_plugin
                 'file' => __FILE__, 'line' => __LINE__,
                 'message' => "Failed to load config from $fpath"), true, false);
             return false;
+        } else {
+            $fname = $this->ID . '.inc.php';
+            // Search plugin_name.inc.php file in any configured path
+            if (!$rcube->config->load_from_file($fname)) {
+                rcube::raise_error(array(
+                    'code' => 527, 'type' => 'php',
+                    'file' => __FILE__, 'line' => __LINE__,
+                    'message' => "Failed to load $fname config file from any configured path"), true, false);
+                return false;
+            }
         }
 
         return true;


### PR DESCRIPTION
Try to load plugin_name.inc.php config file from any pre-configured config path (rcube_config::path array) so webmail admins can move plugin configurations out of www root.
