### PR TITLE
use one line default configuration stub in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN pear install mail_mime mail_mimedecode net_smtp2-beta net_idna2-beta auth_sa
 RUN rm -rf /var/www
 ADD . /var/www
 
-RUN echo -e '<?php\n$config = array();\n' > /var/www/config/config.inc.php
+RUN echo '<?php $config = array();' > /var/www/config/config.inc.php
 RUN rm -rf /var/www/installer
 
 RUN . /etc/apache2/envvars && chown -R ${APACHE_RUN_USER}:${APACHE_RUN_GROUP} /var/www/temp /var/www/logs


### PR DESCRIPTION
Docker doesn't process the -e option on echo properly and mangles the
default configuration file resulting in a white screen when running
roundcube.
