### PR TITLE
Add $config['password_crypt_rounds']

### DIFF
--- a/plugins/password/config.inc.php.dist
+++ b/plugins/password/config.inc.php.dist
@@ -61,6 +61,12 @@ $config['password_dovecotpw_method'] = 'CRAM-MD5';
 // Be aware, the higher the value, the longer it takes to generate the password hashes.
 $config['password_blowfish_cost'] = 12;
 
+// Number of rounds for the sha256 and sha512 crypt hashing algorithms.
+// Must be at least 1000. If not set, then the number of rounds is left up
+// to the crypt() implementation. On glibc this defaults to 5000.
+// Be aware, the higher the value, the longer it takes to generate the password hashes.
+//$config['password_crypt_rounds'] = 50000;
+
 // This option temporarily disables the password change functionality.
 // Use it when the users database server is in maintenance mode or sth like that.
 // You can set it to TRUE/FALSE or a text describing the reason

--- a/plugins/password/password.php
+++ b/plugins/password/password.php
@@ -439,12 +439,22 @@ class password extends rcube_plugin
             break;
 
         case 'sha256-crypt':
-            $crypted = crypt($password, '$5$' . self::random_salt(16));
+            $rounds = (int) $rcmail->config->get('password_crypt_rounds');
+            if ($rounds < 1000)
+                $prefix = '$5$';
+            else
+                $prefix = '$5$rounds=' . $rounds . '$';
+            $crypted = crypt($password, $prefix . self::random_salt(16));
             $prefix  = '{CRYPT}';
             break;
 
         case 'sha512-crypt':
-            $crypted = crypt($password, '$6$' . self::random_salt(16));
+            $rounds = (int) $rcmail->config->get('password_crypt_rounds');
+            if ($rounds < 1000)
+                $prefix = '$6$';
+            else
+                $prefix = '$6$rounds=' . $rounds . '$';
+            $crypted = crypt($password, $prefix . self::random_salt(16));
             $prefix  = '{CRYPT}';
             break;
 


### PR DESCRIPTION
This patch adds the ability to specify the number of rounds for the sha256 and sha512 crypt hashing algorithms. It works similar to the existing password_blowfish_cost option: it allows you to increase the necessary cost/time for a brute force attack.
