### PR TITLE
Emptying the display name when the display name is the main e-mail ad…

### DIFF
--- a/program/lib/Roundcube/rcube_vcard.php
+++ b/program/lib/Roundcube/rcube_vcard.php
@@ -123,11 +123,6 @@ class rcube_vcard
             $this->raw = self::charset_convert($this->raw, $detected_charset);
         }
 
-        // consider FN empty if the same as the primary e-mail address
-        if ($this->raw['FN'][0][0] == $this->raw['EMAIL'][0][0]) {
-            $this->raw['FN'][0][0] = '';
-        }
-
         // find well-known address fields
         $this->displayname  = $this->raw['FN'][0][0];
         $this->surname      = $this->raw['N'][0][0];


### PR DESCRIPTION
Emptying the display name when the display name is the main e-mail address contradicts lines 731 till 734.

The comment on line 731 states:

> make sure FN is not empty (required by RFC2426)
