### PR TITLE
fix address book search

### DIFF
--- a/program/steps/addressbook/search.inc
+++ b/program/steps/addressbook/search.inc
@@ -116,13 +116,10 @@ function rcmail_contact_search()
     // quick-search
     else {
         $search = trim(rcube_utils::get_input_value('_q', rcube_utils::INPUT_GET, true));
-        $fields = explode(',', rcube_utils::get_input_value('_headers', rcube_utils::INPUT_GET));
+        $fields = array_filter(explode(',', rcube_utils::get_input_value('_headers', rcube_utils::INPUT_GET)));
 
         if (empty($fields)) {
             $fields = array_keys($SEARCH_MODS_DEFAULT);
-        }
-        else {
-            $fields = array_filter($fields);
         }
 
         // update search_mods setting


### PR DESCRIPTION
I noticed that address book searching was broken in my git checkout. This seems to be due to the fact that an empty _headers results in a $fields like:

```
Array
(
    [0] => 
)
```

This is probably a bug of some kind in explode(). This is mentioned in comments of the explode() manual.

If $fields is not empty, it does not use $SEARCH_MODS_DEFAULT and it does not search any fields.

If you move the array_filter up, it should fix the issue. 

Reproduce:  go to addressbook. Search for a contact in rcube db making sure no _headers is passed along. (I dont actually know what adds _headers).  No results are returned.
