### PR TITLE
[WIP / POC] Add user export script / user import and export functionality

### DIFF
--- a/bin/userexport.sh
+++ b/bin/userexport.sh
@@ -1,6 +1,25 @@
 #!/usr/bin/env php
 <?php
 
+/*
+ +-----------------------------------------------------------------------+
+ | bin/userexport.sh                                                     |
+ |                                                                       |
+ | This file is part of the Roundcube Webmail client                     |
+ | Copyright (C) 2016, The Roundcube Dev Team                            |
+ |                                                                       |
+ | Licensed under the GNU General Public License version 3 or            |
+ | any later version with exceptions for skins & plugins.                |
+ | See the README file for a full license statement.                     |
+ |                                                                       |
+ | PURPOSE:                                                              |
+ |   Utility script to export user data to a database-independent        |
+ |   format for roundcube migrations.                                    |
+ +-----------------------------------------------------------------------+
+ | Author: Lukas Erlacher <luke@lerlacher.de>                            |
+ +-----------------------------------------------------------------------+
+*/
+
 define('INSTALL_PATH', realpath(__DIR__ . '/..') . '/' );
 ini_set('memory_limit', -1);
 
@@ -92,6 +111,17 @@ if (!isset($users) || empty($users)) {
         );
         // user identities
         $user_d['identities'] = $user->list_identities();
+        // user search
+        $user_d['searches'] = $user->list_searches();
+
+        // dictionary - loaded directly from db
+        $query = 'SELECT * FROM ' . $db->table_name('dictionary', true) . "WHERE `user_id` = ?";
+        $sql_result = $db->query($query, $user->ID);
+        $user_d['dictionary'] = array();
+        while ( $dict = $db->fetch_assoc($sql_result)) {
+            $user_d['dictionary'][] = $dict;
+        }
+
         // contact groups
         $contacts = new rcube_contacts($db, $user->ID);
         $groups = $contacts->list_groups();

--- a/bin/userexport.sh
+++ b/bin/userexport.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env php
+<?php
+
+define('INSTALL_PATH', realpath(__DIR__ . '/..') . '/' );
+ini_set('memory_limit', -1);
+
+require_once INSTALL_PATH.'program/include/clisetup.php';
+
+function print_usage()
+{
+	print "Usage:  userexport -u username -h host -l limit\n";
+	print "--user   IMAP user name\n";
+	print "--host   User IMAP host\n";
+	print "--limit  Limit\n";
+}
+
+// get arguments
+$opts = array('u' => 'user', 'h' => 'host', 'l' => 'limit');
+$args = rcube_utils::get_opt($opts);
+
+if ($_SERVER['argv'][1] == 'help')
+{
+	print_usage();
+	exit;
+}
+
+$rcmail = rcube::get_instance();
+
+// connect to DB
+$db = $rcmail->get_dbh();
+$db->db_connect('w');
+$transaction = false;
+
+if (!$db->is_connected() || $db->is_error()) {
+    _die("No DB connection\n" . $db->is_error());
+}
+
+print "Connected DB, querying...\n";
+
+// simple query for user
+if (!empty($args['user']) && !empty($args['host'])) {
+    print "Simple querying for ${args['user']}@${args['host']}\n";
+    $user = rcube_user::query($args['user'], $args['host']);
+    $users = [$user];
+} else {
+    print "Direct querying for ${args['user']}@${args['host']}\n";
+    $query = "SELECT * FROM " . $db->table_name('users', true);
+
+    print "Query:" . $query . "\n";
+    if (!empty($args['user'])) {
+        $query = $query . " WHERE `username` = ?";
+        $qarg = $args['user'];
+    } else if (!empty($args['mail_host'])) {
+        $query = $query . " WHERE `mail_host` = ?";
+        $qarg = $args['host'];
+    }
+    print "Query:" . $query . "\n";
+
+    if (isset($qarg)) {
+        if (!empty($args['limit'])) {
+            $sql_result = $db->limitquery($query, 0, (int)$args['limit'], $qarg);
+        } else {
+            $sql_result = $db->query($query, $qarg);
+        }
+    } else {
+        if (!empty($args['limit'])) {
+            $sql_result = $db->limitquery($query, 0, (int)$args['limit']);
+        } else {
+            $sql_result = $db->query($query);
+        }
+    }
+
+    $users = [];
+    while ($sql_arr = $db->fetch_assoc($sql_result)) {
+        $users[] = new rcube_user($sql_arr['user_id'], $sql_arr);
+    }
+}
+
+print "\n";
+
+if (!isset($users) || empty($users)) {
+    print "No users found!\n";
+} else {
+    $users_arr = [];
+    foreach ($users as $user) {
+        $user_d = [];
+        // user table
+        $user_d['user'] = array(
+            'user_id' => $user->ID,
+            'data' => $user->data,
+            'language' => $user->language,
+        );
+        // user identities
+        $user_d['identities'] = $user->list_identities();
+        // contact groups
+        $contacts = new rcube_contacts($db, $user->ID);
+        $groups = $contacts->list_groups();
+        $user_d['groups'] = $groups;
+
+        $c_records = $contacts->list_records();
+        foreach ($c_records as $record) {
+            $record_groups = $contacts->get_record_groups($record['ID']);
+            $user_d['contacts'][] = array(
+                'contact' => $record,
+                'groups' => $record_groups
+            );
+        }
+
+        $users_arr[] = $user_d;
+
+    }
+    //dump
+    print_r($users_arr);
+}
+

