### PR TITLE
Check to see if the content frame exists before loading a contact

### DIFF
--- a/program/js/app.js
+++ b/program/js/app.js
@@ -4704,7 +4704,7 @@ function rcube_webmail()
       source = this.env.source ? this.env.address_sources[this.env.source] : null;
 
     // we don't have dblclick handler here, so use 200 instead of this.dblclick_time
-    if (id = list.get_single_selection())
+    if (this.env.contentframe && (id = list.get_single_selection()))
       this.preview_timer = setTimeout(function(){ ref.load_contact(id, 'show'); }, 200);
     else if (this.env.contentframe)
       this.show_contentframe(false);


### PR DESCRIPTION
Similar to the check in msglist_select().

Use cases: It would be useful for skins which want to have a toggle button for the contact frame on the addressbook screen similar to the one for the preview frame on the main screen but it is also useful for plugins which want to prevent a contact from being loaded. It will help me solve JohnDoh/Roundcube-Plugin-Context-Menu#62. I need to trigger the select event on the list to enable/disable the relevant command but I don’t want to update the contact frame.
