### PR TITLE
Update chgdbmailusers.c

### DIFF
--- a/plugins/password/helpers/chgdbmailusers.c
+++ b/plugins/password/helpers/chgdbmailusers.c
@@ -5,7 +5,17 @@
 // set the UID this script will run as (root user)
 #define UID 0
 #define CMD "/usr/sbin/dbmail-users"
-#define RCOK 0x100
+//#define RCOK 0x100 --> use:
+#define RCOK 0
+//instead, because the return of the system() execution, never return 0x100 for me. As I read on 'man system'
+// the return it's -1 on error, and the return status of the command otherwise
+//I had to edit this file too:
+// - drivers/dbmail.php:
+//      change this:  function password_save($currpass, $newpass)
+//      to this:      function save($currpass, $newpass)
+//
+
+
 
 /* INSTALLING:
   gcc -o chgdbmailusers chgdbmailusers.c


### PR DESCRIPTION
I edited this file because password plugin, does not run on my system using dbmail driver.

The reason are:
- on first, on many places the function password_save, is referenced as save, and I had to change the name of this function on drivers/dbmail.php:
- At the file helpers/chgdbmailusers.c, once solved the first problem, when I intended to change a pass, it changes but the page returns an error.  This error dissapears using #define RCOK 0

Sorry for my english ;)
