### PR TITLE
session refactor

### DIFF
--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -374,9 +374,14 @@ $config['session_auth_name'] = null;
 // Session path. Defaults to PHP session.cookie_path setting.
 $config['session_path'] = null;
 
-// Backend to use for session storage. Can either be 'db' (default), 'memcache' or 'php'
+// Backend to use for session storage. Can either be 'db' (default), 'redis', 'memcache', or 'php'
+//
 // If set to 'memcache', a list of servers need to be specified in 'memcache_hosts'
 // Make sure the Memcache extension (http://pecl.php.net/package/memcache) version >= 2.0.0 is installed
+//
+// If set to 'redis', a server needs to be specified in 'redis_hosts'
+// Make sure the Redis extension (http://pecl.php.net/package/redis) version >= 2.0.0 is installed
+//
 // Setting this value to 'php' will use the default session save handler configured in PHP
 $config['session_storage'] = 'db';
 
@@ -396,6 +401,13 @@ $config['memcache_timeout'] = 1;
 // Setting this parameter to -1 disables automatic retry.
 // See http://php.net/manual/en/memcache.addserver.php
 $config['memcache_retry_interval'] = 15;
+
+// use this for accessing redis
+// currently only one host is supported. cluster support may come in a future release.
+// you can pass 4 fields, host, port, database and password.
+// unset fields will be set to the default values host=127.0.0.1, port=6379, database=0, password=  (empty)
+
+$config['redis_hosts'] = null; // e.g. array( 'localhost:6379' );  array( '192.168.1.1:6379:1:secret' );
 
 // check client IP in session authorization
 $config['ip_check'] = false;

--- a/program/lib/Roundcube/rcube.php
+++ b/program/lib/Roundcube/rcube.php
@@ -522,9 +522,12 @@ class rcube
         ini_set('session.cookie_httponly', 1);
 
         // use database for storing session data
-        $this->session = new rcube_session($this->get_dbh(), $this->config);
+        $storage = $this->config->get('session_storage', 'db');
+        $this->session = $this->get_session($storage);
 
+        // register default gc handler
         $this->session->register_gc_handler(array($this, 'gc'));
+
         $this->session->set_secret($this->config->get('des_key') . dirname($_SERVER['SCRIPT_NAME']));
         $this->session->set_ip_check($this->config->get('ip_check'));
 
@@ -534,8 +537,30 @@ class rcube
 
         // start PHP session (if not in CLI mode)
         if ($_SERVER['REMOTE_ADDR']) {
-            $this->session->start();
+            $this->session->start($this->config);
         }
+    }
+
+    /**
+     * get an rcube_session instance
+     *
+     * @return rcube_session
+     */
+    private function get_session($storage)
+    {
+        // class name for this storage
+        $class = "rcube_session_" . $storage;
+
+        // try to instantiate class
+        if(class_exists($class)) {
+            return new $class();
+        }
+
+        // no storage found, raise error
+        rcube::raise_error(array('code' => 604, 'type' => 'session',
+                               'line' => __LINE__, 'file' => __FILE__,
+                               'message' => "Failed to find session driver. Check session_storage config option"),
+                           true, true);
     }
 
 

--- a/program/lib/Roundcube/rcube.php
+++ b/program/lib/Roundcube/rcube.php
@@ -521,48 +521,17 @@ class rcube
         ini_set('session.use_only_cookies', 1);
         ini_set('session.cookie_httponly', 1);
 
-        // use database for storing session data
-        $storage = $this->config->get('session_storage', 'db');
-        $this->session = $this->get_session($storage);
+        // get storage driver from config
+        // $storage = $this->config->get('session_storage', 'db');
 
