### PR TITLE
Update Dockerfile for debian:8.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:latest
+FROM debian:8.0
 MAINTAINER Alex Brandt <alunduil@alunduil.com>
 
 EXPOSE 80 443
@@ -6,11 +6,11 @@ EXPOSE 80 443
 RUN apt-get -qq update
 RUN apt-get install -qq apache2-mpm-event
 
-RUN sed -e 's|/var/www|&/public_html|' -e 's/\(Log \+\)[^ ]\+/\1"|cat"/' -i /etc/apache2/sites-available/default 
-RUN a2ensite default
+RUN sed -e 's|/var/www|&/public_html|' -e 's/\(Log \+\)[^ ]\+/\1"|cat"/' -i /etc/apache2/sites-available/000-default.conf
+RUN a2ensite 000-default
 
-RUN sed -e 's|/var/www|&/public_html|' -e 's/\(Log \+\)[^ ]\+/\1"|cat"/' -i /etc/apache2/sites-available/default-ssl
-RUN sed -e '/SSLCertificateKeyFile/s|ssl-cert-snakeoil.key|ssl-cert.key|' -e '/SSLCertificateFile/s|ssl-cert-snakeoil.pem|ssl-cert.pem|' -i /etc/apache2/sites-available/default-ssl
+RUN sed -e 's|/var/www|&/public_html|' -e 's/\(Log \+\)[^ ]\+/\1"|cat"/' -i /etc/apache2/sites-available/default-ssl.conf
+RUN sed -e '/SSLCertificateKeyFile/s|ssl-cert-snakeoil.key|ssl-cert.key|' -e '/SSLCertificateFile/s|ssl-cert-snakeoil.pem|ssl-cert.pem|' -i /etc/apache2/sites-available/default-ssl.conf
 RUN ln -snf ssl-cert-snakeoil.pem /etc/ssl/certs/ssl-cert.pem
 RUN ln -snf ssl-cert-snakeoil.key /etc/ssl/private/ssl-cert.key
 RUN a2ensite default-ssl


### PR DESCRIPTION
The latest import for the Dockerfile began having failures due to apache
configuration changes in debian.  This update fixes those failures and
pins the base debian image to avoid these issues until we need to update
debian itself.
