### PR TITLE
Fix ldap connection use after release in password plugin

### DIFF
--- a/plugins/password/drivers/ldap.php
+++ b/plugins/password/drivers/ldap.php
@@ -187,12 +187,14 @@ class rcube_ldap_password
         );
 
         $result = $ldap->search($base, $filter, $options);
-        $ldap->done();
         if (is_a($result, 'PEAR_Error') || ($result->count() != 1)) {
+            $ldap->done();
             return '';
         }
+        $userDN = $result->current()->dn();
+        $ldap->done();
 
-        return $result->current()->dn();
+        return $userDN;
     }
 
     /**


### PR DESCRIPTION
After the done() call the ldap connection resource is released and calls on the associated ldap search result object in $result will return FALSE. This prevents _any_ user lookups (at least for us). This PR fixes it by releasing the connection after getting the wanted results.
