### PR TITLE
Filter quoted reply text from spellcheck $text

### DIFF
--- a/program/lib/Roundcube/rcube_spellcheck_enchant.php
+++ b/program/lib/Roundcube/rcube_spellcheck_enchant.php
@@ -82,7 +82,10 @@ class rcube_spellcheck_enchant extends rcube_spellcheck_engine
         if (!$this->enchant_dictionary) {
             return array();
         }
-
+        
+        // get rid of quoted reply text
+        $text = $this->remove_quoted_reply($text);
+        
         // tokenize
         $text = preg_split($this->separator, $text, NULL, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_OFFSET_CAPTURE);
 

--- a/program/lib/Roundcube/rcube_spellcheck_engine.php
+++ b/program/lib/Roundcube/rcube_spellcheck_engine.php
@@ -31,7 +31,7 @@ abstract class rcube_spellcheck_engine
     protected $lang;
     protected $error;
     protected $dictionary;
-    protected $separator = '/[\s\r\n\t\(\)\/\[\]{}<>\\"]+|[:;?!,\.](?=\W|$)/';
+    protected $separator = '/\w+:\/\/\S*|[\s\r\n\t\(\)\/\[\]{}<>\\"`]+|[:;?!,\.](?=\W|$)/';
 
     /**
      * Default constructor

--- a/program/lib/Roundcube/rcube_spellcheck_engine.php
+++ b/program/lib/Roundcube/rcube_spellcheck_engine.php
@@ -41,6 +41,15 @@ abstract class rcube_spellcheck_engine
         $this->dictionary = $dict;
         $this->lang = $lang;
     }
+    
+    /**
+     * Somewhat sloppy method of removing quoted reply text from checking
+     * @param   string  $text   Text content for sanitization/spellchecking
+     * @return  string  The sanitized $text
+     */
+    public function remove_quoted_reply($text){
+        return preg_replace('/(^\w.+:\n)?(^>.*(\n|$))+/', "", $text);
+    }
 
     /**
      * Return a list of languages supported by this backend

--- a/program/lib/Roundcube/rcube_spellcheck_googie.php
+++ b/program/lib/Roundcube/rcube_spellcheck_googie.php
@@ -54,6 +54,10 @@ class rcube_spellcheck_googie extends rcube_spellcheck_engine
      */
     function check($text)
     {
+        
+        // get rid of quoted reply text
+        $text = $this->remove_quoted_reply($text);
+        
         $this->content = $text;
 
         if (empty($text)) {

--- a/program/lib/Roundcube/rcube_spellcheck_pspell.php
+++ b/program/lib/Roundcube/rcube_spellcheck_pspell.php
@@ -89,6 +89,9 @@ class rcube_spellcheck_pspell extends rcube_spellcheck_engine
         if (!$this->plink) {
             return array();
         }
+        
+        // get rid of quoted reply text
+        $text = $this->remove_quoted_reply($text);
 
         // tokenize
         $text = preg_split($this->separator, $text, NULL, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_OFFSET_CAPTURE);


### PR DESCRIPTION
Hello,

Customers that utilize the spellcheck have been complaining that previous emails (quoted replies) are being checked with the spellchecker enabled. 

This patch adds a `remove_quoted_reply` method in the abstract class, and then the appropriate `$text = $this->remove_quoted_reply($text)`s in the child `check` methods.

Suggestions of better ways to accomplish this are welcome, I am new to this community and don't know whether this was intended or not. I also pondered whether this should be a setting, but couldn't really find a use case for wanting to scan previous emails.

This PR is dependant on #295. I submitted them separately because I feel this one may generate more discussion/input than #295, as well as them being two different features
