### PR TITLE
add include_plugin function for optional plugins

### DIFF
--- a/program/lib/Roundcube/rcube_plugin.php
+++ b/program/lib/Roundcube/rcube_plugin.php
@@ -121,6 +121,17 @@ abstract class rcube_plugin
     }
 
     /**
+     * Attempt to load the given plugin which is optional for the current plugin
+     *
+     * @param string Plugin name
+     * @return boolean True on success, false on failure
+     */
+    public function include_plugin($plugin_name)
+    {
+        return $this->api->load_plugin($plugin_name, true, false);
+    }
+
+    /**
      * Load local config file from plugins directory.
      * The loaded values are patched over the global configuration.
      *

--- a/program/lib/Roundcube/rcube_plugin_api.php
+++ b/program/lib/Roundcube/rcube_plugin_api.php
@@ -170,10 +170,11 @@ class rcube_plugin_api
      *
      * @param string Plugin name
      * @param boolean Force loading of the plugin even if it doesn't match the filter
+     * @param boolean Require loading of the plugin, error if it doesn't exist
      *
      * @return boolean True on success, false if not loaded or failure
      */
-    public function load_plugin($plugin_name, $force = false)
+    public function load_plugin($plugin_name, $force = false, $require = true)
     {
         static $plugins_dir;
 
@@ -225,7 +226,7 @@ class rcube_plugin_api
                     true, false);
             }
         }
-        else {
+        elseif ($require) {
             rcube::raise_error(array('code' => 520, 'type' => 'php',
                 'file' => __FILE__, 'line' => __LINE__,
                 'message' => "Failed to load plugin file $fn"), true, false);


### PR DESCRIPTION
one plugin might want to interact with another but only if that plugin is already installed - the second plugin is not required for the first to work. the require_plugin method will cause errors if the optional plugin does not exist so I propose to add a second method include_plugin which will fail silently if the plugin is not available.
