### PR TITLE
Fix to suppress use of problematic characters

### DIFF
--- a/program/steps/settings/save_folder.inc
+++ b/program/steps/settings/save_folder.inc
@@ -48,7 +48,7 @@ else if ($name[0] == '.' && $RCMAIL->config->get('imap_skip_hidden_folders')) {
 else {
     // these characters are problematic e.g. when used in LIST/LSUB
     foreach (array($delimiter, '%', '*') as $char) {
-        if (strpos($name, $delimiter) !== false) {
+        if (strpos($name, $char) !== false) {
             $error = $RCMAIL->gettext('forbiddencharacter') . " ($char)";
             break;
         }


### PR DESCRIPTION
I found a problem with IMAP folder character check.

When roundcube creates IMAP folder, it suppresses the use of the following characters.
delimiter, '%'(percent), '*'(asterisk)

Actually, only delimiter characters are forbidden.