### PR TITLE
pass click event to general hide_menu call

### DIFF
--- a/program/js/app.js
+++ b/program/js/app.js
@@ -1660,7 +1660,7 @@ function rcube_webmail()
         }
         skip = obj.data('parent');
       }
-    }, 10);
+    }, 10, e);
   };
 
   // global keypress event handler


### PR DESCRIPTION
similar to pull request #217 but here while the event arg is defined the event itself is never passed in.
