### PR TITLE
Add support for updating identities on each login

### DIFF
--- a/plugins/new_user_identity/config.inc.php.dist
+++ b/plugins/new_user_identity/config.inc.php.dist
@@ -1,10 +1,15 @@
 <?php
 
-// The id of the address book to use to automatically set a new
+// The id of the address book to use to automatically set a
 // user's full name in their new identity. (This should be an
 // string, which refers to the $config['ldap_public'] array.)
 $config['new_user_identity_addressbook'] = 'People';
 
-// When automatically setting a new users's full name in their
+// When automatically setting a user's full name in their
 // new identity, match the user's login name against this field.
 $config['new_user_identity_match'] = 'uid';
+
+// Determine whether to import user's identities on each login.
+// New user identity will be created for each e-mail address
+// present in address book, but not assigned to any identity.
+$config['new_user_identity_onlogin'] = false;

--- a/plugins/new_user_identity/new_user_identity.php
+++ b/plugins/new_user_identity/new_user_identity.php
@@ -27,10 +27,6 @@ class new_user_identity extends rcube_plugin
 
     function lookup_user_name($args)
     {
-        if (!$args['login_after']) {
-            $this->load_config();
-        }
-
         if ($this->init_ldap($args['host'])) {
             $results = $this->ldap->search('*', $args['user'], true);
 
@@ -67,13 +63,13 @@ class new_user_identity extends rcube_plugin
     {
         $this->load_config();
 
-        if (!$this->rc->config->get('new_user_identity_onlogin')) {
+        if ($this->ldap || !$this->rc->config->get('new_user_identity_onlogin')) {
             return $args;
         }
 
         $identities  = $this->rc->user->list_identities();
         $ldap_entry  = $this->lookup_user_name(array('user' => $this->rc->user->data['username'],
-            'host' => $this->rc->user->data['mail_host'], 'login_after' => true));
+            'host' => $this->rc->user->data['mail_host']));
 
         foreach ($ldap_entry['email_list'] as $email) {
             foreach($identities as $identity) {
@@ -100,6 +96,8 @@ class new_user_identity extends rcube_plugin
         if ($this->ldap) {
             return $this->ldap->ready;
         }
+
+        $this->load_config();
 
         $addressbook = $this->rc->config->get('new_user_identity_addressbook');
         $ldap_config = (array)$this->rc->config->get('ldap_public');


### PR DESCRIPTION
It allows to automatically add new e-mail addresses when user's account is modified in LDAP. Useful especially with $config['identities_level']=1
