### PR TITLE
Fix thumbnail generation when current working directory and install directory differ

### DIFF
--- a/program/steps/mail/get.inc
+++ b/program/steps/mail/get.inc
@@ -81,7 +81,7 @@ else if ($_GET['_thumb']) {
         list(,$ext)     = explode('/', $part->mimetype);
         $mimetype       = $part->mimetype;
         $file_ident     = $MESSAGE->headers->messageID . ':' . $part->mime_id . ':' . $part->size . ':' . $part->mimetype;
-        $cache_basename = $temp_dir . '/' . md5($file_ident . ':' . $RCMAIL->user->ID . ':' . $thumbnail_size);
+        $cache_basename = INSTALL_PATH . '/' . $temp_dir . '/' . md5($file_ident . ':' . $RCMAIL->user->ID . ':' . $thumbnail_size);
         $cache_file     = $cache_basename . '.' . $ext;
 
         // render thumbnail image if not done yet


### PR DESCRIPTION
In Debian, the document root for the HTTPD server is `/var/lib/roundcube` and
the source code folders in there are symbolic links to the actual source code
files in `/usr/share/roundcube`.

```
# ls -l /var/lib/roundcube
total 16
drwxr-xr-x 2 root     root     4096 Mar 31 23:27 config
lrwxrwxrwx 1 root     root       30 Nov  3  2013 index.php -> /usr/share/roundcube/index.php
lrwxrwxrwx 1 root     root       19 Nov  3  2013 logs -> ../../log/roundcube
drwxr-xr-x 2 root     root     4096 Mar 31 23:27 plugins
lrwxrwxrwx 1 root     root       28 Nov  3  2013 program -> /usr/share/roundcube/program
lrwxrwxrwx 1 root     root       31 Nov  3  2013 robots.txt -> /usr/share/roundcube/robots.txt
drwxr-xr-x 2 root     root     4096 Mar 31 23:27 skins
drwxr-x--- 2 www-data www-data 4096 Apr  5 11:47 temp
```

Therefore the current directory is `/usr/share/roundcube` causing thumbnail
generation to fail with a permission error as the directory for temporary files
is being looked for in `/usr/share/roundcube/temp` instead of
`/var/lib/roundcube/temp`.

```
[error] [client x.x.x.x] PHP Warning:  fopen(/40c94193478cd7a5437dd17dc6ad2986.orig.jpeg): failed to open stream: Permission denied in /usr/share/roundcube/program/steps/mail/get.inc on line 72, referer: http://rc.example.net/?_task=mail&_action=show&_uid=1375&_mbox=INBOX&_search=fde40107839e036c853312d9499f3816&_caps=pdf%3D0%2Cflash%3D1%2Ctif%3D1
```

Fix this by using the temporary directory in the installation path stored in
the variable `INSTALL_PATH`.
