### PR TITLE
Fix get_metadata() function response, NIL response was introducing an shift

### DIFF
--- a/program/lib/Roundcube/rcube_imap_generic.php
+++ b/program/lib/Roundcube/rcube_imap_generic.php
@@ -3199,9 +3199,9 @@ class rcube_imap_generic
                 for ($i=0; $i<$size; $i++) {
                     if (isset($mbox) && is_array($data[$i])) {
                         $size_sub = count($data[$i]);
-                        for ($x=0; $x<$size_sub; $x++) {
+                        for ($x=0; $x<$size_sub; $x+=2) {
                             if ($data[$i][$x+1] !== null)
-                                $result[$mbox][$data[$i][$x]] = $data[$i][++$x];
+                                $result[$mbox][$data[$i][$x]] = $data[$i][$x+1];
                         }
                         unset($data[$i]);
                     }


### PR DESCRIPTION
This is a fix for get_metadata() function. Varibles are not incremented correctly in rcube_imap_generic.php when there is a NIL response to GETMETADATA  IMAP command. It is resulting in shift in get_metadata() function answer.:
example:
  'Shared Folders/bnogas/kalendarz2' => 
  array (
    '' => '/shared/vendor/kolab/folder-type',
  ),
instead of:
  'Shared Folders/bnogas/kalendarz2' => 
  array (
    '/shared/vendor/kolab/folder-type' => 'event',
  ),
