### PR TITLE
Use debian:jessie tag, fix security problem that .htaccess is ignored

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:8.0
+FROM debian:jessie
 MAINTAINER Alex Brandt <alunduil@alunduil.com>
 
 EXPOSE 80 443
@@ -7,9 +7,11 @@ RUN apt-get -qq update
 RUN apt-get install -qq apache2-mpm-event ca-certificates
 
 RUN sed -e 's|/var/www/html|/var/www/public_html|' -e 's@\(Log \+\)[^ ]\+@\1"|/bin/cat"@' -i /etc/apache2/sites-available/000-default.conf
+RUN sed -e 's|</VirtualHost>|<Directory /var/www/public_html/>AllowOverride All</Directory></VirtualHost>|' -i /etc/apache2/sites-available/000-default.conf
 RUN a2ensite 000-default
 
 RUN sed -e 's|/var/www/html|/var/www/public_html|' -e 's@\(Log \+\)[^ ]\+@\1"|/bin/cat"@' -i /etc/apache2/sites-available/default-ssl.conf
+RUN sed -e 's|</VirtualHost>|<Directory /var/www/public_html/>AllowOverride All</Directory></VirtualHost>|' -i /etc/apache2/sites-available/default-ssl.conf
 RUN sed -e '/SSLCertificateKeyFile/s|ssl-cert-snakeoil.key|ssl-cert.key|' -e '/SSLCertificateFile/s|ssl-cert-snakeoil.pem|ssl-cert.pem|' -i /etc/apache2/sites-available/default-ssl.conf
 RUN ln -snf ssl-cert-snakeoil.pem /etc/ssl/certs/ssl-cert.pem
 RUN ln -snf ssl-cert-snakeoil.key /etc/ssl/private/ssl-cert.key


### PR DESCRIPTION
- debian:jessie ensures that you get versions like 8.1 etc.
- the additional sed ensures that the htaccess can overwrite the settings

however this is untested. please try it :)

@alunduil ping

see #244 for discussion
