### PR TITLE
fix stringify problem when multiple headers values exist to be returned

### DIFF
--- a/program/lib/Roundcube/rcube_message_header.php
+++ b/program/lib/Roundcube/rcube_message_header.php
@@ -225,8 +225,15 @@ class rcube_message_header
         }
 
         if ($decode) {
-            $value = rcube_mime::decode_header($value, $this->charset);
-            $value = rcube_charset::clean($value);
+            if (is_array($value)) {
+                foreach ($value as $key=>$val) {
+                    $value[$key] = rcube_mime::decode_header($val, $this->charset);
+                    $value[$key] = rcube_charset::clean($val);
+                }
+            } else {
+                $value = rcube_mime::decode_header($value, $this->charset);
+                $value = rcube_charset::clean($value);
+            }
         }
 
         return $value;


### PR DESCRIPTION
some headers can be present multiple times (ie, Received - or other X-headers).
calling rcube_mime::decode_header/rcube_charset::clean stringifies the return value to "Array" instead of returning the array itself.

for a message with multiple Return-Path headers (which generally shouldn't happen, but it did):

$message->get_header('Return-Path',true); // don't mime-decode header value

would return an array, but

$message->get_header('Return-Path',false); // mime-decode header value

would just return the string "Array"

pull request makes both cases return an array and not a string.
