### PR TITLE
attachment_reminder plugin: config file with locale-independent global keywords

### DIFF
--- a/plugins/attachment_reminder/attachment_reminder.js
+++ b/plugins/attachment_reminder/attachment_reminder.js
@@ -33,7 +33,7 @@ function rcmail_get_compose_message()
 
 function rcmail_check_message(msg)
 {
-  var i, rx, keywords = rcmail.gettext('keywords', 'attachment_reminder').split(",").concat([".doc", ".pdf"]);
+  var i, rx, keywords = rcmail.gettext('keywords', 'attachment_reminder').split(",").concat(rcmail.env.global_keywords);
 
   keywords = $.map(keywords, function(n) { return RegExp.escape(n); });
   rx = new RegExp('(' + keywords.join('|') + ')', 'i');

--- a/plugins/attachment_reminder/attachment_reminder.php
+++ b/plugins/attachment_reminder/attachment_reminder.php
@@ -35,7 +35,6 @@ class attachment_reminder extends rcube_plugin
     {
         $rcmail = rcube::get_instance();
 
-        $this->load_config('config.inc.php.dist');
         $this->load_config('config.inc.php');
         $rcmail->output->set_env('global_keywords', (array)$rcmail->config->get('global_keywords', array('.doc','.pdf')));
 

--- a/plugins/attachment_reminder/attachment_reminder.php
+++ b/plugins/attachment_reminder/attachment_reminder.php
@@ -37,7 +37,7 @@ class attachment_reminder extends rcube_plugin
 
         $this->load_config('config.inc.php.dist');
         $this->load_config('config.inc.php');
-        $rcmail->output->set_env('global_keywords', $rcmail->config->get('global_keywords'));
+        $rcmail->output->set_env('global_keywords', (array)$rcmail->config->get('global_keywords', array('.doc','.pdf')));
 
         if ($rcmail->task == 'mail' && $rcmail->action == 'compose') {
             if ($rcmail->config->get('attachment_reminder')) {

--- a/plugins/attachment_reminder/attachment_reminder.php
+++ b/plugins/attachment_reminder/attachment_reminder.php
@@ -35,6 +35,10 @@ class attachment_reminder extends rcube_plugin
     {
         $rcmail = rcube::get_instance();
 
+        $this->load_config('config.inc.php.dist');
+        $this->load_config('config.inc.php');
+        $rcmail->output->set_env('global_keywords', $rcmail->config->get('global_keywords'));
+
         if ($rcmail->task == 'mail' && $rcmail->action == 'compose') {
             if ($rcmail->config->get('attachment_reminder')) {
                 $this->include_script('attachment_reminder.js');

--- a/plugins/attachment_reminder/config.inc.php.dist
+++ b/plugins/attachment_reminder/config.inc.php.dist
@@ -1,0 +1,6 @@
+<?php
+
+// Always check for these words to indicate a missing attachment
+$config['global_keywords'] = array('.doc', '.pdf');
+
+?>


### PR DESCRIPTION
Currently, two keywords are hardcoded into the plugin to indicate a missing attachment: '.doc' and '.pdf'. This patch remopves that hardcoding and allows the user to set custom global keywords in a config file.

My personal use case is that I frequently compose messages in a language other than the set locale. I use this global config file to include keywords from other locales.
