### PR TITLE
Password plugin, cPanel driver

### DIFF
--- a/plugins/password/config.inc.php.dist
+++ b/plugins/password/config.inc.php.dist
@@ -309,7 +309,9 @@ $config['password_cpanel_username'] = 'username';
 $config['password_cpanel_password'] = 'password';
 
 // The cPanel admin hash
-// If you prefer to use a hash instead of plain password, enter it below. Hash takes precedence over password auth
+// If you prefer to use a hash (Remote Access Key) instead of plain password, enter it below.
+// Hash takes precedence over password auth.
+// You can generate a Remote Access Key in WHM -> Clusters -> Remote Access Key
 $config['password_cpanel_hash'] = '';
 
 // The cPanel port to use

--- a/plugins/password/config.inc.php.dist
+++ b/plugins/password/config.inc.php.dist
@@ -25,9 +25,10 @@ $config['password_log'] = false;
 // will be not available (no Password tab in Settings)
 $config['password_login_exceptions'] = null;
 
-// Array of hosts that support password changing. Default is NULL.
+// Array of hosts that support password changing.
 // Listed hosts will feature a Password option in Settings; others will not.
 // Example: array('mail.example.com', 'mail2.example.org');
+// Default is NULL (all hosts supported).
 $config['password_hosts'] = null;
 
 // Enables saving the new password even if it matches the old password. Useful
@@ -306,6 +307,10 @@ $config['password_cpanel_username'] = 'username';
 
 // The cPanel admin password
 $config['password_cpanel_password'] = 'password';
+
+// The cPanel admin hash
+// If you prefer to use a hash instead of plain password, enter it below. Hash takes precedence over password auth
+$config['password_cpanel_hash'] = '';
 
 // The cPanel port to use
 $config['password_cpanel_port'] = 2087;

--- a/plugins/password/drivers/cpanel.php
+++ b/plugins/password/drivers/cpanel.php
@@ -46,12 +46,12 @@ class rcube_cpanel_password
         $this->xmlapi = new xmlapi($rcmail->config->get('password_cpanel_host'));
         $this->xmlapi->set_port($rcmail->config->get('password_cpanel_port'));
         // Hash auth
