### PR TITLE
Fix of really fix UNKNOWN-CTE handling

### DIFF
--- a/program/lib/Roundcube/rcube_imap_generic.php
+++ b/program/lib/Roundcube/rcube_imap_generic.php
@@ -2569,7 +2569,6 @@ class rcube_imap_generic
             return false;
         }
 
-        $initiated = false;
         $binary    = true;
 
         do {
@@ -2732,7 +2731,7 @@ class rcube_imap_generic
                     }
                 }
             }
-        } while (!$this->startsWith($line, $key, true));
+        } while (!$this->startsWith($line, $key, true) || !$initiated);
 
         if ($result !== false) {
             if ($file) {


### PR DESCRIPTION
One more thing, the "|| !$initiated" in while statement is required, because otherwise the loop ends after "continue"  in "handle UNKNOWN-CTE response" (line 2626/2627). In result message is not downloaded using BODY.
