### PR TITLE
add preferences_section_header hook

### DIFF
--- a/program/steps/settings/edit_prefs.inc
+++ b/program/steps/settings/edit_prefs.inc
@@ -51,6 +51,10 @@ function rcmail_user_prefs_form($attrib)
 
     $out = $form_start;
 
+    if(!empty($SECTIONS[$CURR_SECTION]['header'])) {
+        $out .= html::div(array('id' => 'preferences-header', 'class' =>'boxcontent'), $SECTIONS[$CURR_SECTION]['header']);
+    }
+
     foreach ($SECTIONS[$CURR_SECTION]['blocks'] as $class => $block) {
         if (!empty($block['options'])) {
             $table = new html_table(array('cols' => 2));

--- a/program/steps/settings/func.inc
+++ b/program/steps/settings/func.inc
@@ -1241,6 +1241,13 @@ function rcmail_user_prefs($current = null)
             $sections[$idx]['blocks'] = $data['blocks'];
     }
 
+    $data = $RCMAIL->plugins->exec_hook('preferences_section_header',
+        array('section' => $sect['id'], 'header' => '', 'current' => $current));
+
+    if(!empty($data['header'])) {
+        $sections[$idx]['header'] = $data['header'];
+    }
+
     return array($sections, $plugin['cols']);
 }
 


### PR DESCRIPTION
If you write a plugin that adds a section, it could be useful to be able to add a header to the section. This allows you to add some help, comments, legend, or anything really. 

For one of my plugins i found a need for this, because I need to explain what can and cant be set by the user and why. 
