### PR TITLE
Add cPanel Webmail driver

### DIFF
--- a/plugins/password/README
+++ b/plugins/password/README
@@ -28,7 +28,9 @@
  2.3.  Poppassd/Courierpassd (poppassd)
  2.4.  LDAP (ldap)
  2.5.  DirectAdmin Control Panel (directadmin)
- 2.6.  cPanel (cpanel)
+ 2.6.  cPanel
+ 2.6.1.  cPanel WHM (cpanel)
+ 2.6.2.  cPanel Webmail (cpanel_webmail)
  2.7.  XIMSS/Communigate (ximms)
  2.8.  Virtualmin (virtualmin)
  2.9.  hMailServer (hmail)
@@ -190,14 +192,35 @@
  See config.inc.php.dist file for more info.
 
 
- 2.6. cPanel (cpanel)
- --------------------
+ 2.6. cPanel
+ -----------
+
+ cPanel offers various APIs. The `cpanel` driver is configured with and admin
+ account. It can change user's passwords without access to the current password.
+ See the next section.
+
+ The `cpanel_webmail` driver authenticates as the current user and does not need
+ an admin account. See 2.6.2.
+
+
+ 2.6.1. cPanel WHM (cpanel)
+ --------------------------
 
  Install cPanel XMLAPI Client Class into Roundcube program/lib directory
  or any other place in PHP include path. You can get the class from
  https://raw.github.com/CpanelInc/xmlapi-php/master/xmlapi.php
 
  You can configure parameters for connection to cPanel's API interface.
+ See config.inc.php.dist file for more info.
+
+
+ 2.6.2. cPanel Webmail (cpanel_webmail)
+ --------------------------------------
+
+ Specify the host to connect to via 'password_webmail_cpanel_host'. This driver
+ comes with a minimal UAPI implementation and does not use the external xmlapi
+ class.
+
  See config.inc.php.dist file for more info.
 
 

--- a/plugins/password/config.inc.php.dist
+++ b/plugins/password/config.inc.php.dist
@@ -353,6 +353,15 @@ $config['password_cpanel_hash'] = '';
 $config['password_cpanel_port'] = 2087;
 
 
+// cPanel Webmail Driver options
+// -----------------------------
+// The cPanel Host name
+$config['password_cpanel_webmail_host'] = 'host.domain.com';
+
+// The cPanel port to use
+$config['password_cpanel_webmail_port'] = 2096;
+
+
 // XIMSS (Communigate server) Driver options
 // -----------------------------------------
 // Host name of the Communigate server

--- a/plugins/password/drivers/cpanel_webmail.php
+++ b/plugins/password/drivers/cpanel_webmail.php
@@ -1,0 +1,130 @@
+<?php
+
+/**
+ * cPanel Webmail Password Driver
+ *
+ * It uses Cpanel's Webmail UAPI to change the users password.
+ *
+ * This driver has been tested successfully with Digital Pacific hosting.
+ *
+ * @version 4.0
+ * @author Maikel Linke <maikel@email.org.au>
+ *
+ * Copyright (C) 2005-2016, The Roundcube Dev Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+class rcube_cpanel_webmail_password
+{
+    public function save($curpas, $newpass)
+    {
+        $user = $_SESSION['username'];
+        $userpwd = "$user:$curpas";
+        list($login) = split('@', $user);
+        $data = array(
+            'email' => $login,
+            'password' => $newpass
+        );
+        $url = self::url();
+        $response = $this->curl_auth_post($userpwd, $url, $data);
+        return self::decode_response($response);
+    }
+
+    /**
+     * Provides the UAPI URL of the Email::passwd_pop function.
+     *
+     * @return string HTTPS URL
+     */
+    public static function url()
+    {
+        $config = rcmail::get_instance()->config;
+        $storage_host = $_SESSION['storage_host'];
+
+        $host = $config->get('password_cpanel_webmail_host', $storage_host);
+        $port = $config->get('password_cpanel_webmail_port', 2096);
+
+        return "https://$host:$port/execute/Email/passwd_pop";
+    }
+
+    /**
+     * Converts a UAPI response to a password driver response.
+     *
+     * @param string $response JSON response by the Cpanel UAPI
+     * @return mixed response code or array
+     */
+    public static function decode_response($response)
+    {
+        $result = json_decode($response);
+
+        if ($result['status'] === 1) {
+            return PASSWORD_SUCCESS;
+        }
+
+        $errors = $result['errors'];
+        if (is_array($errors) && count($errors) > 0) {
+            return array(
+                'code' => PASSWORD_ERROR,
+                'message' => $errors[0],
+            );
+        }
+
+        return PASSWORD_ERROR;
+    }
+
+    /**
+     * Post data to the given URL using basic authentication.
+     *
+     * Example:
+     *
+     * <code>
+     * curl_auth_post('john:Secr3t', 'https://example.org', array(
+     *     'param' => 'value',
+     *     'param' => 'value'
+     * ));
+     * </code>
+     *
+     * @param string $userpwd user name and password separated by a colon
+     * <code>:</code>
+     * @param string $url the URL to post data to
+     * @param array $postdata the data to post
+     * @return string the body of the reply
+     * @throws Exception
+     */
+    private function curl_auth_post($userpwd, $url, $postdata)
+    {
+        $ch = curl_init();
+        $postfields = http_build_query($postdata, '', '&');
+
+        // see http://php.net/manual/en/function.curl-setopt.php
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($ch, CURLOPT_BUFFERSIZE, 131072);
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_POST, 1);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $postfields);
+        curl_setopt($ch, CURLOPT_USERPWD, $userpwd);
+
+        $result = curl_exec($ch);
+        $error = curl_error($ch);
+        curl_close($ch);
+
+        if ($result === false) {
+            throw new Exception("curl error: $error");
+        }
+
+        return $result;
+    }
+}


### PR DESCRIPTION
This driver does not use an admin account. It uses the user's account to
authenticate at the Webmail API. It uses the recommended UAPI and does
not rely on third-party classes.

@alecpl I wasn't sure about the readme part and the version number. What do you think?