### PR TITLE
minor selector change to avoid iframe security violation + fix for outlook addressbook import

### DIFF
--- a/program/js/app.js
+++ b/program/js/app.js
@@ -6668,7 +6668,7 @@ function rcube_webmail()
       // hide selector on click out of selector element
       var fn = function(e) { if (e.target != container.get(0)) container.hide(); };
       $(document.body).on('mouseup', fn);
-      $('iframe').contents().on('mouseup', fn)
+      $('iframe :not([sandbox]').contents().on('mouseup', fn)
         .load(function(e) { try { $(this).contents().on('mouseup', fn); } catch(e) {}; });
 
       this.folder_selector_element = container;

--- a/program/lib/Roundcube/rcube_csv2vcard.php
+++ b/program/lib/Roundcube/rcube_csv2vcard.php
@@ -56,7 +56,7 @@ class rcube_csv2vcard
         //'email_2_type'          => '',
         //'email_3_address'       => '', //@TODO
         //'email_3_type'          => '',
-        'email_address'         => 'email:main',
+        'email_address'         => 'email:pref',
         //'email_type'            => '',
         'first_name'            => 'firstname',
         'gender'                => 'gender',

--- a/program/steps/mail/sendmail.inc
+++ b/program/steps/mail/sendmail.inc
@@ -201,7 +201,7 @@ if (!empty($headers['Reply-To'])) {
     $headers['Mail-Reply-To'] = $headers['Reply-To'];
 }
 if ($hdr = rcube_utils::get_input_value('_followupto', rcube_utils::INPUT_POST, TRUE, $message_charset)) {
-    $headers['Mail-Followup-To'] = rcmail_email_input_format();
+    $headers['Mail-Followup-To'] = rcmail_email_input_format($hdr);
 }
 
 // remember reply/forward UIDs in special headers

--- a/skins/larry/ui.js
+++ b/skins/larry/ui.js
@@ -345,7 +345,7 @@ function rcube_mail_ui()
         }
       });
 
-    $('iframe').load(function(e){
+    $('iframe :not([sandbox])').load(function(e){
       // this = iframe
       try {
         var doc = this.contentDocument ? this.contentDocument : this.contentWindow ? this.contentWindow.document : null;


### PR DESCRIPTION
If someone updates the header or footer templates to insert an ad banner or somesuch as an iframe and uses the sandbox attribute to prevent that iframe from breaking into the roundcube content, the browser (chrome v33, at least) generates a security exception that prevents UI.init() from finishing.

This minor change to the selector makes it skip any iframes that might cause this problem.
