### PR TITLE
Fixes 'nobodywarning' on sending mailvelope mails

### DIFF
--- a/program/js/app.js
+++ b/program/js/app.js
@@ -4305,8 +4305,8 @@ function rcube_webmail()
       return false;
     }
 
-    // check for empty body
-    if (!this.editor.get_content() && !confirm(this.get_label('nobodywarning'))) {
+    // check for empty body (only possible if not mailvelope encrypted)
+    if (!this.mailvelope_editor && !this.editor.get_content() && !confirm(this.get_label('nobodywarning'))) {
       this.editor.focus();
       return false;
     }


### PR DESCRIPTION
Previously the `nobodywarning` was issued on sending a mailvelope encrypted mail. This didn't appeared if there was content in the textarea before enabling encryption for this mail.

Checking if a mailvelope encrypted mail is empty should be impossible.
