### PR TITLE
Use 'skins' rather than 'themes' for the sake of consistency

### DIFF
--- a/plugins/jqueryui/README
+++ b/plugins/jqueryui/README
@@ -24,7 +24,7 @@ Some jquery-ui modules provide localization. One example is the datepicker modul
 If you want to load localization for a specific module, then set up config.inc.php.
 Check the config.inc.php.dist file on how to set this up for the datepicker module.
 
-As of version 1.8.6 this plugin also supports other themes. If you're a theme
+As of version 1.8.6 this plugin also supports other skins. If you're a theme
 developer and would like a different default theme to be used for your RC theme
 then let me know and we can set things up.
 

--- a/plugins/jqueryui/config.inc.php.dist
+++ b/plugins/jqueryui/config.inc.php.dist
@@ -3,7 +3,7 @@
 // if you want to load localization strings for specific sub-libraries of jquery-ui, configure them here 
 $config['jquery_ui_i18n'] = array('datepicker');
 
-// map Roundcube skins with jquery-ui themes here
+// map Roundcube skins with jquery-ui skins here
 $config['jquery_ui_skin_map'] = array(
   'larry' => 'larry',
   'default' => 'larry',

--- a/plugins/jqueryui/jqueryui.php
+++ b/plugins/jqueryui/jqueryui.php
@@ -3,7 +3,7 @@
 /**
  * jQuery UI
  *
- * Provide the jQuery UI library with according themes.
+ * Provide the jQuery UI library with according skins.
  *
  * @version 1.10.4
  * @author Cor Bosman <roundcube@wa.ter.net>
@@ -33,11 +33,11 @@ class jqueryui extends rcube_plugin
 
         self::$ui_theme = $ui_theme;
 
-        if (file_exists($this->home . "/themes/$ui_theme/jquery-ui-$this->version.custom.css")) {
-            $this->include_stylesheet("themes/$ui_theme/jquery-ui-$this->version.custom.css");
+        if (file_exists($this->home . "/skins/$ui_theme/jquery-ui-$this->version.custom.css")) {
+            $this->include_stylesheet("skins/$ui_theme/jquery-ui-$this->version.custom.css");
         }
         else {
-            $this->include_stylesheet("themes/larry/jquery-ui-$this->version.custom.css");
+            $this->include_stylesheet("skins/larry/jquery-ui-$this->version.custom.css");
         }
 
         if ($ui_theme == 'larry') {
@@ -96,10 +96,10 @@ class jqueryui extends rcube_plugin
         $ui_theme = self::$ui_theme;
         $rcube    = rcube::get_instance();
         $script   = 'plugins/jqueryui/js/jquery.miniColors.min.js';
-        $css      = "plugins/jqueryui/themes/$ui_theme/jquery.miniColors.css";
+        $css      = "plugins/jqueryui/skins/$ui_theme/jquery.miniColors.css";
 
         if (!file_exists(INSTALL_PATH . $css)) {
-            $css = "plugins/jqueryui/themes/larry/jquery.miniColors.css";
+            $css = "plugins/jqueryui/skins/larry/jquery.miniColors.css";
         }
 
         $rcube->output->include_css($css);
@@ -119,10 +119,10 @@ class jqueryui extends rcube_plugin
         $script   = 'plugins/jqueryui/js/jquery.tagedit.js';
         $rcube    = rcube::get_instance();
         $ui_theme = self::$ui_theme;
-        $css      = "plugins/jqueryui/themes/$ui_theme/tagedit.css";
+        $css      = "plugins/jqueryui/skins/$ui_theme/tagedit.css";
 
         if (!file_exists(INSTALL_PATH . $css)) {
-            $css = "plugins/jqueryui/themes/larry/tagedit.css";
+            $css = "plugins/jqueryui/skins/larry/tagedit.css";
         }
 
         $rcube->output->include_css($css);


### PR DESCRIPTION
The paths used by the jqueryui plugin are fixed with 'themes' rather than 'skins', whereas the rest of roundcubemail consistently refers to its 'skins' as 'skins' not 'themes'.
