### PR TITLE
Add option to hide contact photos

### DIFF
--- a/program/localization/en_US/labels.inc
+++ b/program/localization/en_US/labels.inc
@@ -534,6 +534,7 @@ $labels['reqdsn'] = 'Always request a delivery status notification';
 $labels['replysamefolder'] = 'Place replies in the folder of the message being replied to';
 $labels['defaultabook'] = 'Default address book';
 $labels['autocompletesingle'] = 'Skip alternative email addresses in autocompletion';
+$labels['hidecontactphotos'] = 'Hide contact photos';
 $labels['listnamedisplay'] = 'List contacts as';
 $labels['spellcheckbeforesend'] = 'Check spelling before sending a message';
 $labels['spellcheckoptions'] = 'Spellcheck Options';

--- a/program/steps/addressbook/func.inc
+++ b/program/steps/addressbook/func.inc
@@ -179,6 +179,7 @@ function rcmail_contact_source($source=null, $init_env=false, $writable=false)
     }
 
     $OUTPUT->set_env('photocol', is_array($CONTACT_COLTYPES['photo']));
+    $OUTPUT->set_env('hide_contactphotos', $RCMAIL->config->get('hide_contactphotos'));
 
     return $CONTACTS;
 }
@@ -835,19 +836,22 @@ function rcmail_contact_photo($attrib)
         }
     }
 
