### PR TITLE
Plugin preload

### DIFF
--- a/program/include/rcmail.php
+++ b/program/include/rcmail.php
@@ -93,6 +93,10 @@ class rcmail extends rcube
             $this->filename = $basename;
         }
 
+        // load all configured plugins
+        $this->plugins->load_plugins((array)$this->config->get('plugins', array()),
+                                     array('filesystem_attachments', 'jqueryui'));
+
         // start session
         $this->session_init();
 
@@ -124,10 +128,8 @@ class rcmail extends rcube
             $GLOBALS['OUTPUT'] = $this->load_gui(!empty($_REQUEST['_framed']));
         }
 
-        // load plugins
+        // run init method on all the plugins
         $this->plugins->init($this, $this->task);
-        $this->plugins->load_plugins((array)$this->config->get('plugins', array()),
-            array('filesystem_attachments', 'jqueryui'));
     }
 
     /**


### PR DESCRIPTION
I think this may be a solution for allowing plugins to load before sessions.

Ive introduced an rcube_plugins variable name $preload, which tells the plugin code to load this plugin early. Default is false, and then it gets loaded as it is now. If you set $preload in your plugin, you accept that all kinds of variables are not yet initialised, including $task and $app->output. 

I also had to account for $force, so ive also introduced a variable named $initialised, which tells the second phase of plugin init which plugins were already initialised in round 1. 

I think my logic with regards to noajax/noframe etc is ok, but please check. 

This PR would replace PR roundcube/roundcubemail#125

Since I need this code in my PR roundcube/roundcubemail#257 please let me know if you prefer this PR separate or if I should add it there since it's kind of related. 
