### PR TITLE
Update app.js

### DIFF
--- a/program/js/app.js
+++ b/program/js/app.js
@@ -7152,9 +7152,12 @@ function rcube_webmail()
   {
     var url = this.url(action, query);
 
+    if(lock)
+        query._lock=lock;
+          
     // trigger plugin hook
     var result = this.triggerEvent('request'+action, query);
-
+  
     if (result !== undefined) {
       // abort if one the handlers returned false
       if (result === false)


### PR DESCRIPTION
Hi, When I am using event "request+action" and returing  false,  "loading message" doesn't hide.

for example:
 rcmail.addEventListener('requestlist',function(q){
      var response=cachelist.get(q._mbox,q._page)
      response.unlock=q._lock;
      rcmail.http_response(response);
      return false;
}
////////////
if response has not  "unlock" , system doesn't hide 'loading message' and all interface is  seting  busy
