### PR TITLE
Download attachments on saved drafts

### DIFF
--- a/program/js/app.js
+++ b/program/js/app.js
@@ -294,7 +294,7 @@ function rcube_webmail()
         }
         else if (this.env.action == 'compose') {
           this.env.address_group_stack = [];
-          this.env.compose_commands = ['send-attachment', 'remove-attachment', 'send', 'cancel',
+          this.env.compose_commands = ['send-attachment', 'remove-attachment', 'download-attachment', 'send', 'cancel',
             'toggle-editor', 'list-adresses', 'pushgroup', 'search', 'reset-search', 'extwin',
             'insert-response', 'save-response', 'menu-open', 'menu-close'];
 
@@ -1010,7 +1010,7 @@ function rcube_webmail()
       case 'load-attachment':
       case 'open-attachment':
       case 'download-attachment':
-        var qstring = '_mbox='+urlencode(this.env.mailbox)+'&_uid='+this.env.uid+'&_part='+props,
+        var qstring = '_mbox='+urlencode(this.env.mailbox)+'&_uid='+(this.env.uid||this.env.draft_id)+'&_part='+props,
           mimetype = this.env.attachments[props];
 
         // open attachment in frame if it's of a supported mimetype
@@ -1019,6 +1019,8 @@ function rcube_webmail()
             break;
         }
 
+        if (this.env.action == 'compose')
+            this.compose_skip_unsavedcheck = true;
         this.goto_url('get', qstring+'&_download=1', false);
         break;
 

--- a/program/steps/mail/compose.inc
+++ b/program/steps/mail/compose.inc
@@ -1532,7 +1532,7 @@ function rcmail_compose_subject($attrib)
 
 function rcmail_compose_attachment_list($attrib)
 {
-    global $RCMAIL, $OUTPUT, $COMPOSE;
+    global $RCMAIL, $OUTPUT, $COMPOSE, $MESSAGE;
 
     // add ID if not given
     if (!$attrib['id'])
@@ -1560,6 +1560,15 @@ function rcmail_compose_attachment_list($attrib)
 
             $content = sprintf('%s <span class="attachment-size">(%s)</span>',
                 rcube::Q($a_prop['name']), $RCMAIL->show_bytes($a_prop['size']));
+
+            if ($a_prop['pid']) {
+                $content = html::a(array(
+                        'href'  => $MESSAGE->get_part_url($a_prop['pid'], false) . '&_download=1',
+                        'style' => 'padding: 0;',
+                    ),
+                    $content
+                );
+            }
 
             $out .= html::tag('li', array(
                     'id'          => 'rcmfile'.$id,

--- a/program/steps/mail/compose.inc
+++ b/program/steps/mail/compose.inc
@@ -1532,7 +1532,7 @@ function rcmail_compose_subject($attrib)
 
 function rcmail_compose_attachment_list($attrib)
 {
-    global $RCMAIL, $OUTPUT, $COMPOSE, $MESSAGE;
+    global $RCMAIL, $OUTPUT, $COMPOSE;
 
     // add ID if not given
     if (!$attrib['id'])
@@ -1563,8 +1563,9 @@ function rcmail_compose_attachment_list($attrib)
 
             if ($a_prop['pid']) {
                 $content = html::a(array(
-                        'href'  => $MESSAGE->get_part_url($a_prop['pid'], false) . '&_download=1',
-                        'style' => 'padding: 0;',
+                        'href'    => '#',
+                        'onclick' => sprintf("return %s.command('download-attachment', '%s', this)", rcmail_output::JS_OBJECT_NAME, $a_prop['pid']),
+                        'style'   => 'padding: 0;',
                     ),
                     $content
                 );

--- a/program/steps/mail/func.inc
+++ b/program/steps/mail/func.inc
@@ -2268,6 +2268,7 @@ function rcmail_save_attachment($message, $pid, $compose_id, $params = array())
         'path'       => $path,
         'size'       => $path ? filesize($path) : strlen($data),
         'charset'    => $part ? $part->charset : null,
+        'pid'        => $pid,
     );
 
     $attachment = $rcmail->plugins->exec_hook('attachment_save', $attachment);


### PR DESCRIPTION
I often happen to use mail drafts as simple temporary file storage. Unfortunately roundcube doesn't allow to download attachments on saved drafts. With this change the attachment list is extended to offer download links for each attachment.
The draft has to be saved and the mail editor re-opened in order to work.

The change might be a bit too simple, please bear with me.
