### PR TITLE
Added support for %h and %d in poppassd host

### DIFF
--- a/plugins/password/config.inc.php.dist
+++ b/plugins/password/config.inc.php.dist
@@ -132,10 +132,17 @@ $config['password_hash_base64'] = false;
 
 // Poppassd Driver options
 // -----------------------
-// The host which changes the password
+// The host which changes the password (default: localhost)
+// Supported replacement variables:
+//   %n - hostname ($_SERVER['SERVER_NAME'])
+//   %t - hostname without the first part
+//   %d - domain (http hostname $_SERVER['HTTP_HOST'] without the first part)
+//   %h - IMAP host
+//   %z - IMAP domain without first part
+//   %s - domain name after the '@' from e-mail address provided at login screen
 $config['password_pop_host'] = 'localhost';
 
-// TCP port used for poppassd connections
+// TCP port used for poppassd connections (default: 106)
 $config['password_pop_port'] = 106;
 
 

--- a/plugins/password/drivers/poppassd.php
+++ b/plugins/password/drivers/poppassd.php
@@ -40,8 +40,12 @@ class rcube_poppassd_password
         $rcmail = rcmail::get_instance();
 //    include('Net/Socket.php');
         $poppassd = new Net_Socket();
+        
+        $host = $rcmail->config->get('password_pop_host');
+        $host = str_replace('%h', $_SESSION['imap_host'], $host);
+        $host = str_replace('%d', $rcmail->user->get_username('domain'), $host);
 
-        $result = $poppassd->connect($rcmail->config->get('password_pop_host'), $rcmail->config->get('password_pop_port'), null);
+        $result = $poppassd->connect($host, $rcmail->config->get('password_pop_port'), null);
         if (is_a($result, 'PEAR_Error')) {
             return $this->format_error_result(PASSWORD_CONNECT_ERROR, $result->getMessage());
         }

--- a/plugins/password/drivers/poppassd.php
+++ b/plugins/password/drivers/poppassd.php
@@ -41,11 +41,11 @@ class rcube_poppassd_password
 //    include('Net/Socket.php');
         $poppassd = new Net_Socket();
         
-        $host = $rcmail->config->get('password_pop_host');
-        $host = str_replace('%h', $_SESSION['imap_host'], $host);
-        $host = str_replace('%d', $rcmail->user->get_username('domain'), $host);
+        $host = $rcmail->config->get('password_pop_host', 'localhost');
+        $host = rcube_utils::parse_host($host);
+        $port = $rcmail->config->get('password_pop_port', 106)
 
-        $result = $poppassd->connect($host, $rcmail->config->get('password_pop_port'), null);
+        $result = $poppassd->connect($host, $port, null);
         if (is_a($result, 'PEAR_Error')) {
             return $this->format_error_result(PASSWORD_CONNECT_ERROR, $result->getMessage());
         }


### PR DESCRIPTION
With this modification, you can use %d and %h in $config['password_pop_host'] for referring the user's domain or imap host.