### PR TITLE
Fix class in keys list

### DIFF
--- a/plugins/enigma/skins/larry/templates/keys.html
+++ b/plugins/enigma/skins/larry/templates/keys.html
@@ -42,7 +42,7 @@
     <div id="settings-right" role="main" aria-labelledby="aria-label-enigmakeyslist">
         <div id="enigmakeyslist" class="uibox listbox" role="navigation" aria-labelledby="enigmakeyslist-header">
             <div id="enigmakeyslist-header" class="boxtitle"><roundcube:label name="enigma.enigmakeys" /></div>
-            <div class="scroller winfooter">
+            <div class="scroller withfooter">
                 <roundcube:object name="keyslist" id="keys-table" class="listing" role="listbox" cellspacing="0" noheader="true" />
             </div>
             <div class="boxpagenav">


### PR DESCRIPTION
The last few keys were being cut off due to a typo.
