### PR TITLE
Update rcube_sieve_vacation.php

### DIFF
--- a/plugins/managesieve/lib/Roundcube/rcube_sieve_vacation.php
+++ b/plugins/managesieve/lib/Roundcube/rcube_sieve_vacation.php
@@ -338,7 +338,7 @@ class rcube_sieve_vacation extends rcube_sieve_engine
             ) + $attrib);
 
         $auto_addr = $this->rc->config->get('managesieve_vacation_addresses_init');
-        $addresses = !$auto_addr || count($this->vacation) > 1 ? (array) $this->vacation['addresses'] : $this->user_emails();
+        $addresses = !$auto_addr || ( count($this->vacation) > 1 && !empty($this->vacation['addresses'])) ? (array) $this->vacation['addresses'] : $this->user_emails();
 
         // form elements
         $from      = new html_inputfield(array('name' => 'vacation_from', 'id' => 'vacation_from', 'size' => 50));


### PR DESCRIPTION
Problem encountered where $auto_addr was true and vacation['addresses'] was undefined. This caused a null/empty addresses value. The above check ensures that the addresses value is only used if it is defined and populated.

Adding the !empty check ensures what I believe to be the expected behaviour where $auto_addr is true.
