### PR TITLE
Allow plugins to modify the message subject in message_compose

### DIFF
--- a/program/steps/mail/compose.inc
+++ b/program/steps/mail/compose.inc
@@ -78,7 +78,7 @@ if (!is_array($COMPOSE)) {
 
 // add some labels to client
 $OUTPUT->add_label('nosubject', 'nosenderwarning', 'norecipientwarning', 'nosubjectwarning', 'cancel',
-    'nobodywarning', 'notsentwarning', 'notuploadedwarning', 'savingmessage', 'sendingmessage', 
+    'nobodywarning', 'notsentwarning', 'notuploadedwarning', 'savingmessage', 'sendingmessage',
     'messagesaved', 'converting', 'editorwarning', 'searching', 'uploading', 'uploadingmany',
     'fileuploaderror', 'sendmessage', 'newresponse', 'responsename', 'responsetext', 'save',
     'savingresponse', 'restoresavedcomposedata', 'restoremessage', 'delete', 'restore', 'ignore',
@@ -1476,6 +1476,9 @@ function rcmail_compose_subject($attrib)
     }
     else if (!empty($COMPOSE['param']['subject'])) {
         $subject = $COMPOSE['param']['subject'];
+    }
+    if (!empty($COMPOSE['param']['override-subject'])) {
+        $subject = $COMPOSE['param']['override-subject'];
     }
 
     $out = $form_start ? "$form_start\n" : '';


### PR DESCRIPTION
Roundcube will only respect the 'subject' param in instances when the Subject is not set by some other rule -- e.g. if the message being composed is a forward, the Subject will always be "Fwd: ...".  This is disadvantageous to plugins that might want to override the Subject for forwards, or other special messages.

Simply changing the priority order of the different options in the 'if' statements would not work here, though, as the 'subject' param is pre-initialized to the original Subject of the message being forwarded / replied to, etc.; clearly, the default value cannot be a higher priority than adjusted Subjects such as "Re: ..." and "Fwd: ...".  On the other hand, making the 'subject' param default to an empty string would run the risk of breaking existing plugins that expect to find the 'subject' in this parameter.

This PR solves this problem by allowing plugins to change the message subject in message_compose by setting $args['param']['override-subject'].  If the 'override-subject' param is set, then it will be used in deference to any adjusted Subjects that Roundcube may wish to build.

An alternate solution might be to insure that the Subject is adjusted before the message_compose hook is called; however, in the existing code it appears that message_compose needs to be called fairly early in compose.inc, whereas the Subject adjustment happens a fair bit later in the process.  Refactoring might lead to a better solution, but I was wary of side effects that might result, and wasn't sure if this sort of change would be welcome.
