### PR TITLE
add .log suffix to all log file names

### DIFF
--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -77,6 +77,9 @@ $config['log_date_format'] = 'd-M-Y H:i:s O';
 // set to 0 to avoid session IDs being logged.
 $config['log_session_id'] = 8;
 
+// Default extension used for log file name
+$config['log_file_ext'] = '.log';
+
 // Syslog ident string to use, if using the 'syslog' log driver.
 $config['syslog_id'] = 'roundcube';
 

--- a/program/lib/Roundcube/rcube.php
+++ b/program/lib/Roundcube/rcube.php
@@ -1246,7 +1246,7 @@ class rcube
             $log_dir = RCUBE_INSTALL_PATH . 'logs';
         }
 
-        return file_put_contents("$log_dir/$name", $line, FILE_APPEND) !== false;
+        return file_put_contents("$log_dir/$name.log", $line, FILE_APPEND) !== false;
     }
 
     /**

--- a/program/lib/Roundcube/rcube.php
+++ b/program/lib/Roundcube/rcube.php
@@ -1242,11 +1242,17 @@ class rcube
             }
         }
 
+        if (self::$instance) {
+            $log_suf = self::$instance->config->get('log_file_ext', '.log');
+        } else {
+            $log_suf = '.log';
+        }
+
         if (empty($log_dir)) {
             $log_dir = RCUBE_INSTALL_PATH . 'logs';
         }
 
-        return file_put_contents("$log_dir/$name.log", $line, FILE_APPEND) !== false;
+        return file_put_contents("$log_dir/$name$log_suf", $line, FILE_APPEND) !== false;
     }
 
     /**


### PR DESCRIPTION
As lot of files are used (sieve, ldap, errors, password, smtp, imap, session, ...) having such a suffix will make much easier to configure logrotate, using

```
 /var/log/roundcubemail/*.log {
     ...
 }
```
