### PR TITLE
update rcube_plugin_api::exec_hook() to support new hooks that have been added mid-run

### DIFF
--- a/program/lib/Roundcube/rcube_plugin_api.php
+++ b/program/lib/Roundcube/rcube_plugin_api.php
@@ -46,7 +46,7 @@ class rcube_plugin_api
     protected $actionmap = array();
     protected $objectsmap = array();
     protected $template_contents = array();
-    protected $active_hook = false;
+    protected $active_hook = array();
 
     // Deprecated names of hooks, will be removed after 0.5-stable release
     protected $deprecated_hooks = array(
@@ -423,7 +423,7 @@ class rcube_plugin_api
         }
 
         $args += array('abort' => false);
-        $this->active_hook = $hook;
+        array_push($this->active_hook,$hook);
 
         foreach ((array)$this->handlers[$hook] as $callback) {
             $ret = call_user_func($callback, $args);
@@ -436,7 +436,7 @@ class rcube_plugin_api
             }
         }
 
-        $this->active_hook = false;
+        array_pop($this->active_hook);
         return $args;
     }
 
@@ -572,7 +572,7 @@ class rcube_plugin_api
      */
     public function is_processing($hook = null)
     {
-        return $this->active_hook && (!$hook || $this->active_hook == $hook);
+        return count($this->active_hook) && (!$hook || in_array($hook,$this->active_hook));
     }
 
     /**


### PR DESCRIPTION
This pull request fixes 2 things

1) fix tracking of the active_hook state

2) during the hook execution loop check for newly added hooks mid-run

Example: Plugin A dynamically loads plugin B during exec_hook:startup. Without this fix the startup hook of plugin B won't get executed anymore. (In this case kolab_auth plugin during kolab_auth_role_plugins execution)

Additional information to the while loop: 
- foreach won't see react on new added hooks
- using array pointers with while(next()) will not work cause adding new hooks will reset the current array pointer position.

I tried to keep it lightweight and hope this check doesn't affect too much of the performance.

What do yo think?
