### PR TITLE
Encode HTML special chars in additional headers plugin

### DIFF
--- a/plugins/show_additional_headers/show_additional_headers.php
+++ b/plugins/show_additional_headers/show_additional_headers.php
@@ -43,7 +43,7 @@ class show_additional_headers extends rcube_plugin
     $rcmail = rcmail::get_instance();
     foreach ((array)$rcmail->config->get('show_additional_headers', array()) as $header) {
       if ($value = $p['headers']->get($header))
-        $p['output'][$header] = array('title' => $header, 'value' => $value);
+        $p['output'][$header] = array('title' => $header, 'value' => htmlspecialchars($value, ENT_QUOTES), 'html' => 1);
     }
 
     return $p;


### PR DESCRIPTION
Otherwise added headers that e.g. contain email@example.com will send that directly to the browser.
