### PR TITLE
Support SMTPUTF8, relax email address validation

### DIFF
--- a/program/lib/Roundcube/rcube_smtp.php
+++ b/program/lib/Roundcube/rcube_smtp.php
@@ -223,15 +223,31 @@ class rcube_smtp
             return false;
         }
 
+        $exts = $this->conn->getServiceExtensions();
+
         // RFC3461: Delivery Status Notification
         if ($opts['dsn']) {
-            $exts = $this->conn->getServiceExtensions();
-
             if (isset($exts['DSN'])) {
                 $from_params      = 'RET=HDRS';
                 $recipient_params = 'NOTIFY=SUCCESS,FAILURE';
             }
         }
+        //RFC6531: request smtputf8 if needed
+        if (
+            !mb_check_encoding($from,'ASCII') ||
+            !mb_check_encoding($recipients,'ASCII')
+        ) {
+            if (isset($exts['SMTPUTF8'])) {
+                if (!empty($from_params)) {
+                    $from_params .= ' ';
+                }
+                $from_params .= 'SMTPUTF8';
+             }
+             else {
+                 return false;
+             }
+        }
+
 
         // RFC2298.3: remove envelope sender address
         if (empty($opts['mdn_use_from'])

--- a/program/lib/Roundcube/rcube_utils.php
+++ b/program/lib/Roundcube/rcube_utils.php
@@ -61,7 +61,7 @@ class rcube_utils
     public static function check_email($email, $dns_check=true)
     {
         // Check for invalid characters
-        if (preg_match('/[\x00-\x1F\x7F-\xFF]/', $email)) {
+        if (preg_match('/\p{Cc}/u', $email)) {
             return false;
         }
 
@@ -80,14 +80,30 @@ class rcube_utils
         $domain_part = array_pop($email_array);
         $local_part  = implode('@', $email_array);
 
-        // from PEAR::Validate
-        $regexp = '&^(?:
-            ("\s*(?:[^"\f\n\r\t\v\b\s]+\s*)+")|                             #1 quoted name
-            ([-\w!\#\$%\&\'*+~/^`|{}=]+(?:\.[-\w!\#\$%\&\'*+~/^`|{}=]+)*))  #2 OR dot-atom (RFC5322)
-            $&xi';
-
-        if (!preg_match($regexp, $local_part)) {
+        // XXX RFC states that ".." is not allowed in a local-part
+        // of an email address, but apparently gmail allows it.
+        if(preg_match('/^\.|\.$|\.\./',$local_part)) {
             return false;
+        }
+
+        $local_subparts;
+        preg_match_all('/"(?:\\\\.|[^\\\\"])*"|[^\.]+/',$local_part,$local_subparts);
+
+        foreach ($local_subparts[0] as $l) {
+            if(substr($l,0,1) == '"') {
+                // quoted-string, make sure all backslashes and quotes are
+                // escaped
+                $local_quoted = preg_replace('/\\\\(\\\\|\")/','',substr($l,1,-1));
+                if(preg_match('/\\\\|"/',$local_quoted)) {
+                    return false;
+                }
+            }
+            else {
+                // dot-atom portion, make sure there's no prohibited characters
+                if(preg_match('/[\\ ",:;<>@]/',$l)) {
+                    return false;
+                }
+            }
         }
 
         // Validate domain part

--- a/program/lib/Roundcube/rcube_utils.php
+++ b/program/lib/Roundcube/rcube_utils.php
@@ -82,7 +82,7 @@ class rcube_utils
 
         // XXX RFC states that ".." is not allowed in a local-part
         // of an email address, but apparently gmail allows it.
-        if(preg_match('/^\.|\.$|\.\./',$local_part)) {
+        if(preg_match('/^\.|\.$/',$local_part)) {
             return false;
         }
 


### PR DESCRIPTION
If the FROM/TO portions of an email use non-ASCII characters,
check that the SMTP server supports the SMTPUTF8 extension.

Additionally, change some rules for parsing email addresses to
allow for more characters. Basically, SMTPUTF8 makes
nearly any printable character into a valid character in an
email address local part.
