### PR TITLE
mailbox/listing: Make server response for large mailbox listing faster (threaded view)

### DIFF
--- a/program/lib/Roundcube/rcube_result_thread.php
+++ b/program/lib/Roundcube/rcube_result_thread.php
@@ -242,22 +242,10 @@ class rcube_result_thread
             return;
         }
 
+        $raw_data_reverse = implode(self::SEPARATOR_ELEMENT, array_reverse(explode(self::SEPARATOR_ELEMENT, $this->raw_data)));
+        $this->raw_data = $raw_data_reverse;
+
         $this->meta['pos'] = array();
-        $datalen = strlen($this->raw_data);
-        $result  = '';
-        $start   = 0;
-
-        while (($pos = @strpos($this->raw_data, self::SEPARATOR_ELEMENT, $start))
-            || ($start < $datalen && ($pos = $datalen))
-        ) {
-            $len   = $pos - $start;
-            $elem  = substr($this->raw_data, $start, $len);
-            $start = $pos + 1;
-
-            $result = $elem . self::SEPARATOR_ELEMENT . $result;
-        }
-
-        $this->raw_data = rtrim($result, self::SEPARATOR_ELEMENT);
     }
 
     /**


### PR DESCRIPTION
# Symptom

When using roundcube with mailboxes with over 60k messages, list
view was way faster than viewing in threaded view.

Mailbox index view timing:    ~360 ms
Mailbox threaded view timing: ~800 ms
# Resolution

Use native PHP array manipulation functions instead of rolling custom
string data reversal implementation using strpos() and substr() in a
'while' loop.

This optimization is already present in index view handler, but was missing
from threaded view.
# Results after optimization

Both average out around ~360 ms response time.

b.

PS: Could this be merged into 1.1 branch also? Tnx.
