### PR TITLE
Improved show_real_foldernames behaviour

### DIFF
--- a/program/include/rcmail.php
+++ b/program/include/rcmail.php
@@ -1325,7 +1325,8 @@ class rcmail extends rcube
      */
     public function folder_selector($p = array())
     {
-        $p += array('maxlength' => 100, 'realnames' => false, 'is_escaped' => true);
+        $realnames = $this->config->get('show_real_foldernames');
+        $p += array('maxlength' => 100, 'realnames' => $realnames, 'is_escaped' => true);
         $a_mailboxes = array();
         $storage = $this->get_storage();
 

--- a/program/steps/settings/edit_folder.inc
+++ b/program/steps/settings/edit_folder.inc
@@ -135,7 +135,6 @@ function rcmail_folder_form($attrib)
             'id'          => '_parent',
             'name'        => '_parent',
             'noselection' => '---',
-            'realnames'   => false,
             'maxlength'   => 150,
             'unsubscribed' => true,
             'skip_noinferiors' => true,


### PR DESCRIPTION
 The following:

 program/steps/mail/compose.inc :: rcmail_store_target_selection()
  program/steps/settings/edit_folder.inc :: rcmail_folder_form()

both try to localise mailbox names.

Push the logic down into the folder_selector() method which can use:

  $this->config->get('show_real_foldernames')

to decide the correct default behaviour.

Clients functions and methods can still override by adding 'realnames'
named parameter to the folder_selector() call. The obvious example is
the Settings -> Preferences -> Special Folders screen.
