### PR TITLE
Add mime type detection under FreeBSD and Apache 2.4

### DIFF
--- a/program/lib/Roundcube/rcube_mime.php
+++ b/program/lib/Roundcube/rcube_mime.php
@@ -779,6 +779,7 @@ class rcube_mime
             $file_paths[] = '/etc/nginx/mime.types';
             $file_paths[] = '/usr/local/etc/httpd/conf/mime.types';
             $file_paths[] = '/usr/local/etc/apache/conf/mime.types';
+            $file_paths[] = '/usr/local/etc/apache24/mime.types';
         }
 
         foreach ($file_paths as $fp) {


### PR DESCRIPTION
If you use FreeBSD 11 with Apache 2.4.x the default location of the file `mime.types` isn't one of the provided ones.