### PR TITLE
Add $field_blocks to contact_form hook

### DIFF
--- a/program/steps/addressbook/func.inc
+++ b/program/steps/addressbook/func.inc
@@ -516,15 +516,26 @@ function rcmail_contact_form($form, $record, $attrib = null)
 {
     global $RCMAIL;
 
+    // group fields
+    $field_blocks = array(
+        'names'        => array('prefix','firstname','middlename','surname','suffix'),
+        'displayname'  => array('name'),
+        'nickname'     => array('nickname'),
+        'organization' => array('organization'),
+        'department'   => array('department'),
+        'jobtitle'     => array('jobtitle'),
+    );
+
     // Allow plugins to modify contact form content
     $plugin = $RCMAIL->plugins->exec_hook('contact_form', array(
-        'form' => $form, 'record' => $record));
+        'form' => $form, 'record' => $record, 'field_blocks' => $field_blocks));
 
-    $form       = $plugin['form'];
-    $record     = $plugin['record'];
-    $edit_mode  = $RCMAIL->action != 'show' && $RCMAIL->action != 'print';
-    $del_button = $attrib['deleteicon'] ? html::img(array('src' => $RCMAIL->output->get_skin_file($attrib['deleteicon']), 'alt' => $RCMAIL->gettext('delete'))) : $RCMAIL->gettext('delete');
-    $out        = '';
+    $form         = $plugin['form'];
+    $record       = $plugin['record'];
+    $field_blocks = $plugin['field_blocks']
+    $edit_mode    = $RCMAIL->action != 'show' && $RCMAIL->action != 'print';
+    $del_button   = $attrib['deleteicon'] ? html::img(array('src' => $RCMAIL->output->get_skin_file($attrib['deleteicon']), 'alt' => $RCMAIL->gettext('delete'))) : $RCMAIL->gettext('delete');
+    $out          = '';
 
     unset($attrib['deleteicon']);
 
@@ -562,16 +573,6 @@ function rcmail_contact_form($form, $record, $attrib = null)
             if ($record['name'] == rcube_addressbook::compose_display_name(array('name' => '') + (array)$record)) {
                 unset($record['name']);
             }
-
-            // group fields
-            $field_blocks = array(
-                'names'        => array('prefix','firstname','middlename','surname','suffix'),
-                'displayname'  => array('name'),
-                'nickname'     => array('nickname'),
-                'organization' => array('organization'),
-                'department'   => array('department'),
-                'jobtitle'     => array('jobtitle'),
-            );
 
             foreach ($field_blocks as $blockname => $colnames) {
                 $fields = '';

--- a/program/steps/addressbook/func.inc
+++ b/program/steps/addressbook/func.inc
@@ -517,7 +517,7 @@ function rcmail_contact_form($form, $record, $attrib = null)
     global $RCMAIL;
 
     // group fields
-    $field_blocks = array(
+    $head_fields = array(
         'names'        => array('prefix','firstname','middlename','surname','suffix'),
         'displayname'  => array('name'),
         'nickname'     => array('nickname'),
@@ -528,14 +528,14 @@ function rcmail_contact_form($form, $record, $attrib = null)
 
     // Allow plugins to modify contact form content
     $plugin = $RCMAIL->plugins->exec_hook('contact_form', array(
-        'form' => $form, 'record' => $record, 'field_blocks' => $field_blocks));
+        'form' => $form, 'record' => $record, 'head_fields' => $head_fields));
 
-    $form         = $plugin['form'];
-    $record       = $plugin['record'];
-    $field_blocks = $plugin['field_blocks']
-    $edit_mode    = $RCMAIL->action != 'show' && $RCMAIL->action != 'print';
-    $del_button   = $attrib['deleteicon'] ? html::img(array('src' => $RCMAIL->output->get_skin_file($attrib['deleteicon']), 'alt' => $RCMAIL->gettext('delete'))) : $RCMAIL->gettext('delete');
-    $out          = '';
+    $form        = $plugin['form'];
+    $record      = $plugin['record'];
+    $head_fields = $plugin['head_fields']
+    $edit_mode   = $RCMAIL->action != 'show' && $RCMAIL->action != 'print';
+    $del_button  = $attrib['deleteicon'] ? html::img(array('src' => $RCMAIL->output->get_skin_file($attrib['deleteicon']), 'alt' => $RCMAIL->gettext('delete'))) : $RCMAIL->gettext('delete');
+    $out         = '';
 
     unset($attrib['deleteicon']);
 
@@ -574,7 +574,7 @@ function rcmail_contact_form($form, $record, $attrib = null)
                 unset($record['name']);
             }
 
-            foreach ($field_blocks as $blockname => $colnames) {
+            foreach ($head_fields as $blockname => $colnames) {
                 $fields = '';
                 foreach ($colnames as $col) {
                     // skip cols unknown to the backend


### PR DESCRIPTION
Add $field_blocks to contact_form hook, so plugins can change the order of the fields: https://github.com/roundcube/roundcubemail/pull/5281
