### PR TITLE
Fix some timezone offsets.

### DIFF
--- a/program/steps/settings/func.inc
+++ b/program/steps/settings/func.inc
@@ -220,7 +220,7 @@ function rcmail_user_prefs($current = null)
                 foreach (DateTimeZone::listIdentifiers() as $i => $tzs) {
                     try {
                         $tz      = new DateTimeZone($tzs);
-                        $date    = new DateTime('2012-12-21', $tz);
+                        $date    = new DateTime(date('Y-m-d'), $tz);
                         $offset  = $date->format('Z') + 45000;
                         $sortkey = sprintf('%06d.%s', $offset, $tzs);
                         $zones[$sortkey] = array($tzs, $date->format('P'));


### PR DESCRIPTION
2014.10.26 Europe/Moscow timezone changed it's offset  because of change in daylight saving time.
Strange hardcoded date of 2012-12-21 break Europe/Moscow new timezone offset (and possibly some other timezones).
