### PR TITLE
Remove deprecated function flattenImages

### DIFF
--- a/program/lib/Roundcube/rcube_image.php
+++ b/program/lib/Roundcube/rcube_image.php
@@ -166,7 +166,10 @@ class rcube_image
                     else {
                         try {
                             $image = new Imagick($this->image_file);
-                            $image = $image->flattenImages();
+                            
+                            $image->setImageBackgroundColor('white');
+                            $image->setImageAlphaChannel(11);
+                            $image->mergeImageLayers(Imagick::LAYERMETHOD_FLATTEN);
 
                             $image->setImageColorspace(Imagick::COLORSPACE_SRGB);
                             $image->setImageCompressionQuality(75);


### PR DESCRIPTION
flattenImages in imagick is deprecated since php 5.6. 
`PHP Deprecated:  Imagick::flattenImages method is deprecated and it's use should be avoided`

Proposed solution works with imagick 3.1.0+.
11 is used as an alternative to `Imagick::ALPHACHANNEL_REMOVE` which was added in imagick 3.2.0.
