### PR TITLE
Properly set the memcache debug log file name

### DIFF
--- a/program/lib/Roundcube/rcube_session_memcache.php
+++ b/program/lib/Roundcube/rcube_session_memcache.php
@@ -174,6 +174,6 @@ class rcube_session_memcache extends rcube_session
             $line .= ' ' . $data;
         }
 
-        rcube::debug($this->type, $line, $result);
+        rcube::debug('memcache', $line, $result);
     }
 }


### PR DESCRIPTION
Properly set the debug log file name ('memcache') as $this->type is undefined
