### PR TITLE
Fix group creation to work with Net_LDAP3.

### DIFF
--- a/program/lib/Roundcube/rcube_ldap.php
+++ b/program/lib/Roundcube/rcube_ldap.php
@@ -1947,7 +1947,7 @@ class rcube_ldap extends rcube_addressbook
         $new_entry   = array(
             'objectClass' => $this->prop['groups']['object_classes'],
             $name_attr    => $group_name,
-            $member_attr  => '',
+            $member_attr  => array(''),
         );
 
         if (!$this->ldap->add_entry($new_dn, $new_entry)) {


### PR DESCRIPTION
Net_LDAP3::add_entry does not pass empty attributes to ldap_add, thus
let's replace an empty attribute with a non-empty array containing
an empty string as that is supported by ldap_add, too.
