### PR TITLE
Major fix of dependencies: Make sure the PEAR packages are taken from pear.php.net

### DIFF
--- a/composer.json-dist
+++ b/composer.json-dist
@@ -31,9 +31,9 @@
     "require": {
         "php": ">=5.3.7",
         "roundcube/plugin-installer": ">=0.1.5",
-        "pear/mail_mime": ">=1.8.9",
-        "pear/mail_mime-decode": "~1.5.5",
-        "pear/net_smtp": "dev-master",
+        "pear-pear.php.net/mail_mime": ">=1.8.9",
+        "pear-pear.php.net/mail_mimedecode": "~1.5.5",
+        "Net_SMTP": "dev-master",
         "pear-pear.php.net/auth_sasl": ">=1.0.6",
         "pear-pear.php.net/net_idna2": ">=0.1.1",
         "pear-pear.php.net/net_sieve": ">=1.3.2",


### PR DESCRIPTION
By not explicitly add pear.php.net as channelName [1] for PEAR packages
composer is looking in the packagist.org repository for a match.
If someone already registered his package with the same name, the wrong
dependency is taken.

This actually happen in the latest 1.1.2 release. The dependency 'pear/mail_mime' is resolved from packagist.org [2] and ships 'dev-master' instead of the package from pear.php.net [3].

This is a major security issue. If someone registers 'pear/xyz' on packagist.org it can control the source that Roundcube is shipping in a new release.

My assumption is easy to test:

```
git clone https://github.com/roundcube/roundcubemail.git
cp composer.json-dist composer.json
composer install --no-dev
composer show --installed|fgrep pear
```

Please consider a new release of the 1.1. 1.0 may be affected as well. Not confirmed.

[1] https://getcomposer.org/doc/05-repositories.md#pear
[2] https://packagist.org/packages/pear/mail_mime
[3] http://pear.php.net/package/Mail_Mime
