### PR TITLE
Clarify options in config file

### DIFF
--- a/config/config.inc.php.sample
+++ b/config/config.inc.php.sample
@@ -27,7 +27,7 @@ $config = array();
 //       or (Windows): 'sqlite:///C:/full/path/to/sqlite.db'
 $config['db_dsnw'] = 'mysql://roundcube:pass@localhost/roundcubemail';
 
-// The mail host chosen to perform the log-in.
+// The IMAP host chosen to perform the log-in.
 // Leave blank to show a textbox at login, give a list of hosts
 // to display a pulldown menu or set one host as string.
 // To use SSL/TLS connection, enter hostname with prefix ssl:// or tls://

--- a/config/config.inc.php.sample
+++ b/config/config.inc.php.sample
@@ -40,8 +40,8 @@ $config['db_dsnw'] = 'mysql://roundcube:pass@localhost/roundcubemail';
 $config['default_host'] = 'localhost';
 
 // SMTP server host (for sending mails).
-// To use SSL/TLS connection, enter hostname with prefix ssl:// or tls://
-// Supported replacement variables:
+// Enter hostname with prefix tls:// to use STARTTLS, or use
+// prefix ssl:// to use the deprecated SSL over SMTP (aka SMTPS)
 // %h - user's IMAP hostname
 // %n - hostname ($_SERVER['SERVER_NAME'])
 // %t - hostname without the first part

--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -120,7 +120,7 @@ $config['apc_debug'] = false;
 // IMAP
 // ----------------------------------
 
-// The mail host chosen to perform the log-in.
+// The IMAP host chosen to perform the log-in.
 // Leave blank to show a textbox at login, give a list of hosts
 // to display a pulldown menu or set one host as string.
 // To use SSL/TLS connection, enter hostname with prefix ssl:// or tls://

--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -239,7 +239,8 @@ $config['messages_cache_threshold'] = 50;
 // ----------------------------------
 
 // SMTP server host (for sending mails).
-// To use SSL/TLS connection, enter hostname with prefix ssl:// or tls://
+// Enter hostname with prefix tls:// to use STARTTLS, or use
+// prefix ssl:// to use the deprecated SSL over SMTP (aka SMTPS)
 // Supported replacement variables:
 // %h - user's IMAP hostname
 // %n - hostname ($_SERVER['SERVER_NAME'])


### PR DESCRIPTION
When setting up roundcube, the `'default_host'` option confused me (is this about the SMTP or IMAP or database server?) It also wasn't immediately clear that for the SMTP host `tls://` refers to STARTTLS and `ssl://` to SMTPS. I think these changes should clarify the settings for newbies.