### PR TITLE
full path to cat needs to specified in order for this to work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,10 @@ EXPOSE 80 443
 RUN apt-get -qq update
 RUN apt-get install -qq apache2-mpm-event
 
-RUN sed -e 's|/var/www|&/public_html|' -e 's/\(Log \+\)[^ ]\+/\1"|cat"/' -i /etc/apache2/sites-available/000-default.conf
+RUN sed -e 's|/var/www|&/public_html|' -e 's/\(Log \+\)[^ ]\+/\1"|/bin/cat"/' -i /etc/apache2/sites-available/000-default.conf
 RUN a2ensite 000-default
 
-RUN sed -e 's|/var/www|&/public_html|' -e 's/\(Log \+\)[^ ]\+/\1"|cat"/' -i /etc/apache2/sites-available/default-ssl.conf
+RUN sed -e 's|/var/www|&/public_html|' -e 's/\(Log \+\)[^ ]\+/\1"|/bin/cat"/' -i /etc/apache2/sites-available/default-ssl.conf
 RUN sed -e '/SSLCertificateKeyFile/s|ssl-cert-snakeoil.key|ssl-cert.key|' -e '/SSLCertificateFile/s|ssl-cert-snakeoil.pem|ssl-cert.pem|' -i /etc/apache2/sites-available/default-ssl.conf
 RUN ln -snf ssl-cert-snakeoil.pem /etc/ssl/certs/ssl-cert.pem
 RUN ln -snf ssl-cert-snakeoil.key /etc/ssl/private/ssl-cert.key


### PR DESCRIPTION
Running the container with the default site settings will fail because apache can't find the path to `cat`.  Here we specify it explicitly