--- a/bin/userexport.sh
+++ b/bin/userexport.sh
@@ -27,11 +27,12 @@ require_once INSTALL_PATH.'program/include/clisetup.php';
 
 function print_usage()
 {
-	print "Usage:  userexport -f file -u username -h host -l limit\n";
-	print "--file   Output file\n";
-	print "--user   IMAP user name\n";
-	print "--host   User IMAP host\n";
-	print "--limit  Limit\n";
+	print "Usage:  userexport -f file -u username -h host -l limit -v\n";
+	print "--file       Output file\n";
+	print "--user       IMAP user name\n";
+	print "--host       User IMAP host\n";
+	print "--limit      Limit\n";
+	print "--verbose    Dump pretty-printed user records \n";
 }
 
 function vputs($str)
@@ -40,7 +41,7 @@ function vputs($str)
 	fwrite($out, $str);
 }
 // get arguments
-$opts = array('u' => 'user', 'h' => 'host', 'l' => 'limit', 'f' => 'file');
+$opts = array('u' => 'user', 'h' => 'host', 'l' => 'limit', 'f' => 'file', 'v' => 'verbose:');
 $args = rcube_utils::get_opt($opts);
 
 if ($_SERVER['argv'][1] == 'help')
@@ -155,6 +156,10 @@ if (!isset($users) || empty($users)) {
 
     foreach($users_arr as $user_rec) {
         fwrite($file, json_encode($user_rec) . "\n");
+
+        if ($args['verbose']) {
+            vputs(print_r($user_rec, true));
+        }
     }
 
     if (!empty($args['file'])) {

--- a/bin/userimport.sh
+++ b/bin/userimport.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env php
+<?php
+
+/*
+ +-----------------------------------------------------------------------+
+ | bin/userimport.sh                                                     |
+ |                                                                       |
+ | This file is part of the Roundcube Webmail client                     |
+ | Copyright (C) 2016, The Roundcube Dev Team                            |
+ |                                                                       |
+ | Licensed under the GNU General Public License version 3 or            |
+ | any later version with exceptions for skins & plugins.                |
+ | See the README file for a full license statement.                     |
+ |                                                                       |
+ | PURPOSE:                                                              |
+ |   Utility script to import data exported by userexport.sh.            |
+ |                                                                       |
+ +-----------------------------------------------------------------------+
+ | Author: Lukas Erlacher <luke@lerlacher.de>                            |
+ +-----------------------------------------------------------------------+
+*/
+
+define('INSTALL_PATH', realpath(__DIR__ . '/..') . '/' );
+ini_set('memory_limit', -1);
+
+require_once INSTALL_PATH.'program/include/clisetup.php';
+
+function print_usage()
+{
+	print "Usage:  userimport -f file -u username -h host -l limit -c -s -e\n";
+	print "--file       Input file\n";
+	print "--user       IMAP user name\n";
+	print "--host       User IMAP host\n";
+	print "--limit      Limit\n";
+	print "--clobber    Overwrite existing records without asking\n";
+	print "--safe       Skip existing records\n";
+	print "--ephemeral  Include ephemeral data (such as last_login)\n";
+}
+
+// get arguments
+$opts = array('u' => 'user', 'h' => 'host', 'l' => 'limit', 'f' => 'file', 'c' => 'clobber:', 's' => 'safe:', 'e': 'ephemeral:');
+$args = rcube_utils::get_opt($opts);
+
+if ($_SERVER['argv'][1] == 'help')
+{
+	print_usage();
+	exit;
+}
+
+if (!empty($args['file']))
+{
+    $file = fopen($args['file']);
+    if (!$file)
+    {
+        print "Could not open ${args['file']}.\n";
+        exit;
+    }
+} else {
+    if ($args['clobber'] !== true && $args['safe'] !== true)
+    {
+        print "Please specify clobber (-c) or safe (-s) mode to make this script noninteractive if you want to pass input via stdin.\n";
+        exit;
+    }
+    $file = STDIN;
+    print "Reading user records from stdin...\n";
+}
+
+$rcmail = rcube::get_instance();
+$config = $rcmail->config;
+
+// connect to DB
+$db = $rcmail->get_dbh();
+$db->db_connect('w');
+$transaction = false;
+
+if (!$db->is_connected() || $db->is_error()) {
+    _die("No DB connection\n" . $db->is_error());
+}
+
+print ("Connected to DB\n");
+
+while (($line = fgets($file)) !== false)
+{
+    // decode user
+    $record = json_decode($line);
+    $username = $record['user']['data']['username'];
+    $userhost = $record['user']['data']['mail_host'];
+
+    // check if user should be skipped
+    if (!empty($args['host']) && $args['host'] != $userhost)
+    {
+        continue;
+    } 
+    else if (!empty($args['user']) && $args['user'] != $username)
+    {
+        continue;
+    }
+
+    // does user exist?
+    $user = rcube_user::query($username, $userhost);
+
+    if ($user === false)
+    {
+        $user = rcube_user::create($username, $userhost);
+    }
+    else
+    {
+        // safe mode means skip existing users
+        if (!empty($args['safe']))
+        {
+            print "Skipping ${username}@${userhost}.\n";
+            continue;
+        }
+
+        // !clobber means ask
+        if (empty($args['clobber']))
+        {
+            print "WARNING: ${username}@${userhost} already exists in local roundcube DB.\n"
+            echo "Replace existing user? [y/N] ";
+            $clobber = strtolower(fgets(STDIN)[0]) == 'y';
+
+            if ($clobber !== true) {
+                print "Skipping ${username}@${userhost}.\n";
+                continue;
+            }
+        }
+
+        print "Clobbering existing user ${username}@${userhost}.\n";
+    }
+
+    // full steam ahead - will not check before clobbering past here
+
+    // direct user data
+    $userprefs = $record['user']['data']['preferences'];
+
+    $user->save_prefs($userprefs, true);
+
+    if ($args['ephemeral'])
+    {
+        $last_login = $record['user']['data']['last_login'];
+        $created = $record['user']['data']['last_login'];
+
+        $user->touch($last_login);
+
+        $db->query(
+            'UPDATE '.$db->table_name('users', true).
+            ' SET `created` = ? WHERE `user_id` = ?',
+            $created,
+            $user->ID
+        );
+
+    }
+
+    // identities
+    $current_idents = $user->list_identities();
+    $idents_map = array();
+
+    // hash by 'name' and 'email', if they match an import entry they will get overwritten
+    foreach ($current_idents as $ident)
+    {
+        $idents_map[$ident['name'] . '=!=' . $ident['email']] = $ident;
+    }
+
+    $import_idents = $record['identities'];
+
+    foreach($import_idents as $ident)
+    {
+        $hash = $ident['name'] . '=!=' . $ident['email'];
+        if (!empty($idents_map[$hash]))
+        {
+            $user->update_identity($idents_map[$hash]['identity_id'], $ident);
+        }
+        else
+        {
+            $user->insert_identity($ident);
+        }
+
+        // selecting the default identity works by inserting / updating a new identity
+        // with the `standard` column set and then unsetting `standard` from all other
+        // identities.
+        if ($ident['standard'] == 1)
+        {
+            $user->set_default($ident['identity_id']);
+        }
+    }
+
+    // contacts - import groups first
+    $import_groups = $record['groups'];
+    $contacts_manager = new rcube_contacts($db, $user->ID);
+    $current_groups = $contacts_manager->list_groups();
+
+    // groups do not need to be updated (they only have `name` column),
+    // only new groups added
+
+    // ID map that will be needed later for contact->group associations
+    // - keys: import data IDs
+    // - values: IDs in live database
+    $groups_idmap = array();
+
+    // hash on name only this time
+    $groups_map = array();
+    foreach($current_groups as $group)
+    {
+        $groups_map[$group['name']] = $group;
+    }
+
+    foreach($import_groups as $group)
+    {
+        $hash = $group['name'];
+        if (empty($groups_map[$hash]]))
+        {
+            $res = $contacts->create_group($hash);
+            $groups_idmap[$group['contactgroup_id']] = $res['id'];
+        }
+        else
+        {
+            $groups_idmap[$group['contactgroup_id']] = $groups_map[$hash]['contactgroup_id']
+        }
+    }
+
+    // now do actual contacts and group memberships
+    $import_contacts = $record['contacts'];
+    $current_contacts = $contacts->list_rcords();
+
+    // id map for contact->group associations
+    $contacts_idmap = array();
+
+    // hash on contact name - other attributes are optional
+    $contacts_map = array();
+    foreach ($current_contacts as $contact)
+    {
+        $contacts_map[$contact['name']] = $contact;
+    }
+
+    foreach($import_contacts as $contact_rec)
+    {
+        $contact = $contact_rec['contact'];
+        $groups = $contact_rec['groups'];
+
+        $hash = $contact['name'];
+
+        // update or insert contact
+        if (!empty($contacts_map[$hash]))
+        {
+            $contact_db_id = $contacts_map[$hash]['contact_id'];
+            $contacts_manager->update($id, $contact);
+        }
+        else
+        {
+            $contact_db_id = $contacts_manager->insert($contact);
+        }
+        $contacts_idmap[$contact['id']] = $id;
+
+        // now process contactgroup memberships
+        foreach($groups as $import_id, $import_name) {
+            $group_db_id = $groups_idmap[$import_id];
+
+            // FIXME: Batch this? (though it will still be one insert query per contact)
+            // FIXME: Also maybe manually calculate updates that need to be done so
+            //        all the work done in add_to_group isn't necessary
+            $contacts_manager->add_to_group($group_db_id, $contact_db_id);
+        }
+        // TODO: Removal?
+
+
+
+    }
+}
+

--- a/program/lib/Roundcube/rcube_user.php
+++ b/program/lib/Roundcube/rcube_user.php
@@ -354,8 +354,21 @@ class rcube_user
         $query_cols = $query_params = array();
 
         foreach ((array)$data as $col => $value) {
-            $query_cols[]   = $this->db->quote_identifier($col) . ' = ?';
-            $query_params[] = $value;
+            // filter to allowed columns
+            if (in_array($col, [
+                'name',
+                'organization',
+                'email',
+                'reply-to',
+                'bcc',
+                'signature',
+                'html_signature',
+                'standard'
+                ]))
+            {
+                $query_cols[]   = $this->db->quote_identifier($col) . ' = ?';
+                $query_params[] = $value;
+            }
         }
         $query_params[] = $iid;
         $query_params[] = $this->ID;
@@ -391,8 +404,21 @@ class rcube_user
 
         $insert_cols = $insert_values = array();
         foreach ((array)$data as $col => $value) {
-            $insert_cols[]   = $this->db->quote_identifier($col);
-            $insert_values[] = $value;
+            // filter to allowed columns
+            if (in_array($col, [
+                'name',
+                'organization',
+                'email',
+                'reply-to',
+                'bcc',
+                'signature',
+                'html_signature',
+                'standard'
+                ]))
+            {
+                $insert_cols[]   = $this->db->quote_identifier($col);
+                $insert_values[] = $value;
+            }
         }
         $insert_cols[]   = $this->db->quote_identifier('user_id');
         $insert_values[] = $this->ID;
@@ -452,6 +478,10 @@ class rcube_user
      * Make this identity the default one for this user
      *
      * @param int $iid The identity ID
+     *
+     * This function only sets the `standard` column of all identities
+     * *except* the one passed via $iid to 0, relying on `standard` being
+     * set to 1 for the $iid identity.
      */
     function set_default($iid)
     {
@@ -469,13 +499,19 @@ class rcube_user
 
     /**
      * Update user's last_login timestamp
+     *
+     * @param string $last_login The timestamps (null for now)
      */
-    function touch()
+    function touch($last_login = null)
     {
         if ($this->ID) {
+            if ($last_login === null)
+            {
+                $last_login = $this->db->now();
+            }
             $this->db->query(
                 "UPDATE ".$this->db->table_name('users', true).
-                " SET `last_login` = ".$this->db->now().
+                " SET `last_login` = ".$last_login.
                 " WHERE `user_id` = ?",
                 $this->ID);
         }


### PR DESCRIPTION
Hello,

I am currently working on merging two existing roundcube installations into one.

One of them is running with an sqlite db backend and has been upgraded to roundcube 1.2.2. The other one is running with a mysql backend.

There is no easy way to convert either of those backends to another db, let alone the primary key transmogrifications necessary to merge them.

Since roundcube has no facilities for this yet, I am writing scripts to import/export the following user data:

* User records
* User identities
* User contacts (contactgroups + contacts + contact/group associations)

In addition to my usecase of merging roundcube instances, this will also allow switching database backends by exporting the users, setting up a new database, and then reimporting.

This PR currently implements a POC user export script for a potential future
user import/export feature.

I would like to request feedback as to whether
* This is a functionality the roundcube project is interested in merging
* The approach taken in this script looks promising
* There is any user data missing (caches and searches are intentionally ignored at this time; if an argument is made as to why they should be included I will certainly look into doing that.)

If no significant objections are raised, I intend to continue as follows:

* Fix up the codestyle
* Replace the `print_r` at the end by dumping to a suitable data format such as JSON
* Write a corresponding import/merge script

Thanks to the existing db upgrade infrastructure, the import/export scripts I'm writing will not have to "care" about data versions, they can simply be kept current with roundcube; both "source" and "target" roundcube instances can simply both be upgraded to the same (current) version and the import/export scripts should then work.

Thank you in advance for taking the time to read and review this PR!