### PR TITLE
modify pear dependency net_smtp2 to net_smtp in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN a2enmod headers
 RUN a2enmod ssl
 
 RUN apt-get install -qq php5 php-pear php5-mysql php5-pgsql php5-sqlite
-RUN pear install mail_mime mail_mimedecode net_smtp2-beta net_idna2-beta auth_sasl2-beta net_sieve crypt_gpg
+RUN pear install mail_mime mail_mimedecode net_smtp net_idna2-beta auth_sasl net_sieve crypt_gpg
 
 RUN rm -rf /var/www
 ADD . /var/www


### PR DESCRIPTION
Currently installing `Net_SMTP2` results with the following error:

``` bash
[09-Jan-2015 21:15:14 UTC] PHP Fatal error:  Class 'Net_SMTP' not found in /var/www/program/lib/Roundcube/rcube_smtp.php on line 111
```

Switching back to Net_SMTP fixes this issue
