### PR TITLE
Index IX_contactgroups_user_id was created on the wrong table.

### DIFF
--- a/SQL/mssql.initial.sql
+++ b/SQL/mssql.initial.sql
@@ -280,7 +280,7 @@ ALTER TABLE [dbo].[contactgroups] ADD
 	CONSTRAINT [CK_contactgroups_del] CHECK ([del] = '1' or [del] = '0')
 GO
 
-CREATE INDEX [IX_contactgroups_user_id] ON [dbo].[contacts]([user_id]) ON [PRIMARY]
+CREATE INDEX [IX_contactgroups_user_id] ON [dbo].[contactgroups]([user_id]) ON [PRIMARY]
 GO
 
 ALTER TABLE [dbo].[contactgroupmembers] ADD 


### PR DESCRIPTION
The index IX_contactgroups_user_id was created on the [dbo].[contacts] table instead of the [dbo].[contactgroups] table.
