### PR TITLE
better events for get_single_uid/cid

### DIFF
--- a/program/js/app.js
+++ b/program/js/app.js
@@ -7830,13 +7830,17 @@ function rcube_webmail()
   // and return the message uid
   this.get_single_uid = function()
   {
-    return this.env.uid ? this.env.uid : (this.message_list ? this.message_list.get_single_selection() : null);
+    var uid = this.env.uid || (this.message_list ? this.message_list.get_single_selection() : null);
+    var result = ref.triggerEvent('get_single_uid', { uid: uid });
+    return result || uid;
   };
 
   // same as above but for contacts
   this.get_single_cid = function()
   {
-    return this.env.cid ? this.env.cid : (this.contact_list ? this.contact_list.get_single_selection() : null);
+    var cid = this.env.cid || (this.contact_list ? this.contact_list.get_single_selection() : null);
+    var result = ref.triggerEvent('get_single_cid', { cid: cid });
+    return result || cid;
   };
 
   // get the IMP mailbox of the message with the given UID


### PR DESCRIPTION
While working on improving the extensibility of the contextmenu plugin particularly with attention to the zipdownload plugin I found the need for a plugin to be able to override the result of the get_single_uid and get_single_cid functions. In my case, so I can return the id of the item on which the context menu was triggered rather than any current selection.

Updated with Thomas' suggestion from #231 
