### PR TITLE
password: Add missing quote in password_ldap_ppolicy_uri in config.inc.php.dist

### DIFF
--- a/plugins/password/config.inc.php.dist
+++ b/plugins/password/config.inc.php.dist
@@ -280,7 +280,7 @@ $config['password_ldap_ppolicy_cmd'] = 'change_ldap_pass.pl';
 
 // LDAP URI
 // Example: 'ldap://ldap.example.com/ ldaps://ldap2.example.com:636/'
-$config['password_ldap_ppolicy_uri'] = 'ldap://localhost/ ;
+$config['password_ldap_ppolicy_uri'] = 'ldap://localhost/';
 
 // LDAP base name (root directory)
 // Exemple: 'dc=exemple,dc=com'


### PR DESCRIPTION
This was introduced in 5322e91825e82b8548ec0cb9259d862d5a0b634a