### PR TITLE
Make user_domain setting to be used as the mail_domain

### DIFF
--- a/program/include/rcmail.php
+++ b/program/include/rcmail.php
@@ -215,7 +215,7 @@ class rcmail extends rcube
             $domain   = $this->config->mail_domain($_SESSION['storage_host']);
             $username_domain = $this->config->get('username_domain');
             $domain   = is_array($username_domain) ? $username_domain[$domain] : $domain;
-	    $contacts = new rcube_ldap($ldap_config[$id], $this->config->get('ldap_debug'), $domain);
+            $contacts = new rcube_ldap($ldap_config[$id], $this->config->get('ldap_debug'), $domain);
         }
         else if ($id === '0') {
             $contacts = new rcube_contacts($this->db, $this->get_user_id());

--- a/program/include/rcmail.php
+++ b/program/include/rcmail.php
@@ -213,7 +213,9 @@ class rcmail extends rcube
         }
         else if ($id && $ldap_config[$id]) {
             $domain   = $this->config->mail_domain($_SESSION['storage_host']);
-            $contacts = new rcube_ldap($ldap_config[$id], $this->config->get('ldap_debug'), $domain);
+            $username_domain = $this->config->get('username_domain');
+            $domain   = is_array($username_domain) ? $username_domain[$domain] : $domain;
+	    $contacts = new rcube_ldap($ldap_config[$id], $this->config->get('ldap_debug'), $domain);
         }
         else if ($id === '0') {
             $contacts = new rcube_contacts($this->db, $this->get_user_id());


### PR DESCRIPTION
I'm proposing a feature to make the config user_domain be used to set the address book mail_domain.  This is better than using mail_domain config as the email domain can be set to a different domain per host.

An example usage is that of Google Apps Email with custom domains.   If I have a custom domain my imap server is still imap.googlemail.com but my email addresses should not be googlemail.com but my custom domain's.  mail_domain will fix it if I have only one domain, but what if I have to custom domains?
