### PR TITLE
Strikethrough disabled sieve filters

### DIFF
--- a/plugins/managesieve/skins/classic/managesieve.css
+++ b/plugins/managesieve/skins/classic/managesieve.css
@@ -54,6 +54,7 @@
 #filtersetslist tbody tr.disabled td
 {
   color: #999999;
+	text-decoration: line-through;
 }
 
 #filtersetslist tbody td

--- a/plugins/managesieve/skins/larry/managesieve.css
+++ b/plugins/managesieve/skins/larry/managesieve.css
@@ -58,6 +58,7 @@
 #filtersetslist tbody tr.disabled td
 {
   color: #87A3AA;
+	text-decoration: line-through;
 }
 
 #filtersetslist tbody td


### PR DESCRIPTION
On cheap lcd monitors color differences may not be enough. With strikethrough names are disabled sieve rules easy distinguishable.

![sieve](https://cloud.githubusercontent.com/assets/545514/6972091/a34afc06-d981-11e4-93ad-ed100e4796d2.png)
