### PR TITLE
Support for multiple email addresses in new_user_identity plugin

### DIFF
--- a/plugins/new_user_identity/new_user_identity.php
+++ b/plugins/new_user_identity/new_user_identity.php
@@ -44,6 +44,32 @@ class new_user_identity extends rcube_plugin
                 if (!$args['user_email'] && strpos($user_email, '@')) {
                     $args['user_email'] = rcube_utils::idn_to_ascii($user_email);
                 }
+
+                $args['email_list'] = array();
+                $i=0;
+                $keys = array_keys( $results[0] );
+
+                foreach ( $keys as $key ) {
+                    if (!preg_match( '/^email($|:)/', $key )) {
+                        continue;
+                    }
+
+                    if (is_array($results->records[0][$key])) {
+                        foreach($results->records[0][$key] as $alias) {
+                            if(strpos($alias, '@')) {
+                                $args['email_list'][$i++] = rcube_idn_to_ascii($alias);
+                            }
+                        }
+                    }
+                    else {
+                        $alias = $results->records[0][$key];
+                        if (strpos($alias, '@')) {
+                            $args['email_list'][$i++] = rcube_idn_to_ascii($alias);
+                        }
+
+                   }
+                }
+
             }
         }
         return $args;


### PR DESCRIPTION
This change adds support for creating multiple user identities using new_user_identities for each email address available in $config['new_user_identity_addressbook'] .
An user identity is created for each email and email:\* field in addressbook. The first email field is set as default identity.
