### PR TITLE
Possibility of setting port and ssl by imap server

### DIFF
--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -153,6 +153,15 @@ $config['imap_auth_type'] = null;
 // );
 $config['imap_conn_options'] = null;
 
+// IMAP Possibility of setting port and ssl per host
+// $config['imap_hosts_config'] = array(
+//    'mail.domain.tld' => array(
+//       'port' => 993,
+//       'ssl' => 'ssl'
+//   )
+// );
+$config['imap_hosts_config'] = null;
+
 // IMAP connection timeout, in seconds. Default: 0 (use default_socket_timeout)
 $config['imap_timeout'] = 0;
 

--- a/program/include/rcmail.php
+++ b/program/include/rcmail.php
@@ -514,6 +514,7 @@ class rcmail extends rcube
         $default_port    = $this->config->get('default_port');
         $username_domain = $this->config->get('username_domain');
         $login_lc        = $this->config->get('login_lc', 2);
+        $imap_hosts_config = $this->config->get('imap_hosts_config');
 
         // check input for security (#1490500)
         if (($username_maxlen && strlen($username) > $username_maxlen)
@@ -609,6 +610,13 @@ class rcmail extends rcube
                 $this->login_error = self::ERROR_RATE_LIMIT;
                 return false;
             }
+        }
+
+        if (!empty($imap_hosts_config) && isset($imap_hosts_config[$host])) {
+            if (!empty($imap_hosts_config[$host]['port']))
+                $port = $imap_hosts_config[$host]['port'];
+            if (!empty($imap_hosts_config[$host]['ssl']))
+                $ssl = $imap_hosts_config[$host]['ssl'];
         }
 
         $storage = $this->get_storage();


### PR DESCRIPTION
This option is very important when webmail needs to connect to servers with different configurations:

for example:
$config['default_host'] = 'mail.%s';
$config['imap_hosts_config'] = array(
   'mail.b.com.br' => array(
      'port' => 993,
      'ssl' => 'ssl'
  )
);

User user@a.com.br connects with mail.a.com.br on port 143 without ssl
User user@b.com.br connects with mail.b.com.br on port 993 with ssl