### PR TITLE
dont render plugin blocks if none selected

### DIFF
--- a/program/steps/settings/func.inc
+++ b/program/steps/settings/func.inc
@@ -1235,7 +1235,7 @@ function rcmail_user_prefs($current = null)
             $data['blocks']['advanced'] = $adv;
         }
 
-        if (!$found)
+        if ($current && !$found)
             unset($sections[$idx]);
         else
             $sections[$idx]['blocks'] = $data['blocks'];


### PR DESCRIPTION
I noticed that even when I dont select my plugin in the preferences section, it was rendering the blocks. I could not stop it from doing that, because the current code expects there to be content in the section blocks even if your plugin is not showing. 

This PR prevents that. It should not change anything for existing plugins, but now you can modify your plugin to check $args['current'] instead of $args['section'] and only render when your plugin is selected.
