### PR TITLE
Ensure roundcube doesn't render contact names as blank 

### DIFF
--- a/program/lib/Roundcube/rcube_addressbook.php
+++ b/program/lib/Roundcube/rcube_addressbook.php
@@ -550,7 +550,7 @@ abstract class rcube_addressbook
         // fallbacks...
         if ($fn === '') {
             // ... display name
-            if (!empty($contact['name'])) {
+            if (!empty(trim($contact['name']))) {
                 $fn = $contact['name'];
             }
             // ... organization


### PR DESCRIPTION
Issue occurs when importing data/upgrading from older versions of roundcube.
