### PR TITLE
autoselect_host(): support pop. prefix

### DIFF
--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -134,6 +134,10 @@ $config['apc_debug'] = false;
 //          required to match old user data records with the new host.
 $config['default_host'] = 'localhost';
 
+// Some hosts use pop. for both IMAP and POP, breaking the host auto-selection.
+// Set to True if you've got this case.
+$config['host_uses_pop_prefix'] = false;
+
 // TCP port used for IMAP connections
 $config['default_port'] = 143;
 

--- a/program/include/rcmail.php
+++ b/program/include/rcmail.php
@@ -711,8 +711,9 @@ class rcmail extends rcube
      */
     public function autoselect_host()
     {
-        $default_host = $this->config->get('default_host');
-        $host         = null;
+        $default_host   = $this->config->get('default_host');
+        $host_uses_pop_prefix = $this->config->get('host_uses_pop_prefix');
+        $host           = null;
 
         if (is_array($default_host)) {
             $post_host = rcube_utils::get_input_value('_host', rcube_utils::INPUT_POST);
@@ -749,6 +750,11 @@ class rcmail extends rcube
         }
         else {
             $host = rcube_utils::parse_host($default_host);
+        }
+
+        // check if the host is using pop. for both IMAP and POP
+        if ($host_uses_pop_prefix) {
+            $host = 'pop.'.$host;
         }
 
         return $host;


### PR DESCRIPTION
Some hosts use pop. for both IMAP and POP.
Add a flag to fix auto-selection for these hosts.