-        // register default gc handler
-        $this->session->register_gc_handler(array($this, 'gc'));
-
-        $this->session->set_secret($this->config->get('des_key') . dirname($_SERVER['SCRIPT_NAME']));
-        $this->session->set_ip_check($this->config->get('ip_check'));
-
-        if ($this->config->get('session_auth_name')) {
-            $this->session->set_cookiename($this->config->get('session_auth_name'));
-        }
+        // get session driver instance
+        $this->session = rcube_session::factory($this->config);
 
         // start PHP session (if not in CLI mode)
         if ($_SERVER['REMOTE_ADDR']) {
-            $this->session->start($this->config);
+            $this->session->start();
         }
     }
-
-    /**
-     * get an rcube_session instance
-     *
-     * @return rcube_session
-     */
-    private function get_session($storage)
-    {
-        // class name for this storage
-        $class = "rcube_session_" . $storage;
-
-        // try to instantiate class
-        if(class_exists($class)) {
-            return new $class();
-        }
-
-        // no storage found, raise error
-        rcube::raise_error(array('code' => 604, 'type' => 'session',
-                               'line' => __LINE__, 'file' => __FILE__,
-                               'message' => "Failed to find session driver. Check session_storage config option"),
-                           true, true);
-    }
-
 
     /**
      * Garbage collector - cache/temp cleaner

--- a/program/lib/Roundcube/rcube.php
+++ b/program/lib/Roundcube/rcube.php
@@ -520,10 +520,7 @@ class rcube
         ini_set('session.use_cookies', 1);
         ini_set('session.use_only_cookies', 1);
         ini_set('session.cookie_httponly', 1);
-
-        // get storage driver from config
-        // $storage = $this->config->get('session_storage', 'db');
-
+        
         // get session driver instance
         $this->session = rcube_session::factory($this->config);
 

--- a/program/lib/Roundcube/rcube.php
+++ b/program/lib/Roundcube/rcube.php
@@ -520,7 +520,7 @@ class rcube
         ini_set('session.use_cookies', 1);
         ini_set('session.use_only_cookies', 1);
         ini_set('session.cookie_httponly', 1);
-        
+
         // get session driver instance
         $this->session = rcube_session::factory($this->config);
 

--- a/program/lib/Roundcube/rcube_session_db.php
+++ b/program/lib/Roundcube/rcube_session_db.php
@@ -33,8 +33,13 @@ class rcube_session_db extends rcube_session
     private $db;
     private $table_name;
 
-    public function __construct()
+    /**
+     * @param Object $config
+     */
+    public function __construct($config)
     {
+        parent::__construct($config);
+
         // get db instance
         $this->db      = rcube::get_instance()->get_dbh();
 

--- a/program/lib/Roundcube/rcube_session_db.php
+++ b/program/lib/Roundcube/rcube_session_db.php
@@ -1,0 +1,168 @@
+<?php
+
+/*
+ +-----------------------------------------------------------------------+
+ | This file is part of the Roundcube Webmail client                     |
+ | Copyright (C) 2005-2014, The Roundcube Dev Team                       |
+ | Copyright (C) 2011, Kolab Systems AG                                  |
+ |                                                                       |
+ | Licensed under the GNU General Public License version 3 or            |
+ | any later version with exceptions for skins & plugins.                |
+ | See the README file for a full license statement.                     |
+ |                                                                       |
+ | PURPOSE:                                                              |
+ |   Provide database supported session management                       |
+ +-----------------------------------------------------------------------+
+ | Author: Thomas Bruederli <roundcube@gmail.com>                        |
+ | Author: Aleksander Machniak <alec@alec.pl>                            |
+ | Author: Cor Bosman <cor@roundcu.be>                                   |
+ +-----------------------------------------------------------------------+
+*/
+
+/**
+ * Class to provide database session storage
+ *
+ * @package    Framework
+ * @subpackage Core
+ * @author     Thomas Bruederli <roundcube@gmail.com>
+ * @author     Aleksander Machniak <alec@alec.pl>
+ * @author     Cor Bosman <cor@roundcu.be>
+ */
+class rcube_session_db extends rcube_session
+{
+    private $db;
+    private $table_name;
+
+    public function __construct()
+    {
+        // get db instance
+        $this->db      = rcube::get_instance()->get_dbh();
+
+        // session table name
+        $this->table_name = $this->db->table_name('session', true);
+
+        // register sessions handler
+        $this->register_session_handler();
+
+        // register db gc handler
+        $this->register_gc_handler(array($this, 'gc_db'));
+    }
+
+    /**
+     * @param $save_path
+     * @param $session_name
+     * @return bool
+     */
+    public function open($save_path, $session_name)
+    {
+        return true;
+    }
+
+    /**
+     * @return bool
+     */
+    public function close()
+    {
+        return true;
+    }
+
+
+    /**
+     * Handler for session_destroy()
+     *
+     * @param $key
+     * @return bool
+     */
+    public function destroy($key)
+    {
+        if ($key) {
+            $this->db->query("DELETE FROM {$this->table_name} WHERE `sess_id` = ?", $key);
+        }
+
+        return true;
+    }
+
+    /**
+     * Read session data from database
+     *
+     * @param string Session ID
+     *
+     * @return string Session vars
+     */
+    public function read($key)
+    {
+        $sql_result = $this->db->query(
+            "SELECT `vars`, `ip`, `changed`, " . $this->db->now() . " AS ts"
+            . " FROM {$this->table_name} WHERE `sess_id` = ?", $key);
+
+        if ($sql_result && ($sql_arr = $this->db->fetch_assoc($sql_result))) {
+            $this->time_diff = time() - strtotime($sql_arr['ts']);
+            $this->changed   = strtotime($sql_arr['changed']);
+            $this->ip        = $sql_arr['ip'];
+            $this->vars      = base64_decode($sql_arr['vars']);
+            $this->key       = $key;
+
+            return !empty($this->vars) ? (string) $this->vars : '';
+        }
+        return null;
+    }
+
+    /**
+     * insert new data into db session store
+     *
+     * @param $key
+     * @param $vars
+     * @return bool
+     */
+    public function write($key, $vars)
+    {
+        $now        = $this->db->now();
+
+        $this->db->query("INSERT INTO {$this->table_name}"
+                         . " (`sess_id`, `vars`, `ip`, `created`, `changed`)"
+                         . " VALUES (?, ?, ?, $now, $now)",
+                         $key, base64_encode($vars), (string)$this->ip);
+
+        return true;
+    }
+
+
+    /**
+     * update session data
+     *
+     * @param $key
+     * @param $newvars
+     * @param $oldvars
+     *
+     * @return bool
+     */
+    public function update($key, $newvars, $oldvars)
+    {
+        $now        = $this->db->now();
+
+        // if new and old data are not the same, update data
+        // else update expire timestamp only when certain conditions are met
+        if ($newvars !== $oldvars) {
+            $this->db->query("UPDATE {$this->table_name} "
+                             . "SET `changed` = $now, `vars` = ? WHERE `sess_id` = ?",
+                             base64_encode($newvars), $key);
+        }
+        else if ($ts - $this->changed + $this->time_diff > $this->lifetime / 2) {
+            $this->db->query("UPDATE {$this->table_name} SET `changed` = $now"
+                                 . " WHERE `sess_id` = ?", $key);
+        }
+
+        return true;
+    }
+
+    /**
+     * Clean up db sessions.
+     */
+    public function gc_db()
+    {
+        // just clean all old sessions when this GC is called
+        $this->db->query("DELETE FROM " . $this->db->table_name('session')
+                         . " WHERE changed < " . $this->db->now(-$this->gc_enabled));
+    }
+
+}

--- a/program/lib/Roundcube/rcube_session_db.php
+++ b/program/lib/Roundcube/rcube_session_db.php
@@ -41,7 +41,7 @@ class rcube_session_db extends rcube_session
         parent::__construct($config);
 
         // get db instance
-        $this->db      = rcube::get_instance()->get_dbh();
+        $this->db = rcube::get_instance()->get_dbh();
 
         // session table name
         $this->table_name = $this->db->table_name('session', true);

--- a/program/lib/Roundcube/rcube_session_memcache.php
+++ b/program/lib/Roundcube/rcube_session_memcache.php
@@ -15,7 +15,7 @@
  +-----------------------------------------------------------------------+
  | Author: Thomas Bruederli <roundcube@gmail.com>                        |
  | Author: Aleksander Machniak <alec@alec.pl>                            |
- | Author: Cor Bosman <cor@roundcu.be>                                   |
+ | Author: Cor Bosman <cor@roundcu.bet>                                   |
  +-----------------------------------------------------------------------+
 */
 
@@ -32,11 +32,16 @@ class rcube_session_memcache extends rcube_session
 {
     private $memcache;
 
-    public function __construct()
+    /**
+     * @param Object $config
+     */
+    public function __construct($config)
     {
+        parent::__construct($config);
+
         $this->memcache = rcube::get_instance()->get_memcache();
 
-        if(! $this->memcache) {
+        if (!$this->memcache) {
             rcube::raise_error(array('code' => 604, 'type' => 'db',
                                    'line' => __LINE__, 'file' => __FILE__,
                                    'message' => "Failed to connect to memcached. Please check configuration"),
@@ -45,7 +50,6 @@ class rcube_session_memcache extends rcube_session
 
         // register sessions handler
         $this->register_session_handler();
-
     }
 
     /**

--- a/program/lib/Roundcube/rcube_session_memcache.php
+++ b/program/lib/Roundcube/rcube_session_memcache.php
@@ -1,0 +1,140 @@
+<?php
+
+/*
+ +-----------------------------------------------------------------------+
+ | This file is part of the Roundcube Webmail client                     |
+ | Copyright (C) 2005-2014, The Roundcube Dev Team                       |
+ | Copyright (C) 2011, Kolab Systems AG                                  |
+ |                                                                       |
+ | Licensed under the GNU General Public License version 3 or            |
+ | any later version with exceptions for skins & plugins.                |
+ | See the README file for a full license statement.                     |
+ |                                                                       |
+ | PURPOSE:                                                              |
+ |   Provide database supported session management                       |
+ +-----------------------------------------------------------------------+
+ | Author: Thomas Bruederli <roundcube@gmail.com>                        |
+ | Author: Aleksander Machniak <alec@alec.pl>                            |
+ | Author: Cor Bosman <cor@roundcu.be>                                   |
+ +-----------------------------------------------------------------------+
+*/
+
+/**
+ * Class to provide memcache session storage
+ *
+ * @package    Framework
+ * @subpackage Core
+ * @author     Thomas Bruederli <roundcube@gmail.com>
+ * @author     Aleksander Machniak <alec@alec.pl>
+ * @author     Cor Bosman <cor@roundcu.be>
+ */
+class rcube_session_memcache extends rcube_session
+{
+    private $memcache;
+
+    public function __construct()
+    {
+        $this->memcache = rcube::get_instance()->get_memcache();
+
+        if(! $this->memcache) {
+            rcube::raise_error(array('code' => 604, 'type' => 'db',
+                                   'line' => __LINE__, 'file' => __FILE__,
+                                   'message' => "Failed to connect to memcached. Please check configuration"),
+                               true, true);
+        }
+
+        // register sessions handler
+        $this->register_session_handler();
+
+    }
+
+    /**
+     * @param $save_path
+     * @param $session_name
+     * @return bool
+     */
+    public function open($save_path, $session_name)
+    {
+        return true;
+    }
+
+    /**
+     * @return bool
+     */
+    public function close()
+    {
+        return true;
+    }
+
+    /**
+     * Handler for session_destroy() with memcache backend
+     *
+     * @param $key
+     * @return bool
+     */
+    public function destroy($key)
+    {
+        if ($key) {
+            // #1488592: use 2nd argument
+            $this->memcache->delete($key, 0);
+        }
+
+        return true;
+    }
+
+
+    /**
+     * Read session data from memcache
+     *
+     * @param $key
+     * @return null|string
+     */
+    public function read($key)
+    {
+        if ($value = $this->memcache->get($key)) {
+            $arr = unserialize($value);
+            $this->changed = $arr['changed'];
+            $this->ip      = $arr['ip'];
+            $this->vars    = $arr['vars'];
+            $this->key     = $key;
+
+            return !empty($this->vars) ? (string) $this->vars : '';
+        }
+
+        return null;
+    }
+
+    /**
+     * write data to memcache storage
+     *
+     * @param $key
+     * @param $vars
+     * @return bool
+     */
+    public function write($key, $vars)
+    {
+        return $this->memcache->set($key, serialize(array('changed' => time(), 'ip' => $this->ip, 'vars' => $vars)),
+                                    MEMCACHE_COMPRESSED, $this->lifetime + 60);
+    }
+
+    /**
+     * update memcache session data
+     *
+     * @param $key
+     * @param $newvars
+     * @param $oldvars
+     * @return bool
+     */
+    public function update($key, $newvars, $oldvars)
+    {
+        $ts = microtime(true);
+
+        if ($newvars !== $oldvars || $ts - $this->changed > $this->lifetime / 3) {
+            return $this->memcache->set($key, serialize(array('changed' => time(), 'ip' => $this->ip, 'vars' => $newvars)),
+                                        MEMCACHE_COMPRESSED, $this->lifetime + 60);
+        }
+
+        return true;
+    }
+
+}

--- a/program/lib/Roundcube/rcube_session_php.php
+++ b/program/lib/Roundcube/rcube_session_php.php
@@ -30,7 +30,6 @@
  */
 class rcube_session_php extends rcube_session {
 
-
     /**
      * native php sessions don't need a save handler
      * we do need to define abstract function implementations but they are not used.
@@ -43,6 +42,13 @@ class rcube_session_php extends rcube_session {
     public function write($key, $vars) {}
     public function update($key, $newvars, $oldvars) {}
 
+    /**
+     * @param Object $config
+     */
+    public function __construct($config)
+    {
+        parent::__construct($config);
+    }
 
     /**
      * Wrapper for session_write_close()
@@ -58,9 +64,9 @@ class rcube_session_php extends rcube_session {
     /**
      * Wrapper for session_start()
      */
-    public function start($config)
+    public function start()
     {
-        parent::start($config);
+        parent::start();
 
         $this->key     = session_id();
         $this->ip      = $_SESSION['__IP'];

--- a/program/lib/Roundcube/rcube_session_php.php
+++ b/program/lib/Roundcube/rcube_session_php.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ +-----------------------------------------------------------------------+
+ | This file is part of the Roundcube Webmail client                     |
+ | Copyright (C) 2005-2014, The Roundcube Dev Team                       |
+ | Copyright (C) 2011, Kolab Systems AG                                  |
+ |                                                                       |
+ | Licensed under the GNU General Public License version 3 or            |
+ | any later version with exceptions for skins & plugins.                |
+ | See the README file for a full license statement.                     |
+ |                                                                       |
+ | PURPOSE:                                                              |
+ |   Provide database supported session management                       |
+ +-----------------------------------------------------------------------+
+ | Author: Thomas Bruederli <roundcube@gmail.com>                        |
+ | Author: Aleksander Machniak <alec@alec.pl>                            |
+ | Author: Cor Bosman <cor@roundcu.be>                                   |
+ +-----------------------------------------------------------------------+
+*/
+
+/**
+ * Class to provide native php session storage
+ *
+ * @package    Framework
+ * @subpackage Core
+ * @author     Thomas Bruederli <roundcube@gmail.com>
+ * @author     Aleksander Machniak <alec@alec.pl>
+ * @author     Cor Bosman <cor@roundcu.be>
+ */
+class rcube_session_php extends rcube_session {
+
+
+    /**
+     * native php sessions don't need a save handler
+     * we do need to define abstract function implementations but they are not used.
+     */
+
+    public function open($save_path, $session_name) {}
+    public function close() {}
+    public function destroy($key) {}
+    public function read($key) {}
+    public function write($key, $vars) {}
+    public function update($key, $newvars, $oldvars) {}
+
+
+    /**
+     * Wrapper for session_write_close()
+     */
+    public function write_close()
+    {
+        $_SESSION['__IP'] = $this->ip;
+        $_SESSION['__MTIME'] = time();
+
+        parent::write_close();
+    }
+
+    /**
+     * Wrapper for session_start()
+     */
+    public function start($config)
+    {
+        parent::start($config);
+
+        $this->key     = session_id();
+        $this->ip      = $_SESSION['__IP'];
+        $this->changed = $_SESSION['__MTIME'];
+
+    }
+
+}

--- a/program/lib/Roundcube/rcube_session_redis.php
+++ b/program/lib/Roundcube/rcube_session_redis.php
@@ -13,8 +13,6 @@
  | PURPOSE:                                                              |
  |   Provide database supported session management                       |
  +-----------------------------------------------------------------------+
- | Author: Thomas Bruederli <roundcube@gmail.com>                        |
- | Author: Aleksander Machniak <alec@alec.pl>                            |
  | Author: Cor Bosman <cor@roundcu.be>                                   |
  +-----------------------------------------------------------------------+
 */
@@ -30,12 +28,17 @@ class rcube_session_redis extends rcube_session {
 
     private $redis;
 
-    public function __construct()
+    /**
+     * @param Object $config
+     */
+    public function __construct($config)
     {
+        parent::__construct($config);
+
         // instantiate Redis object
         $this->redis = new Redis();
 
-        if (! $this->redis) {
+        if (!$this->redis) {
             rcube::raise_error(array('code' => 604, 'type' => 'session',
                                    'line' => __LINE__, 'file' => __FILE__,
                                    'message' => "Failed to find Redis. Make sure php-redis is included"),
@@ -43,10 +46,10 @@ class rcube_session_redis extends rcube_session {
         }
 
         // get config instance
-        $hosts = rcube::get_instance()->config->get('redis_hosts', array());
+        $hosts = $this->config->get('redis_hosts', array('localhost'));
 
         // host config is wrong
-        if (!is_array($hosts) || empty($hosts) ) {
+        if (!is_array($hosts) || empty($hosts)) {
             rcube::raise_error(array('code' => 604, 'type' => 'session',
                                    'line' => __LINE__, 'file' => __FILE__,
                                    'message' => "Redis host not configured"),
@@ -61,9 +64,9 @@ class rcube_session_redis extends rcube_session {
                                true, true);
         }
 
-        foreach($hosts as $config) {
+        foreach ($hosts as $host) {
             // explode individual fields
-            list($host, $port, $database, $password) = array_pad(explode(':', $config, 4), 4, null);
+            list($host, $port, $database, $password) = array_pad(explode(':', $host, 4), 4, null);
 
             // set default values if not set
             $host = ($host !== null) ? $host : '127.0.0.1';
@@ -115,7 +118,6 @@ class rcube_session_redis extends rcube_session {
 
         // register sessions handler
         $this->register_session_handler();
-
     }
 
     /**

--- a/program/lib/Roundcube/rcube_session_redis.php
+++ b/program/lib/Roundcube/rcube_session_redis.php
@@ -1,0 +1,210 @@
+<?php
+
+/*
+ +-----------------------------------------------------------------------+
+ | This file is part of the Roundcube Webmail client                     |
+ | Copyright (C) 2005-2014, The Roundcube Dev Team                       |
+ | Copyright (C) 2011, Kolab Systems AG                                  |
+ |                                                                       |
+ | Licensed under the GNU General Public License version 3 or            |
+ | any later version with exceptions for skins & plugins.                |
+ | See the README file for a full license statement.                     |
+ |                                                                       |
+ | PURPOSE:                                                              |
+ |   Provide database supported session management                       |
+ +-----------------------------------------------------------------------+
+ | Author: Thomas Bruederli <roundcube@gmail.com>                        |
+ | Author: Aleksander Machniak <alec@alec.pl>                            |
+ | Author: Cor Bosman <cor@roundcu.be>                                   |
+ +-----------------------------------------------------------------------+
+*/
+
+/**
+ * Class to provide redis session storage
+ *
+ * @package    Framework
+ * @subpackage Core
+ * @author     Cor Bosman <cor@roundcu.be>
+ */
+class rcube_session_redis extends rcube_session {
+
+    private $redis;
+
+    public function __construct()
+    {
+        // instantiate Redis object
+        $this->redis = new Redis();
+
+        if (! $this->redis) {
+            rcube::raise_error(array('code' => 604, 'type' => 'session',
+                                   'line' => __LINE__, 'file' => __FILE__,
+                                   'message' => "Failed to find Redis. Make sure php-redis is included"),
+                               true, true);
+        }
+
+        // get config instance
+        $hosts = rcube::get_instance()->config->get('redis_hosts', array());
+
+        // host config is wrong
+        if (!is_array($hosts) || empty($hosts) ) {
+            rcube::raise_error(array('code' => 604, 'type' => 'session',
+                                   'line' => __LINE__, 'file' => __FILE__,
+                                   'message' => "Redis host not configured"),
+                               true, true);
+        }
+
+        // only allow 1 host for now until we support clustering
+        if (count($hosts) > 1) {
+            rcube::raise_error(array('code' => 604, 'type' => 'session',
+                                   'line' => __LINE__, 'file' => __FILE__,
+                                   'message' => "Redis cluster not yet supported"),
+                               true, true);
+        }
+
+        foreach($hosts as $config) {
+            // explode individual fields
+            list($host, $port, $database, $password) = array_pad(explode(':', $config, 4), 4, null);
+
+            // set default values if not set
+            $host = ($host !== null) ? $host : '127.0.0.1';
+            $port = ($port !== null) ? $port : 6379;
+            $database = ($database !== null) ? $database : 0;
+
+            if ($this->redis->connect($host, $port) === false) {
+                rcube::raise_error(
+                    array(
+                        'code' => 604,
+                        'type' => 'session',
+                        'line' => __LINE__,
+                        'file' => __FILE__,
+                        'message' => "Could not connect to Redis server. Please check host and port"
+                    ),
+                    true,
+                    true
+                );
+            }
+
+            if ($password != null && $this->redis->auth($password) === false) {
+                rcube::raise_error(
+                    array(
+                        'code' => 604,
+                        'type' => 'session',
+                        'line' => __LINE__,
+                        'file' => __FILE__,
+                        'message' => "Could not authenticate with Redis server. Please check password."
+                    ),
+                    true,
+                    true
+                );
+            }
+
+            if ($database != 0 && $this->redis->select($database) === false) {
+                rcube::raise_error(
+                    array(
+                        'code' => 604,
+                        'type' => 'session',
+                        'line' => __LINE__,
+                        'file' => __FILE__,
+                        'message' => "Could not select Redis database. Please check database setting."
+                    ),
+                    true,
+                    true
+                );
+            }
+        }
+
+        // register sessions handler
+        $this->register_session_handler();
+
+    }
+
+    /**
+     * @param $save_path
+     * @param $session_name
+     * @return bool
+     */
+    public function open($save_path, $session_name)
+    {
+        return true;
+    }
+
+    /**
+     * @return bool
+     */
+    public function close()
+    {
+        return true;
+    }
+
+    /**
+     * remove data from store
+     *
+     * @param $key
+     * @return bool
+     */
+    public function destroy($key)
+    {
+        if ($key) {
+            $this->redis->del($key);
+        }
+
+        return true;
+    }
+
+
+    /**
+     * read data from redis store
+     *
+     * @param $key
+     * @return null
+     */
+    public function read($key)
+    {
+        if ($value = $this->redis->get($key)) {
+            $arr = unserialize($value);
+            $this->changed = $arr['changed'];
+            $this->ip      = $arr['ip'];
+            $this->vars    = $arr['vars'];
+            $this->key     = $key;
+
+            return !empty($this->vars) ? (string) $this->vars : '';
+        }
+
+        return null;
+    }
+
+
+    /**
+     * write data to redis store
+     *
+     * @param $key
+     * @param $newvars
+     * @param $oldvars
+     * @return bool
+     */
+    public function update($key, $newvars, $oldvars)
+    {
+        $ts = microtime(true);
+
+        if ($newvars !== $oldvars || $ts - $this->changed > $this->lifetime / 3) {
+            $this->redis->setex($key, $this->lifetime + 60, serialize(array('changed' => time(), 'ip' => $this->ip, 'vars' => $newvars)));
+        }
+
+        return true;
+    }
+
+
+    /**
+     * write data to redis store
+     *
+     * @param $key
+     * @param $vars
+     * @return bool
+     */
+    public function write($key, $vars)
+    {
+        return $this->redis->setex($key, $this->lifetime + 60, serialize(array('changed' => time(), 'ip' => $this->ip, 'vars' => $vars)));
+    }
+
+
+}

--- a/program/lib/Roundcube/rcube_session_redis.php
+++ b/program/lib/Roundcube/rcube_session_redis.php
@@ -4,14 +4,13 @@
  +-----------------------------------------------------------------------+
  | This file is part of the Roundcube Webmail client                     |
  | Copyright (C) 2005-2014, The Roundcube Dev Team                       |
- | Copyright (C) 2011, Kolab Systems AG                                  |
  |                                                                       |
  | Licensed under the GNU General Public License version 3 or            |
  | any later version with exceptions for skins & plugins.                |
  | See the README file for a full license statement.                     |
  |                                                                       |
  | PURPOSE:                                                              |
- |   Provide database supported session management                       |
+ |   Provide redis supported session management                       |
  +-----------------------------------------------------------------------+
  | Author: Cor Bosman <cor@roundcu.be>                                   |
  +-----------------------------------------------------------------------+


### PR DESCRIPTION
This is a rewrite of the rcube_session class. It introduces 3 new classes, rcube_session_db, rcube_session_memcache and rcube_session_native. 
- The native class is necessary to inherit functionality from the abstract class, and to make the code not have to go through all kinds of ugly hoops to exclude the native php sessions. These exceptions are now maintained in the native class.
- I had to move the plugin initialisation up in the execution order. Originally plugins were initialised after session_init, giving you the dummy plugin api class. Since I implemented a plugin hook for session storage, this had to be moved to before session_init. I am not sure if there are any large issues with this, but a brief check didnt seem to show any. 
- I made the write save handler a bit different from the rest. Some of it is handled in the abstract class. The original code had all kinds of calculations to see if a session should be written, or if we could use a cached version. I obviously wanted to keep that logic. But I belief some of that could be moved to the abstract class, making the implementation classes a little cleaner and allowing the abstract class to make some of these decisions.  But, i did leave some of it in the implementation class because the db and memcache implementations do things slightly different. I did not want to mess with those decision processes, so I left them in the implementation classes. Maybe sometime in the future we can unify these calculations and make the implementation classes cleaner. 
- I wrote a redis implementation plugin that can be found here: https://github.com/corbosman/roundcube_redis_session .  With your permission I would like to bring that into core with another PR once this has been (hopefully) approved. Redis is a much better choice as a session cache than memcache because of two reasons.
  1. memcache is not persistent. A restart of the memcache server will kill all your sessions. This makes updates of the memcache server software a huge pain.
  2. memcache can actually delete session on its own. It allows for key deletion whenever it feels like it really. This makes memcache not an ideal choice for sessions. 

Redis has none of these problems. 

I did quite a bit of testing to make sure everything works with all the implementation classes, but I can not rule out that I made a mistake. So please review carefully. 
