### PR TITLE
Enable to change Content-Type charset and MIME header encoding

### DIFF
--- a/program/steps/mail/sendmail.inc
+++ b/program/steps/mail/sendmail.inc
@@ -490,6 +490,10 @@ if (preg_match('/[^\x00-\x7F]/', $MAIL_MIME->getTXTBody())) {
     $text_charset      = $message_charset;
     $transfer_encoding = $RCMAIL->config->get('force_7bit') ? 'quoted-printable' : '8bit';
 }
+else if (strncmp(strtoupper($message_charset), 'ISO-2022', 8) == 0 && preg_match('/\x1B/', $MAIL_MIME->getTXTBody())) {
+    $text_charset      = $message_charset;
+    $transfer_encoding = '7bit';
+}
 else {
     $text_charset      = 'US-ASCII';
     $transfer_encoding = '7bit';

--- a/program/steps/mail/sendmail.inc
+++ b/program/steps/mail/sendmail.inc
@@ -516,10 +516,13 @@ if ($pgp_mime) {
     $MAIL_MIME->setParam('preamble', 'This is an OpenPGP/MIME encrypted message (RFC 2440 and 3156)');
 }
 
+// default MIME head encoding
+$default_head_encoding = $RCMAIL->config->get('default_head_encoding', 'quoted-printable');
+
 // encoding settings for mail composing
 $MAIL_MIME->setParam('text_encoding', $transfer_encoding);
 $MAIL_MIME->setParam('html_encoding', 'quoted-printable');
-$MAIL_MIME->setParam('head_encoding', 'quoted-printable');
+$MAIL_MIME->setParam('head_encoding', $default_head_encoding);
 $MAIL_MIME->setParam('head_charset', $message_charset);
 $MAIL_MIME->setParam('html_charset', $message_charset);
 $MAIL_MIME->setParam('text_charset', $text_charset);


### PR DESCRIPTION
This enables two changes:

- Add a configuration variable "default_head_encoding" which enables to change the encoding for MIME header (e.g., Subject) from Q-encoding (default) to B-encoding (preferred for multibyte languages).

- Change the "charset" value in the "Content-Type" MIME header if:

  - the value of $message_charset is "ISO-2022-*" (which means, for example, that POST[_charset] is set to be that value), and

  - the message body contains ESC (0x1B).

These changes do NOT disturb users at all as long as they do not set the configuration variable "default_head_encoding" and they do not use ESC (0x1B) in the message body.
