### PR TITLE
Enhancement: make default search scope configurable

### DIFF
--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -1153,6 +1153,13 @@ $config['force_7bit'] = false;
 // Please note that folder names should to be in sync with $config['*_mbox'] options
 $config['search_mods'] = null;  // Example: array('*' => array('subject'=>1, 'from'=>1), 'Sent' => array('subject'=>1, 'to'=>1));
 
+// Defaults of the search field configuration - scope
+// Available options:
+// - 'base': search only the current mailbox (defaut)
+// - 'sub':  search current and subordinate mailboxes
+// - 'all':  search all mailboxes (recommended if your IMAP server has good search capability - SOLR or similar)
+$config['search_scope'] = 'base';
+
 // Defaults of the addressbook search field configuration.
 $config['addressbook_search_mods'] = null;  // Example: array('name'=>1, 'firstname'=>1, 'surname'=>1, 'email'=>1, '*'=>1);
 

--- a/program/steps/mail/func.inc
+++ b/program/steps/mail/func.inc
@@ -66,8 +66,12 @@ if (empty($RCMAIL->action) || $RCMAIL->action == 'list') {
     if (empty($RCMAIL->action)) {
         $OUTPUT->set_env('search_mods', rcmail_search_mods());
 
-        if (!empty($_SESSION['search_scope']))
+        if (!empty($_SESSION['search_scope'])) {
             $OUTPUT->set_env('search_scope', $_SESSION['search_scope']);
+        }
+        else {
+            $OUTPUT->set_env('search_scope', $RCMAIL->config->get('search_scope'));
+        }
 
         rcmail_list_pagetitle();
     }


### PR DESCRIPTION
Reason:
When underlying IMAP server provides a decent search implementation (i.e.
SOLR), which searches instantly across all indexed content, searching only
current mailbox by default is inconvenient and also unexpected.

Large commercial (or free but not open source) webmail solutions have made
users depend on good search capability which instantly searches across all
mail messages the user has in their account (in all mailboxes in RC's terms).
To make RC more appealing to those users (or less repulsive), having decent
default search settings is a must.
