### PR TITLE
Clarify temp/logs directories permissions

### DIFF
--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -318,11 +318,13 @@ $config['auto_create_user'] = true;
 // Enables possibility to log in using email address from user identities
 $config['user_aliases'] = false;
 
-// use this folder to store log files (must be writeable for apache user)
+// use this folder to store log files
+// must be writeable for the user who runs PHP process (Apache user if mod_php is being used)
 // This is used by the 'file' log driver.
 $config['log_dir'] = RCUBE_INSTALL_PATH . 'logs/';
 
-// use this folder to store temp files (must be writeable for apache user)
+// use this folder to store temp files
+// must be writeable for the user who runs PHP process (Apache user if mod_php is being used)
 $config['temp_dir'] = RCUBE_INSTALL_PATH . 'temp/';
 
 // expire files in temp_dir after 48 hours


### PR DESCRIPTION
When installing Roundcube on a web server other than Apache or when using a PHP "runner" other than mod_php user "apache" will not work. This PR clarifies the description a bit.
