### PR TITLE
Add timeout for password-driver vpopmaild

### DIFF
--- a/plugins/password/README
+++ b/plugins/password/README
@@ -310,6 +310,9 @@
 
  Set $config['password_vpopmaild_port'] to the port of vpopmaild.
 
+ Set $config['password_vpopmaild_timeout'] to the timeout used for the TCP 
+ connection to vpopmaild (You may want to set it higher on busy servers).
+
 
  3. Driver API
  -------------

--- a/plugins/password/config.inc.php.dist
+++ b/plugins/password/config.inc.php.dist
@@ -256,6 +256,9 @@ $config['password_vpopmaild_host'] = 'localhost';
 // TCP port used for vpopmaild connections
 $config['password_vpopmaild_port'] = 89;
 
+// Timout used for the connection to vpopmaild (in seconds)
+$config['password_vpopmaild_timeout'] = 10;
+
 
 // cPanel Driver options
 // --------------------------

--- a/plugins/password/drivers/vpopmaild.php
+++ b/plugins/password/drivers/vpopmaild.php
@@ -22,6 +22,8 @@ class rcube_vpopmaild_password
             $rcmail->config->get('password_vpopmaild_port'), null))) {
             return PASSWORD_CONNECT_ERROR;
         }
+	
+        $vpopmaild->setTimeout($rcmail->config->get('password_vpopmaild_timeout'),0);
 
         $result = $vpopmaild->readLine();
         if(!preg_match('/^\+OK/', $result)) {


### PR DESCRIPTION
Before this change, the vpopmaild driver didn't run into a timeout so that in case of a busy vpopmaild the browser kept loading and loading.
