### PR TITLE
Fix wash_style() to accept style declarations with new lines.

### DIFF
--- a/program/lib/Roundcube/rcube_washtml.php
+++ b/program/lib/Roundcube/rcube_washtml.php
@@ -175,7 +175,7 @@ class rcube_washtml
         $result = array();
 
         foreach (explode(';', $style) as $declaration) {
-            if (preg_match('/^\s*([a-z\-]+)\s*:\s*(.*)\s*$/i', $declaration, $match)) {
+            if (preg_match('/^\s*([a-z\-]+)\s*:\s*(.*)\s*$/is', $declaration, $match)) {
                 $cssid = $match[1];
                 $str   = $match[2];
                 $value = '';


### PR DESCRIPTION
Some(?) email clients wrap long lines in HTML messages. With some _bad luck_, the wrapping occurs in the middle of a style declaration. This is an example of a style declaration after wrapping:

``` html
  (...)<div style="padding: 0px
            20px;border:1px solid #000;">(...)
```

With the `s` modifier in `preg_match()`, the dot `.` in the regular expression accepts the `\n` and the style declaration remains correct.
