### PR TITLE
Update language_in option of Closure Compiler to match current code

### DIFF
--- a/bin/jsshrink.sh
+++ b/bin/jsshrink.sh
@@ -2,7 +2,7 @@
 PWD=`dirname "$0"`
 JS_DIR="$PWD/../program/js"
 JAR_DIR='/tmp'
-LANG_IN='ECMASCRIPT3'
+LANG_IN='ECMASCRIPT5'
 # latest version requires Java 7, we'll use an older one
 #CLOSURE_COMPILER_URL='http://dl.google.com/closure-compiler/compiler-latest.zip'
 CLOSURE_COMPILER_URL='http://dl.google.com/closure-compiler/compiler-20131014.zip'


### PR DESCRIPTION
The JavaScript Promise code added in 7b8a0af and 2965a98 is not supported under the ES3 spec. Update the language_in setting of Closeure Compiler to ES5 to avoid warnings like:

```
./bin/../program/js/app.js:3396: WARNING - Keywords and reserved words are not allowed as unquoted property names in older versions of JavaScript. If you are targeting newer versions of JavaScript, set the appropriate language_in option.
    }).catch(function(err) {
       ^
```

also

```
./bin/../program/js/publickey.js:8: ERROR - Parse error. IE8 (and below) will parse trailing commas in array and object literals incorrectly. If you are targeting newer versions of JS, set the appropriate language_in option.
        "https://keys.fedoraproject.org/",
        ^
```

though the warnings in publickey.js could also be fixed just be removing the trailing commas.
