### PR TITLE
Add session_garbage plugin hook call

### DIFF
--- a/program/lib/Roundcube/rcube_session.php
+++ b/program/lib/Roundcube/rcube_session.php
@@ -409,11 +409,13 @@ class rcube_session
                 $res = $this->db->query("SELECT sess_id, created, changed, ip FROM " . $this->db->table_name('session')
                     . " WHERE changed < " . $this->db->now(-$this->gc_enabled));
 
-                while ($sql_arr = $this->db->fetch_assoc($res)) {
-                    $data = rcmail::get_instance()->plugins->exec_hook('session_garbage', array('session' => $sql_arr));
-                    if (!$data['abort']) {
-                        // delete the expired session
-                        $this->db->query("DELETE FROM " . $this->db->table_name('session') . " WHERE sess_id = ?", $sql_arr['sess_id']);
+                if ($res) {
+                    while ($sql_arr = $this->db->fetch_assoc($res)) {
+                        $data = rcmail::get_instance()->plugins->exec_hook('session_garbage', array('session' => $sql_arr));
+                        if (!$data['abort']) {
+                            // delete the expired session
+                            $this->db->query("DELETE FROM " . $this->db->table_name('session') . " WHERE sess_id = ?", $sql_arr['sess_id']);
+                        }
                     }
                 }
             }

--- a/program/lib/Roundcube/rcube_session.php
+++ b/program/lib/Roundcube/rcube_session.php
@@ -405,10 +405,17 @@ class rcube_session
     protected function gc_shutdown()
     {
         if ($this->gc_enabled) {
-            // just delete all expired sessions
             if ($this->storage == 'db') {
-                $this->db->query("DELETE FROM " . $this->db->table_name('session')
+                $res = $this->db->query("SELECT sess_id, created, changed, ip FROM " . $this->db->table_name('session')
                     . " WHERE changed < " . $this->db->now(-$this->gc_enabled));
+
+                while ($sql_arr = $this->db->fetch_assoc($res)) {
+                    $data = rcmail::get_instance()->plugins->exec_hook('session_garbage', array('session' => $sql_arr));
+                    if (!$data['abort']) {
+                        // delete the expired session
+                        $this->db->query("DELETE FROM " . $this->db->table_name('session') . " WHERE sess_id = ?", $sql_arr['sess_id']);
+                    }
+                }
             }
 
             foreach ($this->gc_handlers as $fct) {


### PR DESCRIPTION
Add session_garbage plugin hook call to the rcube_session class. This call needed if you want to collect the user authentication informations to a database. You can handle the session start and close via other hooks (login_after, login_failed, session_destroy) but if a session isn't closed properly you can't log it. With this change you get the chance to do other session_id related tasks before the session fully deleted.
