### PR TITLE
Update spellcheck regex to ignore URIs, emails, and additional quote char

### DIFF
--- a/program/lib/Roundcube/rcube_spellcheck_engine.php
+++ b/program/lib/Roundcube/rcube_spellcheck_engine.php
@@ -31,7 +31,7 @@ abstract class rcube_spellcheck_engine
     protected $lang;
     protected $error;
     protected $dictionary;
-    protected $separator = '/\w+:\/\/\S*|[\s\r\n\t\(\)\/\[\]{}<>\\"`]+|[:;?!,\.](?=\W|$)/';
+    protected $separator = '/\w+:\/\/\?S*|[\s\r\n\t\(\)\/\[\]{}<>\\"`]+|[:;?!,\.](?=\W|$)/';
 
     /**
      * Default constructor

--- a/program/lib/Roundcube/rcube_spellcheck_engine.php
+++ b/program/lib/Roundcube/rcube_spellcheck_engine.php
@@ -31,7 +31,7 @@ abstract class rcube_spellcheck_engine
     protected $lang;
     protected $error;
     protected $dictionary;
-    protected $separator = '/[\s\r\n\t\(\)\/\[\]{}<>\\"]+|[:;?!,\.](?=\W|$)/';
+    protected $separator = '/\w+:\/\/\S*|[\s\r\n\t\(\)\/\[\]{}<>\\"`]+|[:;?!,\.](?=\W|$)/';
 
     /**
      * Default constructor

--- a/program/lib/Roundcube/rcube_spellcheck_engine.php
+++ b/program/lib/Roundcube/rcube_spellcheck_engine.php
@@ -31,7 +31,7 @@ abstract class rcube_spellcheck_engine
     protected $lang;
     protected $error;
     protected $dictionary;
-    protected $separator = '/\w+:\/\/\?S*|[\s\r\n\t\(\)\/\[\]{}<>\\"`]+|[:;?!,\.](?=\W|$)/';
+    protected $separator = '/\w+@\w+\.\w+|\w+:\/\/\?S*|[\s\r\n\t\(\)\/\[\]{}<>\\"`]+|[:;?!,\.](?=\W|$)/';
 
     /**
      * Default constructor

--- a/program/lib/Roundcube/rcube_spellcheck_engine.php
+++ b/program/lib/Roundcube/rcube_spellcheck_engine.php
@@ -31,7 +31,7 @@ abstract class rcube_spellcheck_engine
     protected $lang;
     protected $error;
     protected $dictionary;
-    protected $separator = '/\w+@\w+\.\w+|\w+:\/\/\?S*|[\s\r\n\t\(\)\/\[\]{}<>\\"`]+|[:;?!,\.](?=\W|$)/';
+    protected $separator = '/\w+@\w+\.\w+|\w+:\/\/?\w+\.\w+|[\s\r\n\t\(\)\/\[\]{}<>\\"`]+|[:;?!,\.](?=\W|$)/';
 
     /**
      * Default constructor


### PR DESCRIPTION
Hello,

Customers that utilize the spellcheck have been complaining that URIs and emails are not properly handled with the spellcheck function (as well as the ` char). 

This patch modifies the `$seperator` regex to treat URIs and Emails the same way as any other separator char. This allows for filtering of everything without the need to modify downstream code.

Suggestions of better ways to accomplish this are welcome, I am new to this community and don't know whether this was intended or not.
