### PR TITLE
Fixed fetching photo for non primary email

### DIFF
--- a/program/steps/addressbook/photo.inc
+++ b/program/steps/addressbook/photo.inc
@@ -40,7 +40,7 @@ else {
     if ($email = rcube_utils::get_input_value('_email', rcube_utils::INPUT_GPC)) {
         foreach ($RCMAIL->get_address_sources() as $s) {
             $abook = $RCMAIL->get_address_book($s['id']);
-            $result = $abook->search(array('email'), $email, 1, true, true, 'photo');
+            $result = $abook->search(array('email'), array($email), 1, true, true, 'photo');
             while ($result && ($record = $result->iterate())) {
                 if ($record['photo'])
                     break 2;


### PR DESCRIPTION
Now fails to fetch a profile photo when its not the primary e-mail (first contact e-mail).
Changed to a different type of search.
