### PR TITLE
Disable composeoptions by default if not set by user.

### DIFF
--- a/skins/larry/ui.js
+++ b/skins/larry/ui.js
@@ -191,7 +191,7 @@ function rcube_mail_ui()
           return false;
         }).css('cursor', 'pointer');
 
-        if (get_pref('composeoptions') !== '0') {
+        if (get_pref('composeoptions') && get_pref('composeoptions') !== '0') {
           $('#composeoptionstoggle').click();
         }
 


### PR DESCRIPTION
Many user do not need or want the compose editor to be visible. Hiding them is not an option for them as this setting is only stored in localStorage or cookie, so after cleaning their browser sessions the composeoptions are visible again.
This change disables the composeoptions by default if not defined otherwise by a user.
