### PR TITLE
Do not mask fatal error when unable to load PEAR class

### DIFF
--- a/program/lib/Roundcube/bootstrap.php
+++ b/program/lib/Roundcube/bootstrap.php
@@ -99,7 +99,7 @@ if (!preg_match($regexp, $path)) {
 spl_autoload_register('rcube_autoload');
 
 // set PEAR error handling (will also load the PEAR main class)
-@PEAR::setErrorHandling(PEAR_ERROR_CALLBACK, 'rcube_pear_error');
+PEAR::setErrorHandling(PEAR_ERROR_CALLBACK, 'rcube_pear_error');
 
 
 


### PR DESCRIPTION
A failure to load PEAR consistutes a fatal PHP error, and @-loading it prevents that error from being logged, making debugging problems with loading the PEAR class really difficult. It should therefore be loaded without the @ sign, allowing the fatal error to end up in the logs, if it occurs.
