### PR TITLE
Open exceptions link in new Tab

### DIFF
--- a/skins/larry/templates/about.html
+++ b/skins/larry/templates/about.html
@@ -18,7 +18,7 @@
 <p class="license">This program is free software; you can redistribute it and/or modify
 it under the terms of the <a href="http://www.gnu.org/licenses/gpl.html" target="_blank">GNU General Public License</a>
 as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.<br/>
-Some <a href="http://roundcube.net/license">exceptions</a> for skins &amp; plugins apply.
+Some <a href="https://roundcube.net/license" target="_blank">exceptions</a> for skins &amp; plugins apply.
 </p>
 
 </div>


### PR DESCRIPTION
open the exceptions link in a new tab, as it is not rendered in Chrome on https-Sites, also change link to https.
