### PR TITLE
use alternate separator in sed statement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,10 @@ EXPOSE 80 443
 RUN apt-get -qq update
 RUN apt-get install -qq apache2-mpm-event
 
-RUN sed -e 's|/var/www/html|/var/www/public_html|' -e 's/\(Log \+\)[^ ]\+/\1"|/bin/cat"/' -i /etc/apache2/sites-available/000-default.conf
+RUN sed -e 's|/var/www/html|/var/www/public_html|' -e 's@\(Log \+\)[^ ]\+@\1"|/bin/cat"@' -i /etc/apache2/sites-available/000-default.conf
 RUN a2ensite 000-default
 
-RUN sed -e 's|/var/www/html|/var/www/public_html|' -e 's/\(Log \+\)[^ ]\+/\1"|/bin/cat"/' -i /etc/apache2/sites-available/default-ssl.conf
+RUN sed -e 's|/var/www/html|/var/www/public_html|' -e 's@\(Log \+\)[^ ]\+@\1"|/bin/cat"@' -i /etc/apache2/sites-available/default-ssl.conf
 RUN sed -e '/SSLCertificateKeyFile/s|ssl-cert-snakeoil.key|ssl-cert.key|' -e '/SSLCertificateFile/s|ssl-cert-snakeoil.pem|ssl-cert.pem|' -i /etc/apache2/sites-available/default-ssl.conf
 RUN ln -snf ssl-cert-snakeoil.pem /etc/ssl/certs/ssl-cert.pem
 RUN ln -snf ssl-cert-snakeoil.key /etc/ssl/private/ssl-cert.key


### PR DESCRIPTION
hub had a problem with the quotes in the sed expression so rather than
worry about it, I've dropped the problem completely.  The double quotes
don't mask the slash in the path for cat.  Thus, using a different
separator removes the problem of a truncated expression.
