### PR TITLE
extend generic plugin templates to respect _framed option

### DIFF
--- a/skins/classic/templates/plugin.html
+++ b/skins/classic/templates/plugin.html
@@ -5,18 +5,28 @@
 <roundcube:include file="/includes/links.html" />
 <script type="text/javascript" src="/functions.js"></script>
 </head>
-<body>
+<roundcube:if condition="env:framed" />
+	<body class="iframe">
+<roundcube:else />
+	<body>
+	<roundcube:include file="/includes/taskbar.html" />
+	<roundcube:include file="/includes/header.html" />
+<roundcube:endif />
 
-<roundcube:include file="/includes/taskbar.html" />
-<roundcube:include file="/includes/header.html" />
-<roundcube:if condition="env:task == 'settings'" />
+<roundcube:if condition="env:task == 'settings' &amp;&amp; !env:framed" />
   <roundcube:include file="/includes/settingstabs.html" />
 <roundcube:endif />
 
-<div id="mainscreen">
+<roundcube:if condition="!env:framed" />
+	<div id="mainscreen">
+<roundcube:endif />
+
 <roundcube:object name="plugin.body" />
-</div>
-  
+
+<roundcube:if condition="!env:framed" />
+	</div>
+<roundcube:endif />
+
 <roundcube:object name="plugin.footer" />
 
 </body>

--- a/skins/larry/templates/plugin.html
+++ b/skins/larry/templates/plugin.html
@@ -4,21 +4,31 @@
 <title><roundcube:object name="pagetitle" /></title>
 <roundcube:include file="/includes/links.html" />
 </head>
-<body class="noscroll">
+<roundcube:if condition="env:framed" />
+	<body class="iframe">
+<roundcube:else />
+	<body class="noscroll">
 
-<roundcube:include file="/includes/header.html" />
+	<roundcube:include file="/includes/header.html" />
 
-<div id="mainscreen" class="offset">
+	<div id="mainscreen" class="offset">
+<roundcube:endif />
 
-<roundcube:if condition="env:task == 'settings'" />
+<roundcube:if condition="env:task == 'settings' &amp;&amp; !env:framed" />
 	<roundcube:include file="/includes/settingstabs.html" />
 <roundcube:endif />
 
-<div id="pluginbody" class="uibox contentbox">
-<roundcube:object name="plugin.body" />
-</div>
+<roundcube:if condition="!env:framed" />
+	<div id="pluginbody" class="uibox contentbox">
+<roundcube:endif />
 
-</div>
+<roundcube:object name="plugin.body" />
+
+<roundcube:if condition="!env:framed" />
+	</div>
+
+	</div>
+<roundcube:endif />
 
 <roundcube:object name="plugin.footer" />
 


### PR DESCRIPTION
The generic plugin template always loads the full UI. This adds conditions to make it respect the _framed option (some plugins load things in iframes).

I know the new template files look a little messy, perhaps it would be better to create a second generic template for _framed?
