### PR TITLE
Don't hardcode the INBOX redirect

### DIFF
--- a/program/js/app.js
+++ b/program/js/app.js
@@ -1403,9 +1403,7 @@ function rcube_webmail()
 
     var url = this.get_task_url(task);
 
-    if (task == 'mail')
-      url += '&_mbox=INBOX';
-    else if (task == 'logout' && !this.env.server_error)
+    if (task == 'logout' && !this.env.server_error)
       this.clear_compose_data();
 
     this.redirect(url);


### PR DESCRIPTION
If we remove this expression and didn't hardcode the INBOX redirect the app will return to the previously opened mbox when switch back to email from Preferences or Addressbook.
