### PR TITLE
Limit list_tables() and list_cols() to current schema

### DIFF
--- a/program/lib/Roundcube/rcube_db.php
+++ b/program/lib/Roundcube/rcube_db.php
@@ -609,7 +609,8 @@ class rcube_db
     {
         // get tables if not cached
         if ($this->tables === null) {
-            $q = $this->query('SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES ORDER BY TABLE_NAME');
+            $q = $this->query('SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = ? ORDER BY TABLE_NAME',
+                array($this->db_dsnw_array['database']));
 
             if ($q) {
                 $this->tables = $q->fetchAll(PDO::FETCH_COLUMN, 0);
@@ -631,8 +632,8 @@ class rcube_db
      */
     public function list_cols($table)
     {
-        $q = $this->query('SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = ?',
-            array($table));
+        $q = $this->query('SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = ? AND TABLE_SCHEMA = ?',
+            array($table, $this->db_dsnw_array['database']));
 
         if ($q) {
             return $q->fetchAll(PDO::FETCH_COLUMN, 0);


### PR DESCRIPTION
When checking if DB schema is up-to-date, limit the checks to tables in our current schema. Otherwise the installer might return false positives when DB user has access to multiple schemas with different versions of Roundcube.
