### PR TITLE
Implemented attaching pub PGP key to outgoing messages.

### DIFF
--- a/plugins/enigma/config.inc.php.dist
+++ b/plugins/enigma/config.inc.php.dist
@@ -28,6 +28,9 @@ $config['enigma_sign_all'] = false;
 // Enable encrypting all messages by default
 $config['enigma_encrypt_all'] = false;
 
+// Enable signing all messages by default
+$config['enigma_attach_pubkey'] = false;
+
 // Default for how long to store private key passwords (in minutes).
 // When set to 0 passwords will be stored for the whole session.
 $config['enigma_password_time'] = 5;

--- a/plugins/enigma/enigma.php
+++ b/plugins/enigma/enigma.php
@@ -339,6 +339,25 @@ class enigma extends rcube_plugin
             );
         }
 
+        if (!isset($no_override['enigma_attach_pubkey'])) {
+            if (!$p['current']) {
+                $p['blocks']['main']['content'] = true;
+                return $p;
+            }
+
+            $field_id = 'rcmfd_enigma_attach_pubkey';
+            $input    = new html_checkbox(array(
+                    'name'  => '_enigma_attach_pubkey',
+                    'id'    => $field_id,
+                    'value' => 1,
+            ));
+
+            $p['blocks']['main']['options']['enigma_encrypt_all'] = array(
+                'title'   => html::label($field_id, $this->gettext('attachpubkeydefault')),
+                'content' => $input->show($this->rc->config->get('enigma_attach_pubkey') ? 1 : 0),
+            );
+        }
+
         if (!isset($no_override['enigma_password_time'])) {
             if (!$p['current']) {
                 $p['blocks']['main']['content'] = true;
@@ -380,6 +399,7 @@ class enigma extends rcube_plugin
                 'enigma_encryption'    => (bool) rcube_utils::get_input_value('_enigma_encryption', rcube_utils::INPUT_POST),
                 'enigma_sign_all'      => (bool) rcube_utils::get_input_value('_enigma_sign_all', rcube_utils::INPUT_POST),
                 'enigma_encrypt_all'   => (bool) rcube_utils::get_input_value('_enigma_encrypt_all', rcube_utils::INPUT_POST),
+                'enigma_attach_pubkey' => (bool) rcube_utils::get_input_value('_enigma_attach_pubkey', rcube_utils::INPUT_POST),
                 'enigma_password_time' => intval(rcube_utils::get_input_value('_enigma_password_time', rcube_utils::INPUT_POST)),
             );
         }

--- a/plugins/enigma/lib/enigma_driver_gnupg.php
+++ b/plugins/enigma/lib/enigma_driver_gnupg.php
@@ -339,6 +339,17 @@ class enigma_driver_gnupg extends enigma_driver
         }
     }
 
+    public function pubkey_for_attach($email)
+    {
+        try {
+            $pubkey = $this->gpg->exportPublicKey($email, true);
+            return $pubkey;
+        }
+        catch (Exception $e) {
+            return $this->get_error_from_exception($e);
+        }
+    }
+
     /**
      * Converts Crypt_GPG exception into Enigma's error object
      *

--- a/plugins/enigma/lib/enigma_engine.php
+++ b/plugins/enigma/lib/enigma_engine.php
@@ -921,6 +921,38 @@ class enigma_engine
         return $result;
     }
 
+    function get_gpg_pubkey_for_attach($email)
+    {
+        $this->load_pgp_driver();
+        $result = $this->pgp_driver->pubkey_for_attach($email);
+
+        if ($result instanceof enigma_error) {
+            rcube::raise_error(array(
+                'code' => 600, 'type' => 'php',
+                'file' => __FILE__, 'line' => __LINE__,
+                'message' => "Enigma plugin: " . $result->getMessage()
+                ), true, false);
+        }
+
+        return $result;
+    }
+
+    function get_keyID($email)
+    {
+        $this->load_pgp_driver();
+        $result = $this->pgp_driver->get_keyID($email);
+
+        if ($result instanceof enigma_error) {
+            rcube::raise_error(array(
+                'code' => 600, 'type' => 'php',
+                'file' => __FILE__, 'line' => __LINE__,
+                'message' => "Enigma plugin: " . $result->getMessage()
+                ), true, false);
+        }
+
+        return $result;
+    }
+
     /**
      * Find PGP private/public key
      *

--- a/plugins/enigma/lib/enigma_ui.php
+++ b/plugins/enigma/lib/enigma_ui.php
@@ -730,6 +730,11 @@ class enigma_ui
         $menu->add(null, $chbox->show($this->rc->config->get('enigma_encrypt_all') ? 1 : 0,
             array('name' => '_enigma_encrypt', 'id' => 'enigmaencryptopt')));
 
+        $menu->add(null, html::label(array('for' => 'enigmaattachpubkeyopt'),
+            rcube::Q($this->enigma->gettext('attachpubkeymsg'))));
+        $menu->add(null, $chbox->show($this->rc->config->get('enigma_attach_pubkey') ? 1 : 0, 
+            array('name' => '_enigma_attachpubkey', 'id' => 'enigmaattachpubkeyopt')));
+
         $menu = html::div(array('id' => 'enigmamenu', 'class' => 'popupmenu'), $menu->show());
 
         // Options menu contents

--- a/plugins/enigma/localization/en_US.inc
+++ b/plugins/enigma/localization/en_US.inc
@@ -53,6 +53,7 @@ $labels['supportsignatures'] = 'Enable message signatures verification';
 $labels['supportdecryption'] = 'Enable message decryption';
 $labels['signdefault'] = 'Sign all messages by default';
 $labels['encryptdefault'] = 'Encrypt all messages by default';
+$labels['attachpubkeydefault'] = 'Attach my public PGP key by default';
 $labels['passwordtime'] = 'Keep private key passwords for';
 $labels['nminutes'] = '$m minute(s)';
 $labels['wholesession'] = 'the whole session';
@@ -82,6 +83,7 @@ $labels['signmsg'] = 'Digitally sign this message';
 $labels['enterkeypasstitle'] = 'Enter key passphrase';
 $labels['enterkeypass'] = 'A passphrase is needed to unlock the secret key ($keyid) for user: $user.';
 $labels['arialabelkeyexportoptions'] = 'Keys export options';
+$labels['attachpubkeymsg'] = 'Attach my public key';
 
 $messages = array();
 $messages['sigvalid'] = 'Verified signature from $sender.';


### PR DESCRIPTION
Saw this was a feature slated for the 1.2 release so I thought I might help out.

Edits do the following.

-before message is encrypted or signed, check if the "Attach public key" checkbox is checked.
-get the public key for the email address identified in the message header (allows for user to change identities during compose).
-insert the attachment through the Mail_mime object's addAttachment method
