### PR TITLE
remove debug test code

### DIFF
--- a/program/steps/addressbook/print.inc
+++ b/program/steps/addressbook/print.inc
@@ -97,7 +97,7 @@ function rcmail_contact_details($attrib)
                 'address'      => array(),
                 'website'      => array(),
                 'im'           => array(),
-                'groups' => array('value' => 'sdfsdfs', 'label' => $RCMAIL->gettext('groups')),
+                'groups'       => array(),
             ),
         ),
         'personal' => array(


### PR DESCRIPTION
found an obsolete test group that shows up when printing a user from a ldap directory entry.

Group: sdfsdfs
