### PR TITLE
bring %s variable support in setting smtp_server

### DIFF
--- a/config/config.inc.php.sample
+++ b/config/config.inc.php.sample
@@ -47,6 +47,7 @@ $config['default_host'] = 'localhost';
 // %t - hostname without the first part
 // %d - domain (http hostname $_SERVER['HTTP_HOST'] without the first part)
 // %z - IMAP domain (IMAP hostname without the first part)
+// %s - domain name after the '@' from e-mail address provided
 // For example %n = mail.domain.tld, %t = domain.tld
 $config['smtp_server'] = '';
 

--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -63,7 +63,7 @@ $config['debug_level'] = 1;
 $config['log_driver'] = 'file';
 
 // date format for log entries
-// (read http://php.net/manual/en/function.date.php for all format characters)  
+// (read http://php.net/manual/en/function.date.php for all format characters)
 $config['log_date_format'] = 'd-M-Y H:i:s O';
 
 // length of the session ID to prepend each log line with
@@ -222,6 +222,7 @@ $config['messages_cache_threshold'] = 50;
 // %t - hostname without the first part
 // %d - domain (http hostname $_SERVER['HTTP_HOST'] without the first part)
 // %z - IMAP domain (IMAP hostname without the first part)
+// %s - domain name after the '@' from e-mail address provided
 // For example %n = mail.domain.tld, %t = domain.tld
 $config['smtp_server'] = '';
 
@@ -247,9 +248,9 @@ $config['smtp_auth_cid'] = null;
 // Optional SMTP authentication password to be used for smtp_auth_cid
 $config['smtp_auth_pw'] = null;
 
-// SMTP HELO host 
-// Hostname to give to the remote server for SMTP 'HELO' or 'EHLO' messages 
-// Leave this blank and you will get the server variable 'server_name' or 
+// SMTP HELO host
+// Hostname to give to the remote server for SMTP 'HELO' or 'EHLO' messages
+// Leave this blank and you will get the server variable 'server_name' or
 // localhost if that isn't defined.
 $config['smtp_helo_host'] = '';
 
@@ -438,11 +439,11 @@ $config['password_charset'] = 'ISO-8859-1';
 $config['sendmail_delay'] = 0;
 
 // Maximum number of recipients per message. Default: 0 (no limit)
-$config['max_recipients'] = 0; 
+$config['max_recipients'] = 0;
 
 // Maximum allowednumber of members of an address group. Default: 0 (no limit)
 // If 'max_recipients' is set this value should be less or equal
-$config['max_group_members'] = 0; 
+$config['max_group_members'] = 0;
 
 // Name your service. This is displayed on the login screen and in the window title
 $config['product_name'] = 'Roundcube Webmail';
@@ -567,7 +568,7 @@ $config['plugins'] = array();
 // USER INTERFACE
 // ----------------------------------
 
-// default messages sort column. Use empty value for default server's sorting, 
+// default messages sort column. Use empty value for default server's sorting,
 // or 'arrival', 'date', 'subject', 'from', 'to', 'fromto', 'size', 'cc'
 $config['message_sort_col'] = '';
 
@@ -629,7 +630,7 @@ $config['protect_default_folders'] = true;
 // Disable localization of the default folder names listed above
 $config['show_real_foldernames'] = false;
 
-// if in your system 0 quota means no limit set this option to true 
+// if in your system 0 quota means no limit set this option to true
 $config['quota_zero_as_unlimited'] = false;
 
 // Make use of the built-in spell checker. It is based on GoogieSpell.
@@ -719,7 +720,7 @@ $config['address_book_type'] = 'sql';
 // Array key must contain only safe characters, ie. a-zA-Z0-9_
 $config['ldap_public'] = array();
 
-// If you are going to use LDAP for individual address books, you will need to 
+// If you are going to use LDAP for individual address books, you will need to
 // set 'user_specific' to true and use the variables to generate the appropriate DNs to access it.
 //
 // The recommended directory structure for LDAP is to store all the address book entries
@@ -732,7 +733,7 @@ $config['ldap_public'] = array();
 //
 // So the base_dn would be uid=%fu,ou=people,o=root
 // The bind_dn would be the same as based_dn or some super user login.
