### PR TITLE
Wrong path on windows server

### DIFF
--- a/installer/test.php
+++ b/installer/test.php
@@ -91,8 +91,7 @@ if ($RCI->config['log_driver'] != 'syslog')
     $dirs[] = $RCI->config['log_dir'] ? $RCI->config['log_dir'] : 'logs';
 
 foreach ($dirs as $dir) {
-    $dirpath = $dir[0] == '/' ? $dir : INSTALL_PATH . $dir;
-    if (is_writable(realpath($dirpath))) {
+    if (is_writable(realpath($dir))) {
         $RCI->pass($dir);
         $pass = true;
     }


### PR DESCRIPTION
After the installation the INSTALL_PATH is wrong and the chmod check is always false.
