### PR TITLE
Honor dont_override setting for plugin config

### DIFF
--- a/program/lib/Roundcube/rcube_config.php
+++ b/program/lib/Roundcube/rcube_config.php
@@ -425,6 +425,12 @@ class rcube_config
     public function merge($prefs)
     {
         $prefs = $this->fix_legacy_props($prefs);
+        // Honor the dont_override setting for any existing user preferences
+        if(is_array($prefs['dont_override']) && !empty($prefs['dont_override'])) {
+            foreach ($prefs['dont_override'] as $key) {
+                unset($this->userprefs[$key]);
+            }
+        }
         $this->prop = array_merge($this->prop, $prefs, $this->userprefs);
     }
 


### PR DESCRIPTION
Because I like to have the configuration of my plugins all in once place, this fix would help me do that. But maybe this is a security concern, as a plugin can now override all user preferences with it's own default values. Let me know what you think.
