### PR TITLE
pass full message object on message_sent event

### DIFF
--- a/program/lib/Roundcube/rcube.php
+++ b/program/lib/Roundcube/rcube.php
@@ -1661,7 +1661,7 @@ class rcube
             $this->plugins->exec_hook('message_send_error', $plugin + array('error' => $error));
         }
         else {
-            $this->plugins->exec_hook('message_sent', array('headers' => $headers, 'body' => $msg_body));
+            $this->plugins->exec_hook('message_sent', array('headers' => $headers, 'body' => $msg_body, 'message' => $message));
 
             // remove MDN headers after sending
             unset($headers['Return-Receipt-To'], $headers['Disposition-Notification-To']);


### PR DESCRIPTION
In an integration project we are working on we need to get the full message object on the message_sent event in order to separately save text and html formats of the email.
This may also be helpful in other scenarios so I am proposing the change we made in case it can help others.

If there is already a way of getting the object without the change I would appreciate you could point me in the right direction.