### PR TITLE
Update mail.css, preventing accidental selections

### DIFF
--- a/skins/larry/mail.css
+++ b/skins/larry/mail.css
@@ -275,7 +275,7 @@ table.messagelist.fixedcopy {
 .messagelist tr > .flag,
 .messagelist tr > .priority {
 	width: 20px;
-	padding: 2px 3px !important;
+	padding: 3px 3px !important;
 }
 
 .messagelist tr > .threads {


### PR DESCRIPTION
A padding-top:3px and a padding-bottom:3px would solve some issues with touch devices (when adjacent rows are accidentally selected) and they would never hide many emails (only 1 or 2) because the padding increase is not excessive.
