### PR TITLE
Archive: Add Thunderbird compatible Month option

### DIFF
--- a/plugins/archive/archive.php
+++ b/plugins/archive/archive.php
@@ -188,6 +188,12 @@ class archive extends rcube_plugin
                             . $delimiter . $rcmail->format_date($message->timestamp, 'm');
                         break;
 
+                    case 'thunderbirdmonth':
+                        $subfolder = $rcmail->format_date($message->timestamp, 'Y')
+                            . $delimiter . $rcmail->format_date($message->timestamp, 'Y')
+                            . '-' . $rcmail->format_date($message->timestamp, 'm');
+                        break;
+
                     case 'sender':
                         $from = $message->get('from');
                         preg_match('/[\b<](.+@.+)[\b>]/i', $from, $m);
@@ -410,6 +416,7 @@ class archive extends rcube_plugin
             $archive_type->add($this->gettext('none'), '');
             $archive_type->add($this->gettext('archivetypeyear'), 'year');
             $archive_type->add($this->gettext('archivetypemonth'), 'month');
+            $archive_type->add($this->gettext('archivetypethunderbirdmonth'), 'thunderbirdmonth');
             $archive_type->add($this->gettext('archivetypesender'), 'sender');
             $archive_type->add($this->gettext('archivetypefolder'), 'folder');
 

--- a/plugins/archive/localization/en_CA.inc
+++ b/plugins/archive/localization/en_CA.inc
@@ -25,6 +25,7 @@ $labels['settingstitle'] = 'Archive';
 $labels['archivetype'] = 'Divide archive by';
 $labels['archivetypeyear'] = 'Year (e.g. Archive/2012)';
 $labels['archivetypemonth'] = 'Month (e.g. Archive/2012/06)';
+$labels['archivetypethunderbirdmonth'] = 'Month - Thunderbird compatible (e.g. Archive/2012/2012-06)';
 $labels['archivetypefolder'] = 'Original folder';
 $labels['archivetypesender'] = 'Sender email';
 $labels['unkownsender'] = 'unknown';

--- a/plugins/archive/localization/en_GB.inc
+++ b/plugins/archive/localization/en_GB.inc
@@ -25,6 +25,7 @@ $labels['settingstitle'] = 'Archive';
 $labels['archivetype'] = 'Divide archive by';
 $labels['archivetypeyear'] = 'Year (e.g. Archive/2012)';
 $labels['archivetypemonth'] = 'Month (e.g. Archive/2012/06)';
+$labels['archivetypethunderbirdmonth'] = 'Month - Thunderbird compatible (e.g. Archive/2012/2012-06)';
 $labels['archivetypefolder'] = 'Original folder';
 $labels['archivetypesender'] = 'Sender email';
 $labels['unkownsender'] = 'unknown';

--- a/plugins/archive/localization/en_US.inc
+++ b/plugins/archive/localization/en_US.inc
@@ -27,6 +27,7 @@ $labels['settingstitle'] = 'Archive';
 $labels['archivetype'] = 'Divide archive by';
 $labels['archivetypeyear'] = 'Year (e.g. Archive/2012)';
 $labels['archivetypemonth'] = 'Month (e.g. Archive/2012/06)';
+$labels['archivetypethunderbirdmonth'] = 'Month - Thunderbird compatible (e.g. Archive/2012/2012-06)';
 $labels['archivetypefolder'] = 'Original folder';
 $labels['archivetypesender'] = 'Sender email';
 $labels['unkownsender'] = 'unknown';


### PR DESCRIPTION
Hi,

This adds another option to the Archive plugin, which allows the user to divide the archive by months, but using the same subfolder format as Thunderbird, as shown below:

![Thunderbird Archive Options](https://cloud.githubusercontent.com/assets/5109054/22378651/3b080cb2-e4ae-11e6-9126-b5e34b119e36.PNG)

This means that the Archive folders of Roundcube and Thunderbird remain compatible and the user can use whichever of the clients to archive mail successfully and without having two folders for each month.

This is a tweak that I've found useful when implementing and transitioning to Roundcube in an environment that previously primarily used Thunderbird, so I thought other users may benefit from using it. I've done the English localizations, but I don't know any other languages, sorry!

Thanks! :)