### PR TITLE
Small CSS fix

### DIFF
--- a/skins/larry/mail.css
+++ b/skins/larry/mail.css
@@ -850,7 +850,7 @@ h2.subject {
 
 h3.subject {
 	font-size: 14px;
-	margin: 0 12em 0 0;
+	margin: 0 15em 0 0;
 	padding: 8px 8px 4px 8px;
 	white-space: nowrap;
 	overflow: hidden;


### PR DESCRIPTION
The new view HTML/plaintext icons inside #messageheader when viewing a HTML message with Roundcube 1.0.1 mean that we need a wider CSS margin on the message subject.

Otherwise a long subject line runs behind the two new icons and the "..." ellipsis at the end is lost.

The problem shows up frequently with the threecol plugin installed:

```
https://github.com/tofi86/Roundcube-Plugin-Threecol-Layout
```

(I have submitted a pull request to make that work with 1.0.1)

However you see the same problem with the standard mailbox view if a message has a very long subject line.
