### PR TITLE
Fix saving :addresses

### DIFF
--- a/plugins/managesieve/lib/Roundcube/rcube_sieve_engine.php
+++ b/plugins/managesieve/lib/Roundcube/rcube_sieve_engine.php
@@ -968,7 +968,7 @@ class rcube_sieve_engine
 
                     $this->form['actions'][$i]['reason']    = str_replace("\r\n", "\n", $reason);
                     $this->form['actions'][$i]['subject']   = $subject[$idx];
-                    $this->form['actions'][$i]['addresses'] = array_shift($addresses);
+                    $this->form['actions'][$i]['addresses'] = array_pop($addresses);
                     $this->form['actions'][$i][$interval_type] = $intervals[$idx];
 // @TODO: vacation :mime, :from, :handle
 


### PR DESCRIPTION
Running 1.0.2 with the managesieve plugin I noticed that I could no longer save additional addresses with vacation-type rules. Values entered into the field(s) just get discarded. I looked into the code and it appears that the value in `$addresses` actually looks like

``` php
(
    [0] => Array  
        (
            [0] =>   
        )

    [1] => Array
        (  
            [0] => email@address
            [1] => second@address
        )

)
```

So `array_shift` just returns an empty array every time.

From git log I could not immediately figure out when this broke, but this PR fixes it for me.
