### PR TITLE
don't use env for group-rename action

### DIFF
--- a/program/js/app.js
+++ b/program/js/app.js
@@ -6195,13 +6195,14 @@ function rcube_webmail()
   this.group_create = function()
   {
     var input = $('<input>').attr('type', 'text'),
-      content = $('<label>').text(this.get_label('namex')).append(input);
+      content = $('<label>').text(this.get_label('namex')).append(input),
+      source = this.env.source;
 
     this.simple_dialog(content, 'newgroup',
       function() {
         var name;
         if (name = input.val()) {
-          ref.http_post('group-create', {_source: ref.env.source, _name: name},
+          ref.http_post('group-create', {_source: source, _name: name},
             ref.set_busy(true, 'loading'));
           return true;
         }

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -6322,7 +6322,9 @@ function rcube_webmail()
     else {
       $(this.treelist.get_item(key)).children().first().html(prop.name);
       this.env.contactfolders[key].name = this.env.contactgroups[key].name = prop.name;
-      this.set_group_prop(prop);
+
+      if (prop.id == this.env.group)
+        this.set_group_prop(prop);
     }
 
     // update list node and re-sort it

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -6219,13 +6219,15 @@ function rcube_webmail()
 
     var group_name = this.env.contactgroups['G' + this.env.source + this.env.group].name,
       input = $('<input>').attr('type', 'text').val(group_name),
-      content = $('<label>').text(this.get_label('namex')).append(input);
+      content = $('<label>').text(this.get_label('namex')).append(input),
+      source = this.env.source,
+      group = this.env.group;
 
     this.simple_dialog(content, 'grouprename',
       function() {
         var name;
         if ((name = input.val()) && name != group_name) {
-          ref.http_post('group-rename', {_source: ref.env.source, _gid: ref.env.group, _name: name},
+          ref.http_post('group-rename', {_source: source, _gid: group, _name: name},
             ref.set_busy(true, 'loading'));
           return true;
         }


### PR DESCRIPTION
slightly related to #5648. I'm updating my contextmenu plugin. Currently when renaming a contact group it is a requirment that the group is the one currently selected in the UI because the JS that sends the request after the user fills in the dialog uses the group info from the env. by setting that information into veriables when the dialog is opened then the requirement to have the group selected is removed. 