### PR TITLE
Enigma: fix storing password for whole session

### DIFF
--- a/plugins/enigma/lib/enigma_engine.php
+++ b/plugins/enigma/lib/enigma_engine.php
@@ -1075,8 +1075,10 @@ class enigma_engine
             $config = $this->rc->decrypt($config);
             $config = @unserialize($config);
         }
-
-        $threshold = time() - $this->password_time;
+        
+        if($this->password_time) {
+            $threshold = time() - $this->password_time;
+        }
         $keys      = array();
 
         // delete expired passwords


### PR DESCRIPTION
Noticed an issue with selecting storing the password for the whole session. When entering the password I would immediately be prompted for the password again over and over. It seemed like having 0 as the password_time was causing the password to never be stored. 
