### PR TITLE
Add new hook to modify head fields order

### DIFF
--- a/program/steps/addressbook/func.inc
+++ b/program/steps/addressbook/func.inc
@@ -573,6 +573,10 @@ function rcmail_contact_form($form, $record, $attrib = null)
                 'jobtitle'     => array('jobtitle'),
             );
 
+            // Allow plugins to modify order of the contact form head fields
+            $plugin = $RCMAIL->plugins->exec_hook('contact_form_field_blocks', array('field_blocks' => $field_blocks));
+            $field_blocks = $plugin['field_blocks'];
+
             foreach ($field_blocks as $blockname => $colnames) {
                 $fields = '';
                 foreach ($colnames as $col) {


### PR DESCRIPTION
Add hook to allow plugins to modify order of the contact form head fields

With this hook a plugin can change the order of the contact form head fields from
`'names'    => array('prefix','firstname','middlename','surname','suffix'),`
to eg.:
`'names'    => array('prefix','surname','firstname','middlename','suffix'),`
or any other language dependent special order.
