### PR TITLE
fix for bug #1490101

### DIFF
--- a/skins/larry/print.css
+++ b/skins/larry/print.css
@@ -15,7 +15,7 @@ body {
 	margin: 2mm;
 }
 
-body, td, th, span, div, p {
+body, td, th, div, p {
 	font-size: 9pt;
 	color: #000;
 }


### PR DESCRIPTION
the span directive here is superfluous - the body directive would already have applied the font size anyway (unless it was intentionally overridden by the html content of the message, which is the problem in bug #1490101).
