### PR TITLE
Fix smart column display in rcmail_js_message_list().

### DIFF
--- a/program/steps/mail/func.inc
+++ b/program/steps/mail/func.inc
@@ -399,6 +399,11 @@ function rcmail_js_message_list($a_headers, $insert_top=false, $a_show_cols=null
         $head_replace = true;
     }
 
+    // get name of smart From/To column in folder context
+    if (array_search('fromto', $a_show_cols) !== false) {
+        $smart_col = rcmail_message_list_smart_column_name();
+    }
+
     $search_set  = $RCMAIL->storage->get_search_set();
     $multifolder = $search_set && $search_set[1]->multi;
 
@@ -433,11 +438,6 @@ function rcmail_js_message_list($a_headers, $insert_top=false, $a_show_cols=null
     $a_headers   = $plugin['messages'];
 
     $thead = $head_replace ? rcmail_message_list_head($_SESSION['list_attrib'], $a_show_cols) : NULL;
-
-    // get name of smart From/To column in folder context
-    if (array_search('fromto', $a_show_cols) !== false) {
-        $smart_col = rcmail_message_list_smart_column_name();
-    }
 
     $OUTPUT->command('set_message_coltypes', $a_show_cols, $thead, $smart_col);
 


### PR DESCRIPTION
This fixes an issue where the Sent folder will show the From address in
the 'fromto' column rather than, as it should, the To address. This
appears to be because the call to
rcmail_message_list_smart_column_name() is made after the folder context
has been overridden, thus getting the wrong folder name and making a
wrong decision about the contents of 'fromto'.

This patch moves the call to rcmail_message_list_smart_column_name() to
be earlier in the rcmail_js_message_list() function and seems to have
fixed the issue for me.

This issue was experienced on the Roundcubemail packages distributed by
the Kolab 3.3 repository (both the recently released 1.1 and the version
prior to that). The fix is also tested against that version.

Signed-off-by: Toke Høiland-Jørgensen toke@toke.dk
