### PR TITLE
plugins/password: Add config option for password schemes to SQL driver

### DIFF
--- a/plugins/password/config.inc.php.dist
+++ b/plugins/password/config.inc.php.dist
@@ -72,6 +72,9 @@ $config['password_query'] = 'SELECT update_passwd(%c, %u)';
 // your operating system supports the other hash functions.
 $config['password_crypt_hash'] = 'md5';
 
+// Enables use of password with crypt method prefix in %D, e.g. {MD5}$1$LUiMYWqx$fEkg/ggr/L6Mb2X7be4i1/
+$config['password_with_scheme'] = false;
+
 // By default domains in variables are using unicode.
 // Enable this option to use punycoded names
 $config['password_idn_ascii'] = false;

--- a/plugins/password/drivers/sql.php
+++ b/plugins/password/drivers/sql.php
@@ -61,23 +61,28 @@ class rcube_sql_password
             case 'md5':
                 $len = 8;
                 $salt_hashindicator = '$1$';
+                $password_scheme = 'MD5'
                 break;
             case 'des':
                 $len = 2;
+                $password_scheme = 'LANMAN'
                 break;
             case 'blowfish':
                 $cost = (int) $rcmail->config->get('password_blowfish_cost');
                 $cost = $cost < 4 || $cost > 31 ? 12 : $cost;
                 $len  = 22;
                 $salt_hashindicator = sprintf('$2a$%02d$', $cost);
+                $password_scheme = 'BLF-CRYPT';
                 break;
             case 'sha256':
                 $len = 16;
                 $salt_hashindicator = '$5$';
+                $password_scheme = 'SHA256-CRYPT'
                 break;
             case 'sha512':
                 $len = 16;
                 $salt_hashindicator = '$6$';
+                $password_scheme = 'SHA512-CRYPT';
                 break;
             default:
                 return PASSWORD_CRYPT_ERROR;
@@ -89,7 +94,12 @@ class rcube_sql_password
                 $salt .= $seedchars[rand(0, 63)];
             }
 
-            $sql = str_replace('%c',  $db->quote(crypt($passwd, $salt_hashindicator ? $salt_hashindicator .$salt.'$' : $salt)), $sql);
+            if $rcmail->config->get('password_scheme')
+                $password_scheme = '{' . $password_scheme . '}'
+            else
+                $password_scheme = ''
+
+            $sql = str_replace('%c',  $db->quote($password_scheme . crypt($passwd, $salt_hashindicator ? $salt_hashindicator .$salt.'$' : $salt)), $sql);
         }
 
         // dovecotpw


### PR DESCRIPTION
Often the password scheme is prepended to the hash. Dovecot is doing
that and the VirtualMailManager (VMM).

Add a boolean option to enable prepending the scheme.

The `doveadm pw` cannot be used, especially if Roundcube is not
installed on the mail server. Actually `password_dovecotpw_with_method`
could be renamed, if that is allowed.
