### PR TITLE
Enable use of TLSv1.1 and TLSv1.2 for IMAP.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@ CHANGELOG Roundcube Webmail
 - Fix PHP7 warning "session_start(): Session callback expects true/false return value" (#1490624)
 - Fix XSS issue in SVG images handling (#1490625)
 - Fix missing language name in "Add to Dictionary" request in HTML mode (#1490634)
+- Enable use of TLSv1.1 and TLSv1.2 for IMAP.
 
 RELEASE 1.2-beta
 ----------------

--- a/program/lib/Roundcube/rcube_imap_generic.php
+++ b/program/lib/Roundcube/rcube_imap_generic.php
@@ -997,7 +997,13 @@ class rcube_imap_generic
                 return false;
             }
 
-            if (!stream_socket_enable_crypto($this->fp, true, STREAM_CRYPTO_METHOD_TLS_CLIENT)) {
+            // There is no flag to enable all TLS methods. Net_SMTP
+            // handles enabling TLS similarly.
+            $crypto_method = STREAM_CRYPTO_METHOD_TLS_CLIENT
+                | @STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT
+                | @STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT;
+
+            if (!stream_socket_enable_crypto($this->fp, true, $crypto_method)) {
                 $this->setError(self::ERROR_BAD, "Unable to negotiate TLS");
                 $this->closeConnection();
                 return false;

--- a/program/lib/Roundcube/rcube_imap_generic.php
+++ b/program/lib/Roundcube/rcube_imap_generic.php
@@ -997,11 +997,16 @@ class rcube_imap_generic
                 return false;
             }
 
-            // There is no flag to enable all TLS methods. Net_SMTP
-            // handles enabling TLS similarly.
-            $crypto_method = STREAM_CRYPTO_METHOD_TLS_CLIENT
-                | @STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT
-                | @STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT;
+            if (isset($this->prefs['socket_options']['ssl']['crypto_method'])) {
+                $crypto_method = $this->prefs['socket_options']['ssl']['crypto_method'];
+            }
+            else {
+                // There is no flag to enable all TLS methods. Net_SMTP
+                // handles enabling TLS similarly.
+                $crypto_method = STREAM_CRYPTO_METHOD_TLS_CLIENT
+                    | @STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT
+                    | @STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT;
+            }
 
             if (!stream_socket_enable_crypto($this->fp, true, $crypto_method)) {
                 $this->setError(self::ERROR_BAD, "Unable to negotiate TLS");


### PR DESCRIPTION
Currently, Roundcube is only able to use TLSv1 to connect to IMAP. The use TLSv1 is becoming increasingly discouraged. This patch enables IMAP connections using TLSv1.1 and TLSv1.2. Net_SMTP uses the same flag handling for its support of TLSv1.1 and TLSv1.2.
