### PR TITLE
SQL, upgrade: increase session table ip field size for IPv6 addresses

### DIFF
--- a/SQL/mssql/2016100900.sql
+++ b/SQL/mssql/2016100900.sql
@@ -1,0 +1,2 @@
+ALTER TABLE [dbo].[session] ALTER COLUMN [ip] [varchar] (40) COLLATE Latin1_General_CI_AI NOT NULL
+GO

--- a/SQL/mysql/2016100900.sql
+++ b/SQL/mysql/2016100900.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `session` MODIFY `ip` varchar(40) NOT NULL;

--- a/SQL/oracle/2016100900.sql
+++ b/SQL/oracle/2016100900.sql
@@ -1,0 +1,1 @@
+ALTER TABLE session MODIFY ip varchar(41) NOT NULL;

--- a/SQL/postgres/2016100900.sql
+++ b/SQL/postgres/2016100900.sql
@@ -1,0 +1,1 @@
+ALTER TABLE session ALTER COLUMN ip TYPE character varying(41);


### PR DESCRIPTION
Commit 84d06edb06 introduced IPv6 support on SQL session table but
failed at providing upgrade SQL scripts, this commit fixes it.

Fixes: 84d06edb06 ("IPv6 Compatability")
Signed-off-by: Sylvain Rochet gradator@gradator.net
