### PR TITLE
Don't let PHP log E_DEPRECATED errors.

### DIFF
--- a/program/lib/Roundcube/bootstrap.php
+++ b/program/lib/Roundcube/bootstrap.php
@@ -26,7 +26,7 @@
  */
 
 $config = array(
-    'error_reporting'         => E_ALL & ~E_NOTICE & ~E_STRICT,
+    'error_reporting'         => E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED,
     // Some users are not using Installer, so we'll check some
     // critical PHP settings here. Only these, which doesn't provide
     // an error/warning in the logs later. See (#1486307).


### PR DESCRIPTION
Net_Smtp is spamming the error log with entires like these:

```
[10-Apr-2015 10:51:02 Europe/Berlin] PHP Deprecated:  Non-static method PEAR::isError() should not be called statically, assuming $this from incompatible context in /var/www/webmailer/roundcube/vendor/pear/net_smtp/Net/SMTP.php on line 263
[10-Apr-2015 10:51:02 Europe/Berlin] PHP Deprecated:  Non-static method PEAR::isError() should not be called statically, assuming $this from incompatible context in /var/www/webmailer/roundcube/vendor/pear/net_smtp/Net/SMTP.php on line 1117
[10-Apr-2015 10:51:02 Europe/Berlin] PHP Deprecated:  Non-static method PEAR::isError() should not be called statically, assuming $this from incompatible context in /var/www/webmailer/roundcube/vendor/pear/net_smtp/Net/SMTP.php on line 263
[10-Apr-2015 10:51:02 Europe/Berlin] PHP Deprecated:  Non-static method PEAR::isError() should not be called statically, assuming $this from incompatible context in /var/www/webmailer/roundcube/vendor/pear/net_smtp/Net/SMTP.php on line 1127
[10-Apr-2015 10:51:02 Europe/Berlin] PHP Deprecated:  Non-static method PEAR::isError() should not be called statically, assuming $this from incompatible context in /var/www/webmailer/roundcube/vendor/pear/net_smtp/Net/SMTP.php on line 263
[10-Apr-2015 10:51:02 Europe/Berlin] PHP Deprecated:  Non-static method PEAR::isError() should not be called statically, assuming $this from incompatible context in /var/www/webmailer/roundcube/vendor/pear/net_smtp/Net/SMTP.php on line 1132
[10-Apr-2015 10:51:04 Europe/Berlin] PHP Deprecated:  Non-static method PEAR::isError() should not be called statically, assuming $this from incompatible context in /var/www/webmailer/roundcube/vendor/pear/net_smtp/Net/SMTP.php on line 489
[10-Apr-2015 10:51:04 Europe/Berlin] PHP Deprecated:  Non-static method PEAR::isError() should not be called statically, assuming $this from incompatible context in /var/www/webmailer/roundcube/vendor/pear/net_smtp/Net/SMTP.php on line 263
[10-Apr-2015 10:51:04 Europe/Berlin] PHP Deprecated:  Non-static method PEAR::isError() should not be called statically, assuming $this from incompatible context in /var/www/webmailer/roundcube/vendor/pear/net_smtp/Net/SMTP.php on line 492
[10-Apr-2015 10:51:04 Europe/Berlin] PHP Deprecated:  Non-static method PEAR::isError() should not be called statically, assuming $this from incompatible context in /var/www/webmailer/roundcube/vendor/pear/net_smtp/Net/SMTP.php on line 495
```

To prevent that, E_DEPRECATED errors should be disabled.

As an aside, it would be great if this could somehow be configured.