-        if (!empty($rcmail->config->get('password_cpanel_hash'))) {
-            $this->xmlapi->hash_auth( $this->cuser, $rcmail->config->get('password_cpanel_hash'));
+        if (!empty($cpanel_hash = $rcmail->config->get('password_cpanel_hash'))) {
+            $this->xmlapi->hash_auth( $this->cuser, $cpanel_hash);
         }
         // Pass auth
-        else if (!empty($rcmail->config->get('password_cpanel_password'))) {
-            $this->xmlapi->hash_auth( $this->cuser, $rcmail->config->get('password_cpanel_password'));
+        else if (!empty($cpanel_password = $rcmail->config->get('password_cpanel_password'))) {
+            $this->xmlapi->hash_auth( $this->cuser, $cpanel_password);
         }
         else {
             return false;

--- a/plugins/password/drivers/cpanel.php
+++ b/plugins/password/drivers/cpanel.php
@@ -45,22 +45,19 @@ class rcube_cpanel_password
         // Setup the xmlapi connection
         $this->xmlapi = new xmlapi($rcmail->config->get('password_cpanel_host'));
         $this->xmlapi->set_port($rcmail->config->get('password_cpanel_port'));
-		
-		// Hash auth
-		if ( ! empty ( $rcmail->config->get( 'password_cpanel_hash' ) ) ) {
-			$this->xmlapi->hash_auth( $this->cuser, $rcmail->config->get( 'password_cpanel_hash' ) );
+        // Hash auth
+		if (!empty($rcmail->config->get('password_cpanel_hash'))) {
+		    $this->xmlapi->hash_auth( $this->cuser, $rcmail->config->get('password_cpanel_hash'));
 		}
-		
 		// Pass auth
-		else if ( ! empty ( $rcmail->config->get( 'password_cpanel_password' ) ) ) {
-			$this->xmlapi->hash_auth( $this->cuser, $rcmail->config->get( 'password_cpanel_password' ) );
+		else if (!empty($rcmail->config->get('password_cpanel_password'))) {
+		    $this->xmlapi->hash_auth( $this->cuser, $rcmail->config->get('password_cpanel_password'));
 		}
-		
 		else {
-			return false;
+		    return false;
 		}
 		
-        $this->xmlapi->set_output('json');
+		$this->xmlapi->set_output('json');
         $this->xmlapi->set_debug(0);
 
         return $this->setPassword($_SESSION['username'], $newpass);
@@ -93,7 +90,7 @@ class rcube_cpanel_password
 		}
 		$cpanel_user = $query['acct'][0]['user'];
 
-        $query = $this->xmlapi->api2_query( $cpanel_user, 'Email', 'passwdpop', $data );
+        $query = $this->xmlapi->api2_query($cpanel_user, 'Email', 'passwdpop', $data);
         $query  = json_decode($query, true);
         $result = $query['cpanelresult']['data'][0];
 

--- a/plugins/password/drivers/cpanel.php
+++ b/plugins/password/drivers/cpanel.php
@@ -45,7 +45,21 @@ class rcube_cpanel_password
         // Setup the xmlapi connection
         $this->xmlapi = new xmlapi($rcmail->config->get('password_cpanel_host'));
         $this->xmlapi->set_port($rcmail->config->get('password_cpanel_port'));
-        $this->xmlapi->password_auth($this->cuser, $rcmail->config->get('password_cpanel_password'));
+		
+		// Hash auth
+		if ( ! empty ( $rcmail->config->get( 'password_cpanel_hash' ) ) ) {
+			$this->xmlapi->hash_auth( $this->cuser, $rcmail->config->get( 'password_cpanel_hash' ) );
+		}
+		
+		// Pass auth
+		else if ( ! empty ( $rcmail->config->get( 'password_cpanel_password' ) ) ) {
+			$this->xmlapi->hash_auth( $this->cuser, $rcmail->config->get( 'password_cpanel_password' ) );
+		}
+		
+		else {
+			return false;
+		}
+		
         $this->xmlapi->set_output('json');
         $this->xmlapi->set_debug(0);
 
@@ -70,8 +84,16 @@ class rcube_cpanel_password
         }
 
         $data['password'] = $password;
+		
+		// Get the cPanel user
+		$query = $this->xmlapi->listaccts( 'domain', $data['domain'] );
+		$query = json_decode( $query, true );
+		if ( $query['status'] != 1 ) {
+			return false;
+		}
+		$cpanel_user = $query['acct'][0]['user'];
 
-        $query  = $this->xmlapi->api2_query($this->cuser, 'Email', 'passwdpop', $data);
+        $query = $this->xmlapi->api2_query( $cpanel_user, 'Email', 'passwdpop', $data );
         $query  = json_decode($query, true);
         $result = $query['cpanelresult']['data'][0];
 

--- a/plugins/password/drivers/cpanel.php
+++ b/plugins/password/drivers/cpanel.php
@@ -46,18 +46,18 @@ class rcube_cpanel_password
         $this->xmlapi = new xmlapi($rcmail->config->get('password_cpanel_host'));
         $this->xmlapi->set_port($rcmail->config->get('password_cpanel_port'));
         // Hash auth
-		if (!empty($rcmail->config->get('password_cpanel_hash'))) {
-		    $this->xmlapi->hash_auth( $this->cuser, $rcmail->config->get('password_cpanel_hash'));
-		}
-		// Pass auth
-		else if (!empty($rcmail->config->get('password_cpanel_password'))) {
-		    $this->xmlapi->hash_auth( $this->cuser, $rcmail->config->get('password_cpanel_password'));
-		}
-		else {
-		    return false;
-		}
-		
-		$this->xmlapi->set_output('json');
+        if (!empty($rcmail->config->get('password_cpanel_hash'))) {
+            $this->xmlapi->hash_auth( $this->cuser, $rcmail->config->get('password_cpanel_hash'));
+        }
+        // Pass auth
+        else if (!empty($rcmail->config->get('password_cpanel_password'))) {
+            $this->xmlapi->hash_auth( $this->cuser, $rcmail->config->get('password_cpanel_password'));
+        }
+        else {
+            return false;
+        }
+        
+        $this->xmlapi->set_output('json');
         $this->xmlapi->set_debug(0);
 
         return $this->setPassword($_SESSION['username'], $newpass);
@@ -81,14 +81,14 @@ class rcube_cpanel_password
         }
 
         $data['password'] = $password;
-		
-		// Get the cPanel user
-		$query = $this->xmlapi->listaccts( 'domain', $data['domain'] );
-		$query = json_decode( $query, true );
-		if ( $query['status'] != 1 ) {
-			return false;
-		}
-		$cpanel_user = $query['acct'][0]['user'];
+        
+        // Get the cPanel user
+        $query = $this->xmlapi->listaccts( 'domain', $data['domain'] );
+        $query = json_decode( $query, true );
+        if ( $query['status'] != 1 ) {
+            return false;
+        }
+        $cpanel_user = $query['acct'][0]['user'];
 
         $query = $this->xmlapi->api2_query($cpanel_user, 'Email', 'passwdpop', $data);
         $query  = json_decode($query, true);


### PR DESCRIPTION
Add support for hash auth (cPanel Remote Access Key) in the Password plugin's cPanel driver and call the $xmlapi->listaccts() method to retrieve the cPanel account user that owns the domain (required for cPanel reseller accounts).
