### PR TITLE
Avoid PHP fatal error with LDAP object

### DIFF
--- a/program/lib/Roundcube/rcube_ldap.php
+++ b/program/lib/Roundcube/rcube_ldap.php
@@ -932,7 +932,7 @@ class rcube_ldap extends rcube_addressbook
         $result = $this->ldap->search($base_dn, $prop['filter'], $prop['scope'], $attrs, $prop, $count);
 
         // we have a search result resource, get all entries
-        if (!$count && $result && $result->count() > 0) {
+        if (!$count && $result) {
             $result = $result->entries();
             unset($result['count']);
         }


### PR DESCRIPTION
After last change to file `rcube_ldap.php`, my roundcube instance was getting this error:

```
PHP Fatal error:  Cannot use object of type Net_LDAP3_Result as array in ...
```

In

``` php
protected function extended_search($count = false)
```

`$result = $this->ldap->search()` returns an LDAP object.
If the search returns no results (and if `$is_extended_search` is false), then it gets to line 971 trying to do a `usort()` and then a `count()` on an object, instead of an array.
