### PR TITLE
Update mail.css, preventing accidental selections

### DIFF
--- a/skins/classic/mail.css
+++ b/skins/classic/mail.css
@@ -627,7 +627,7 @@ table.messagelist.fixedcopy
 .messagelist tbody tr th,
 .messagelist tbody tr td
 {
-  height: 20px;
+  height: 22px;
   padding: 0;
   font-size: 11px;
   overflow: hidden;


### PR DESCRIPTION
A height:22px would solve some issues with touch devices (when adjacent rows are accidentally selected) and it would never hide many emails (only 1 or 2) because the height increase is not excessive.
