### PR TITLE
Sorted skins alphabetically

### DIFF
--- a/program/steps/settings/func.inc
+++ b/program/steps/settings/func.inc
@@ -1260,6 +1260,7 @@ function rcmail_get_skins()
     }
 
     closedir($dir);
+    sort($skins);
 
     return $skins;
 }


### PR DESCRIPTION
Since readdir on Linux does not return sorted results, if there are more skins installed the listing on the Settings page looks messy. Sorting them alphabetically on retrieval helps to organize and display them nicely.
