### PR TITLE
New gearman driver for password plugin

### DIFF
--- a/plugins/password/config.inc.php.dist
+++ b/plugins/password/config.inc.php.dist
@@ -367,3 +367,8 @@ $config['password_expect_params'] = '';
 $config['password_smb_host'] = 'localhost';
 // Location of smbpasswd binary
 $config['password_smb_cmd'] = '/usr/bin/smbpasswd';
+
+// gearman driver options
+// ---------------------
+// Gearman host (default: localhost)
+$config['password_gearman_host'] = 'localhost';

--- a/plugins/password/drivers/gearman.php
+++ b/plugins/password/drivers/gearman.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Gearman Password Driver
+ *
+ * Payload is json string containing username, oldPassword and newPassword
+ * Return value is a json string saying result: true if success.
+ *
+ * @version 1.0
+ * @author Mohammad Anwari <mdamt@mdamt.net>
+ */
+
+class rcube_gearman_password
+{
+  function save($currpass, $newpass)
+  {
+    $user = $_SESSION['username'];
+    $rcmail = rcmail::get_instance();
+
+    if (extension_loaded('gearman')) {
+      $success = false;
+      $gmc= new GearmanClient();
+
+      $gmc->addServer($rcmail->config->get('password_gearman_host'));
+      $payload = array("username" => $user, "oldPassword" => $currpass, "newPassword" => $newpass);
+      $result = $gmc->doNormal("setPassword", json_encode($payload));
+      $success = json_decode($result);
+      if ($success->result == 1) {
+        return PASSWORD_SUCCESS;
+      } else {
+        rcube::raise_error(array(
+          'code' => 600,
+          'type' => 'php',
+          'file' => __FILE__, 'line' => __LINE__,
+          'message' => "Password plugin: Gearman authentication failed for user $user: $error"
+        ), true, false);
+      }
+    }
+    else {
+      rcube::raise_error(array(
+        'code' => 600,
+        'type' => 'php',
+        'file' => __FILE__, 'line' => __LINE__,
+        'message' => "Password plugin: PECL Gearman module not loaded"
+      ), true, false);
+    }
+
+    return PASSWORD_ERROR;
+  }
+}
+?>


### PR DESCRIPTION
This is a gearman driver for password plugin. The gearman payload is a json string containing username, oldPassword and newPassword. Gearman remote worker will send a json string back with 'result' having value of true when it is a successfull operation and false otherwise. 

This driver requires gearman module from http://pecl.php.net/package/gearman 
