### PR TITLE
HAproxy protocol header support for IMAP connections

### DIFF
--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -144,11 +144,21 @@ $config['imap_auth_type'] = null;
 // IMAP socket context options
 // See http://php.net/manual/en/context.ssl.php
 // The example below enables server certificate validation
+//
+// proxy_protocol is used to inject HAproxy style headers in the TCP stream
+// See http://www.haproxy.org/download/1.6/doc/proxy-protocol.txt
 //$config['imap_conn_options'] = array(
 //  'ssl'         => array(
 //     'verify_peer'  => true,
 //     'verify_depth' => 3,
 //     'cafile'       => '/etc/openssl/certs/ca.crt',
+//   ),
+//  'proxy_protocol' => 1 | 2 | array ( // required (either version number (1|2) or array with 'version' key)
+//       'version'       => 1 | 2, // required, if array
+//       'remote_addr'   => $_SERVER['REMOTE_ADDR'],
+//       'remote_port'   => $_SERVER['REMOTE_PORT'],
+//       'local_addr'    => $_SERVER['SERVER_ADDR'],
+//       'local_port'    => $_SERVER['SERVER_PORT'],
 //   ),
 // );
 $config['imap_conn_options'] = null;

--- a/program/lib/Roundcube/rcube_imap_generic.php
+++ b/program/lib/Roundcube/rcube_imap_generic.php
@@ -958,6 +958,14 @@ class rcube_imap_generic
             return false;
         }
 
+        // insert proxy protocol header, if enabled
+        if (!empty($this->prefs['socket_options'])) {
+            $proxy_protocol_header = rcube_utils::proxy_protocol_header($this->prefs['socket_options'], $this->fp);
+            if (strlen($proxy_protocol_header) > 0) {
+                fwrite($this->fp, $proxy_protocol_header);
+            }
+        }
+        
         if ($this->prefs['timeout'] > 0) {
             stream_set_timeout($this->fp, $this->prefs['timeout']);
         }


### PR DESCRIPTION
Introduce optional support to inject PROXY protocol headers after
opening IMAP TCP streams.

Version 1 (text based) and version 2 (binary) protocol header types are
supported. Supports both IPv4 and IPv6 style headers.

http://www.haproxy.org/download/1.6/doc/proxy-protocol.txt