-    if ($plugin['url'])
-        $photo_img = $plugin['url'];
-    else if (preg_match('!^https?://!i', $record['photo']))
-        $photo_img = $record['photo'];
-    else if ($record['photo']) {
-        $url = array('_action' => 'photo', '_cid' => $record['ID'], '_source' => $SOURCE_ID);
-        if ($file_id) {
-            $url['_photo'] = $ff_value = $file_id;
+    // only process photo if it should be shown
+    if (!$RCMAIL->config->get('hide_contactphotos')) {
+
+        if ($plugin['url'])
+            $photo_img = $plugin['url'];
+        else if (preg_match('!^https?://!i', $record['photo']))
+            $photo_img = $record['photo'];
+        else if ($record['photo']) {
+            $url = array('_action' => 'photo', '_cid' => $record['ID'], '_source' => $SOURCE_ID);
+            if ($file_id) {
+                $url['_photo'] = $ff_value = $file_id;
+            }
+            $photo_img = $RCMAIL->url($url);
+        } else {
+            $ff_value = '-del-'; // will disable delete-photo action
         }
-        $photo_img = $RCMAIL->url($url);
-    }
-    else {
-        $ff_value = '-del-'; // will disable delete-photo action
     }
 
     $content = html::div($attrib, html::img(array(

--- a/program/steps/addressbook/show.inc
+++ b/program/steps/addressbook/show.inc
@@ -39,6 +39,9 @@ if ($cid && ($record = $CONTACTS->get_record($cid, true))) {
     }
 }
 
+// configure environment to hide contact photos
+$OUTPUT->set_env('hide_contactphotos', $RCMAIL->config->get('hide_contactphotos'));
+
 // get address book name (for display)
 rcmail_set_sourcename($CONTACTS);
 

--- a/program/steps/addressbook/upload_photo.inc
+++ b/program/steps/addressbook/upload_photo.inc
@@ -52,6 +52,11 @@ if ($filepath = $_FILES['_photo']['tmp_name']) {
             'mimetype' => 'image/' . $imageprop['type'],
             'group' => 'contact',
         ));
+
+        //since the user uploaded a photo, assume contact photos shall be shown
+        if($RCMAIL->config->get('hide_contactphotos')){
+            $RCMAIL->user->save_prefs(array('hide_contactphotos' => false));
+        }
     }
     else {
         $attachment['error'] = $RCMAIL->gettext('invalidimageformat');

--- a/program/steps/mail/show.inc
+++ b/program/steps/mail/show.inc
@@ -77,6 +77,7 @@ if ($uid) {
 
     // set environment
     $OUTPUT->set_env('delimiter', $RCMAIL->storage->get_hierarchy_delimiter());
+    $OUTPUT->set_env('hide_contactphotos', $RCMAIL->config->get('hide_contactphotos'));
 
     // set configuration
     $RCMAIL->set_env_config(array('delete_junk', 'flag_for_deletion', 'read_when_deleted',
@@ -348,7 +349,9 @@ function rcmail_message_contactphoto($attrib)
     $placeholder = $attrib['placeholder'] ? $RCMAIL->output->abs_url($attrib['placeholder'], true) : null;
     $placeholder = $RCMAIL->output->asset_url($placeholder ?: 'program/resources/blank.gif');
 
-    if ($MESSAGE->sender) {
+    $hide_contactphoto = $RCMAIL->config->get('hide_contactphotos');
+
+    if ($MESSAGE->sender && !$hide_contactphoto) {
         $photo_img = $RCMAIL->url(array(
             '_task'   => 'addressbook',
             '_action' => 'photo',

--- a/program/steps/settings/func.inc
+++ b/program/steps/settings/func.inc
@@ -1064,6 +1064,21 @@ function rcmail_user_prefs($current = null)
                     'content' => $checkbox->show($config['autocomplete_single']?1:0),
                 );
             }
+
+            // show option to hide contact photos
+            if (!isset($no_override['hide_contactphotos'])) {
+                if (!$current) {
+                    continue 2;
+                }
+
+                $field_id = 'rcmfd_hide_contactphotos';
+                $checkbox = new html_checkbox(array('name' => '_hide_contactphotos', 'id' => $field_id, 'value' => 1));
+
+                $blocks['main']['options']['hide_contactphotos'] = array(
+                    'title'   => html::label($field_id, rcube::Q($RCMAIL->gettext('hidecontactphotos'))),
+                    'content' => $checkbox->show($config['hide_contactphotos']?1:0),
+                );
+            }
         break;
 
         // Special IMAP folders

--- a/program/steps/settings/save_prefs.inc
+++ b/program/steps/settings/save_prefs.inc
@@ -104,6 +104,7 @@ case 'addressbook':
         'addressbook_sort_col' => rcube_utils::get_input_value('_addressbook_sort_col', rcube_utils::INPUT_POST),
         'addressbook_name_listing' => intval(rcube_utils::get_input_value('_addressbook_name_listing', rcube_utils::INPUT_POST)),
         'addressbook_pagesize' => is_numeric($_POST['_addressbook_pagesize']) ? max(2, intval($_POST['_addressbook_pagesize'])) : $CONFIG['addressbook_pagesize'],
+        'hide_contactphotos'  => isset($_POST['_hide_contactphotos']) ? true : false,
     );
 
     break;

--- a/skins/larry/templates/contact.html
+++ b/skins/larry/templates/contact.html
@@ -12,8 +12,9 @@
 	<roundcube:if condition="strlen(env:sourcename)" />
 		<div id="sourcename"><roundcube:label name="addressbook" />: <roundcube:var name="env:sourcename" /></div>
 	<roundcube:endif />
-
+	<roundcube:if condition="!env:hide_contactphotos" />
 	<div id="contactphoto"><roundcube:object name="contactphoto" id="contactpic" placeholder="/images/contactpic.png" placeholderGroup="/images/contactgroup.png" /></div>
+	<roundcube:endif />
 	<roundcube:object name="contacthead" id="contacthead" />
 	<br style="clear:both" />
 

--- a/skins/larry/templates/contactedit.html
+++ b/skins/larry/templates/contactedit.html
@@ -13,17 +13,19 @@
 		<div id="sourcename"><roundcube:label name="addressbook" />: <roundcube:var name="env:sourcename" condition="env:action!='add'" /><roundcube:object name="sourceselector" id="sourceselect" condition="env:action=='add'" /></div>
 	<roundcube:endif />
 
-	<fieldset id="contactphoto">
-		<legend class="voice"><roundcube:label name="contactphoto" /></legend>
-		<roundcube:object name="contactphoto" id="contactpic" placeholder="/images/contactpic.png" />
-		<roundcube:if condition="env:photocol" />
-		<roundcube:object name="fileDropArea" id="contactpic" />
-		<div class="formlinks">
-			<roundcube:button command="upload-photo" id="uploadformlink" type="link" label="replacephoto" class="iconlink upload disabled" classAct="iconlink upload active" onclick="UI.show_uploadform();return false" condition="env:photocol" /><br/>
-			<roundcube:button command="delete-photo" type="link" label="delete" class="iconlink delete disabled" classAct="iconlink delete active" condition="env:photocol" />
-		</div>
-		<roundcube:endif />
-	</fieldset>
+	<roundcube:if condition="!env:hide_contactphotos" />
+		<fieldset id="contactphoto">
+			<legend class="voice"><roundcube:label name="contactphoto" /></legend>
+			<roundcube:object name="contactphoto" id="contactpic" placeholder="/images/contactpic.png" />
+			<roundcube:if condition="env:photocol" />
+			<roundcube:object name="fileDropArea" id="contactpic" />
+			<div class="formlinks">
+				<roundcube:button command="upload-photo" id="uploadformlink" type="link" label="replacephoto" class="iconlink upload disabled" classAct="iconlink upload active" onclick="UI.show_uploadform();return false" condition="env:photocol" /><br/>
+				<roundcube:button command="delete-photo" type="link" label="delete" class="iconlink delete disabled" classAct="iconlink delete active" condition="env:photocol" />
+			</div>
+			<roundcube:endif />
+		</fieldset>
+	<roundcube:endif />
 
 	<roundcube:object name="contactedithead" id="contacthead" size="16" form="editform" />
 	<br style="clear:both" />

--- a/skins/larry/templates/contactprint.html
+++ b/skins/larry/templates/contactprint.html
@@ -10,7 +10,9 @@
 <div id="header"><roundcube:object name="logo" src="/images/roundcube_logo.png" id="toplogo" border="0" alt="Logo" /></div>
 
 <div id="contact-details" class="boxcontent">
+	<roundcube:if condition="!env:hide_contactphotos" />
 	<div id="contactphoto"><roundcube:object name="contactphoto" id="contactpic" placeholder="/images/contactpic.png" placeholderGroup="/images/contactgroup.png" /></div>
+	<roundcube:endif />
 	<roundcube:object name="contacthead" id="contacthead" />
 	<br style="clear:both" />
 	<roundcube:object name="contactdetails" />

--- a/skins/larry/templates/message.html
+++ b/skins/larry/templates/message.html
@@ -75,7 +75,9 @@
 </div>
 <roundcube:object name="messageFullHeaders" id="full-headers" />
 
+<roundcube:if condition="!env:hide_contactphotos" />
 <div id="contactphoto"><roundcube:object name="contactphoto" /></div>
+<roundcube:endif />
 </div>
 
 <div id="messagecontent">

--- a/skins/larry/templates/messagepreview.html
+++ b/skins/larry/templates/messagepreview.html
@@ -34,7 +34,9 @@
 <h3 class="subject"><span class="voice"><roundcube:label name="subject" />: </span><roundcube:object name="messageHeaders" valueOf="subject" /></h3>
 
 <a href="#details" id="previewheaderstoggle" class="moreheaderstoggle" aria-expanded="false"><span class="iconlink" title="<roundcube:label name='togglemoreheaders' />"></span></a>
+<roundcube:if condition="!env:hide_contactphotos" />
 <div id="contactphoto"><roundcube:object name="contactphoto" /></div>
+<roundcube:endif />
 
 <table class="headers-table" id="preview-shortheaders"><tbody><tr>
 <roundcube:if condition="env:mailbox == config:drafts_mbox || env:mailbox == config:sent_mbox">


### PR DESCRIPTION
Hi,

as discussed in the mailing list, we implemented feature request [#1490538](http://trac.roundcube.net/ticket/1490538) (Allow hiding contact photos in message display).

We added an option in the addressbook settings to toggle the display of contact photos in the mail view and addressbook.

Naturally, we had to add a label for this option. Unfortunately we are not aware of the correct project workflow regarding translation issues, so we just added an english label to the `en_US` language package. Of course we are happy to adapt the correct way to add labels if this turns out to be wrong.

If the option is set, contact photos won't be shown in message views and previews. In the addressbook, the user will neither see the contact photos nor edit them (just like as the functionality would have never been there).

When using the Larry skin, we prevent the image from being included into the HTML and hence the contact photo will not be shown at all. If another skin is used, only the blank placeholder image will be delivered.

However, there is still one issue left we would like to solve. If the contact photo in the mail preview is hidden and the user uses the Larry skin, a gap is visible where the photo would normally be. This problem could be solved by adding an appropriate CSS class to the header which would reduce the padding.

Is this possible with the roundcube template engine or do you have another idea to fix this issue?
