### PR TITLE
Explicitly deny access to newly created "Dockerfile"

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -34,7 +34,7 @@ RewriteRule ^(?!installer|[a-f0-9]{16})(\.?[^\.]+)$ - [F]
 # - deny access to some locations
 RewriteRule ^/?(\.git|\.tx|SQL|bin|config|logs|temp|tests|program\/(include|lib|localization|steps)) - [F]
 # - deny access to some documentation files
-RewriteRule /?(README\.md|composer\.json-dist|composer\.json|package\.xml)$ - [F]
+RewriteRule /?(README\.md|composer\.json-dist|composer\.json|package\.xml|Dockerfile)$ - [F]
 </IfModule>
 
 <IfModule mod_deflate.c>


### PR DESCRIPTION
It should be denied anyways by another rule in .htacces,
but i think it is worth adding it anyways.

```
# - deny access to files not containing a dot or starting with a dot
#   in all locations except installer directory
RewriteRule ^(?!installer|[a-f0-9]{16})(\.?[^\.]+)$ - [F]
```