-/* 
+/*
  * example config for Verisign directory
  *
 $config['ldap_public']['Verisign'] = array(
@@ -830,7 +831,7 @@ $config['ldap_public']['Verisign'] = array(
   'sub_fields' => array(),
   // Generate values for the following LDAP attributes automatically when creating a new record
   'autovalues' => array(
-  // 'uid'  => 'md5(microtime())',               // You may specify PHP code snippets which are then eval'ed 
+  // 'uid'  => 'md5(microtime())',               // You may specify PHP code snippets which are then eval'ed
   // 'mail' => '{givenname}.{sn}@mydomain.com',  // or composite strings with placeholders for existing attributes
   ),
   'sort'           => 'cn',         // The field to sort the listing by.
@@ -850,7 +851,7 @@ $config['ldap_public']['Verisign'] = array(
   // definition for contact groups (uncomment if no groups are supported)
   // for the groups base_dn, the user replacements %fu, %u, $d and %dc work as for base_dn (see above)
   // if the groups base_dn is empty, the contact base_dn is used for the groups as well
-  // -> in this case, assure that groups and contacts are separated due to the concernig filters! 
+  // -> in this case, assure that groups and contacts are separated due to the concernig filters!
   'groups'  => array(
     'base_dn'           => '',
     'scope'             => 'sub',       // Search mode: sub|base|list
@@ -999,7 +1000,7 @@ $config['logout_purge'] = false;
 // Compact INBOX on logout
 $config['logout_expunge'] = false;
 
-// Display attached images below the message body 
+// Display attached images below the message body
 $config['inline_images'] = true;
 
 // Encoding of long/non-ascii attachment names:

--- a/program/lib/Roundcube/rcube_smtp.php
+++ b/program/lib/Roundcube/rcube_smtp.php
@@ -72,7 +72,18 @@ class rcube_smtp
             'smtp_auth_callbacks' => array(),
         ));
 
-        $smtp_host = rcube_utils::parse_host($CONFIG['smtp_server']);
+        $smtp_user = str_replace('%u', $rcube->get_user_name(), $CONFIG['smtp_user']);
+        $smtp_pass = str_replace('%p', $rcube->get_user_password(), $CONFIG['smtp_pass']);
+        $smtp_auth_type = empty($CONFIG['smtp_auth_type']) ? NULL : $CONFIG['smtp_auth_type'];
+
+        if (!empty($CONFIG['smtp_auth_cid'])) {
+            $smtp_authz = $smtp_user;
+            $smtp_user  = $CONFIG['smtp_auth_cid'];
+            $smtp_pass  = $CONFIG['smtp_auth_pw'];
+        }
+
+        // provide $smtp_user to provide %s variable in smtp_server setting
+        $smtp_host = rcube_utils::parse_host($CONFIG['smtp_server'], '', $smtp_user);
         // when called from Installer it's possible to have empty $smtp_host here
         if (!$smtp_host) $smtp_host = 'localhost';
         $smtp_port     = is_numeric($CONFIG['smtp_port']) ? $CONFIG['smtp_port'] : 25;
@@ -138,16 +149,6 @@ class rcube_smtp
             && ($timeout = ini_get('default_socket_timeout'))
         ) {
             $this->conn->setTimeout($timeout);
-        }
-
-        $smtp_user = str_replace('%u', $rcube->get_user_name(), $CONFIG['smtp_user']);
-        $smtp_pass = str_replace('%p', $rcube->get_user_password(), $CONFIG['smtp_pass']);
-        $smtp_auth_type = empty($CONFIG['smtp_auth_type']) ? NULL : $CONFIG['smtp_auth_type'];
-
-        if (!empty($CONFIG['smtp_auth_cid'])) {
-            $smtp_authz = $smtp_user;
-            $smtp_user  = $CONFIG['smtp_auth_cid'];
-            $smtp_pass  = $CONFIG['smtp_auth_pw'];
         }
 
         // attempt to authenticate to the SMTP server

--- a/program/lib/Roundcube/rcube_utils.php
+++ b/program/lib/Roundcube/rcube_utils.php
@@ -607,10 +607,11 @@ class rcube_utils
      *
      * @param string $name Hostname
      * @param string $host Optional IMAP hostname
+     * @param string $user_email Optional e-mail address
      *
      * @return string Hostname
      */
-    public static function parse_host($name, $host = '')
+    public static function parse_host($name, $host = '', $user_email = '')
     {
         if (!is_string($name)) {
             return $name;
@@ -618,17 +619,25 @@ class rcube_utils
 
         // %n - host
         $n = preg_replace('/:\d+$/', '', $_SERVER['SERVER_NAME']);
+
         // %t - host name without first part, e.g. %n=mail.domain.tld, %t=domain.tld
         $t = preg_replace('/^[^\.]+\./', '', $n);
+
         // %d - domain name without first part
         $d = preg_replace('/^[^\.]+\./', '', $_SERVER['HTTP_HOST']);
+
         // %h - IMAP host
         $h = $_SESSION['storage_host'] ? $_SESSION['storage_host'] : $host;
+
         // %z - IMAP domain without first part, e.g. %h=imap.domain.tld, %z=domain.tld
         $z = preg_replace('/^[^\.]+\./', '', $h);
+
         // %s - domain name after the '@' from e-mail address provided at login screen. Returns FALSE if an invalid email is provided
         if (strpos($name, '%s') !== false) {
-            $user_email = self::get_input_value('_user', self::INPUT_POST);
+            if (empty($user_email)) {
+                $user_email = self::get_input_value('_user', self::INPUT_POST);
+            }
+
             $user_email = self::idn_convert($user_email, true);
             $matches    = preg_match('/(.*)@([a-z0-9\.\-\[\]\:]+)/i', $user_email, $s);
             if ($matches < 1 || filter_var($s[1]."@".$s[2], FILTER_VALIDATE_EMAIL) === false) {


### PR DESCRIPTION
%s is available in defaut_host so providing %s variable support in smtp_server should be also possible since when you're using imap.domain.de you often have smtp.domain.de, too.
