### PR TITLE
extend plugin password to avoid sudo (use ssh instead calling chpasswd)

### DIFF
--- a/plugins/password/README
+++ b/plugins/password/README
@@ -262,6 +262,9 @@
 
  Attached wrapper script (helpers/chpass-wrapper.py) restricts password changes
  to uids >= 1000 and can deny requests based on a blacklist.
+ 
+ For a more secure setup see the notes in section sudo or use the new wrapper
+ chpass-wrapper-expect.py, for usage see there. 
 
 
  2.12.  LDAP - no PEAR (ldap_simple)
@@ -317,7 +320,9 @@
 
  Driver to change user password via the 'expect' command.
  See config.inc.php.dist file for configuration description.
-
+ 
+ For easyer and more secure of the expect script a new wrapper is
+ is provided: chpass-wrapper-expect.py, see there and sudo for setup
 
  2.18.  Samba (smb)
  -----------------------------------
@@ -375,21 +380,21 @@
  4. Sudo setup
  -------------
 
-// try to be more secure and use dovecot or pam methods
-// if this is not possible in your setup you can increase security by
-// sudo to a wrapper, where you can implement some security meassures
+ try to be more secure and use dovecot or pam methods
+ if this is not possible in your setup you can increase security by
+ sudo to a wrapper, where you can implement some security meassures
 
-//    1. a simple wraper is provided by this plugin: helpers/chpasswrapper.py
-//    2. move wrapper out of default location to a random place
-//    3. change permissons of wrapper to root:www 770 to avoid changes by user or webserver
-//    4. add some security meassures, i.e. limit userids where password can be changed
-//    5. allow webserver sudo for wrapper only (se below)
+    1. two wrappers are provided by this plugin: chpass-wrapper.py / chpass-wrapper_expect.py
+    2. move wrapper out of the default location to a random place
+    3. change permissons of wrapper to root:www 770 to avoid changes by user or webserver
+    4. add some security meassures, i.e. limit userids where password can be changed
+    5. allow webserver sudo for wrapper only (se below)
 
  Some drivers that execute system commands (like chpasswd) require use of sudo command.
  Here's a sample for CentOS 7:
 
  # cat <<END >/etc/sudoers.d/99-roundcubemail
- apache ALL=NOPASSWD:/srv/wrapper/roundcube/chpasswrapper.py
+ apache ALL=NOPASSWD:/<RANDOMPATH>/roundcube/wrapper/chpass-wrapper.py
  Defaults:apache !requiretty
  <<END
 

--- a/plugins/password/README
+++ b/plugins/password/README
@@ -375,11 +375,21 @@
  4. Sudo setup
  -------------
 
+// try to be more secure and use dovecot or pam methods
+// if this is not possible in your setup you can increase security by
+// sudo to a wrapper, where you can implement some security meassures
+
+//    1. a simple wraper is provided by this plugin: helpers/chpasswrapper.py
+//    2. move wrapper out of default location to a random place
+//    3. change permissons of wrapper to root:www 770 to avoid changes by user or webserver
+//    4. add some security meassures, i.e. limit userids where password can be changed
+//    5. allow webserver sudo for wrapper only (se below)
+
  Some drivers that execute system commands (like chpasswd) require use of sudo command.
  Here's a sample for CentOS 7:
 
  # cat <<END >/etc/sudoers.d/99-roundcubemail
- apache ALL=NOPASSWD:/usr/sbin/chpasswd
+ apache ALL=NOPASSWD:/srv/wrapper/roundcube/chpasswrapper.py
  Defaults:apache !requiretty
  <<END
 

--- a/plugins/password/config.inc.php.dist
+++ b/plugins/password/config.inc.php.dist
@@ -373,8 +373,30 @@ $config['password_ximss_port'] = 11024;
 
 // chpasswd Driver options
 // ---------------------
-// Command to use (see "Sudo setup" in README)
-$config['password_chpasswd_cmd'] = 'sudo /usr/sbin/chpasswd 2> /dev/null';
+// 2017-02-13: Remarks by Kay Marquardt <kay@rrr.de>
+// allowing sudo chpasswd directly IMHO opens a security hole!
+// any script on the webserver can change password for every user.
+// $config['password_chpasswd_cmd'] = 'sudo /usr/sbin/chpasswd 2>/dev/null';
+
+// try to be more secure and use other methods
+// if this is not possible in your setup, you can increase security by
+// sudo to a wrapper, where you can implement some security meassures:
+//    1. a simple wraper is provided by this plugin: helpers/chpasswrapper.py 
+//    2. move wrapper out of default location to a random place
+//    3. change permissons of wrapper to root:www 770 to avoid changes by user or webserver
+//    4. add some security meassures, i.e. limit userids where password can be changed
+//    5. allow webserver sudo for wrapper only (see README)
+// $config['password_chpasswd_cmd'] = 'sudo /<RANDOMPATH>/roundcube/wrapper/chpass-wrapper.py';
+
+// IMHO the most flexible and secure method for users with interactive shell access is to use ssh with expect
+// I modifed the chpasss driver to provide the old password needed, additionally it pass the script response in case of error.
+
+//    1. use my wrapper for the nice expect script provided by this plugin: helpers/chpass-wrapper-expect.py 
+//    2. move wrapper out of default location to a random place
+//    3. change permissons of wrapper to root:www 770 to avoid changes by user or webserver
+//    4. edit arguments to provide loginmethod and hostname, see wrapper for mor options 
+//    5. remove sudo rules you may have applied (see README)
+$config['password_chpasswd_cmd'] = '/<RANDOMPATH>/roundcube/wrapper/chpass-wrapper-expect.py -ssh -host localhost';
 
 
 // XMail Driver options

--- a/plugins/password/config.inc.php.dist
+++ b/plugins/password/config.inc.php.dist
@@ -394,7 +394,7 @@ $config['password_ximss_port'] = 11024;
 //    1. use my wrapper for the nice expect script provided by this plugin: helpers/chpass-wrapper-expect.py 
 //    2. move wrapper out of default location to a random place
 //    3. change permissons of wrapper to root:www 770 to avoid changes by user or webserver
-//    4. edit arguments to provide loginmethod and hostname, see wrapper for mor options 
+//    4. edit arguments to provide loginmethod and hostname.
 //    5. remove sudo rules you may have applied (see README)
 $config['password_chpasswd_cmd'] = '/<RANDOMPATH>/roundcube/wrapper/chpass-wrapper-expect.py -ssh -host localhost';
 

--- a/plugins/password/drivers/chpasswd.php
+++ b/plugins/password/drivers/chpasswd.php
@@ -8,8 +8,9 @@
  *
  * For installation instructions please read the README file.
  *
- * @version 2.0
+ * @version 3.0
  * @author Alex Cartwright <acartwright@mutinydesign.co.uk>
+ * @author rewrtitten by KaM <kay@rrr.de>
  *
  * Copyright (C) 2005-2013, The Roundcube Dev Team
  *
@@ -34,12 +35,43 @@ class rcube_chpasswd_password
         $cmd = rcmail::get_instance()->config->get('password_chpasswd_cmd');
         $username = $_SESSION['username'];
 
-        $handle = popen($cmd, "w");
-        fwrite($handle, "$username:$newpass\n");
+        // change popen to proc_open to chatch responses from command
+        $desc = array(
+            0 => array('pipe', 'r'), // 0 is STDIN for process
+            1 => array('pipe', 'w'), // 1 is STDOUT for process
+            2 => array('file', strtok(cmd,  ' ') . '-error.log', 'a') // 2 is STDERR for process
+        );
 
-        if (pclose($handle) == 0) {
-            return PASSWORD_SUCCESS;
+        // spawn the sub process
+        $process = proc_open($cmd, $desc, $pipes);
+
+        // does sub prescess exist?
+        if (is_resource($process)) {
+            // send send username and new pass to chpasswd command / warpper 
+            fwrite($pipes[0], "$username:$newpass\n");
+            // new: send old passwd for expect sript, works also with chpasswd
+            fwrite($pipes[0], "$currpass\n");
+            fclose($pipes[0]);
+
+            // read response from sub process
+            $message = stream_get_contents($pipes[1]);
+
+            // all done! Clean up
+            fclose($pipes[1]);
+            fclose($pipes[2]);
+
+            if (!proc_close($process)) {
+              return PASSWORD_SUCCESS;
+            }
+            else {
+                // return response in case of error
+                return array(
+                    'code'    => PASSWORD_ERROR,
+                    'message' => "<br>" . $message
+                );
+            }
         }
+        // sub process failed!
         else {
             rcube::raise_error(array(
                 'code' => 600,
@@ -48,7 +80,4 @@ class rcube_chpasswd_password
                 'message' => "Password plugin: Unable to execute $cmd"
                 ), true, false);
         }
-
-        return PASSWORD_ERROR;
-    }
 }

--- a/plugins/password/helpers/chpass-wrapper-expect.py
+++ b/plugins/password/helpers/chpass-wrapper-expect.py
@@ -20,23 +20,13 @@
 // allowing sudo chpasswd directly opens a security hole!
 // any script on the webserver can change password for every user, incl. root
 
-// try to be more secure and use dovecot or pam methods
-// if this is not possible in your setup you can increase security by
-// sudo to a wrapper, where you can implement some security meassures
-
-//    1. a simple wraper is provided by this plugin: helpers/chpasswrapper.py 
-//    2. move wrapper out of default location to a random place
-//    3. change permissons of wrapper to root:www 770 to avoid changes by user or webserver
-//    4. add some security meassures, i.e. limit userids where password can be changed
-//    5. allow webserver sudo for wrapper only (see README)
-
 // IMHO the most flexible and secure method for users with interactive shell access is to use ssh with an expect script
 // I modifed the chpasss driver to provide the old password needed, additionally it pass the script response in case of error.
 
-//    1. I wrote a wrapper for the nice expect script provided by this plugin: helpers/chpass-wrapper-expect.py 
+//    1. I wrote a wrapper (this script) for expect script provided by this plugin. 
 //    2. move wrapper out of default location to a random place
 //    3. change permissons of wrapper to root:www 770 to avoid changes by user or webserver
-//    4. I add some security meassures and password policy, see wrapper for details 
+//    4. I add some security meassures(see README) 
 //    5. remove sudo rules you may have applied (see README)
 """
 

--- a/plugins/password/helpers/chpass-wrapper-expect.py
+++ b/plugins/password/helpers/chpass-wrapper-expect.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python
+#
+# use passwd-expect to login to host and change password
+# you need to install expect on the webserver host
+# i.e. "apt-get install expect" or "yast -i expect"
+#
+# you need an writeable .ssh dir in webserver homedir
+# you can test this by do ssh user@host as webserver
+#
+# Parameter:
+# -ssh           use ssh for connetion to host (default)
+# -host hostname connect to hostname (default localhost)
+# - policy #     0-4 enable password local password checks
+# -timeout #     0 - 99 time in s to wait for response
+#
+# all other parameters are passed to passwd-expect, see there.
+#
+"""
+// 2017-02-13: Remarks by Kay Marquardt kay@rrr.de
+// allowing sudo chpasswd directly opens a security hole!
+// any script on the webserver can change password for every user, incl. root
+
+// try to be more secure and use dovecot or pam methods
+// if this is not possible in your setup you can increase security by
+// sudo to a wrapper, where you can implement some security meassures
+
+//    1. a simple wraper is provided by this plugin: helpers/chpasswrapper.py 
+//    2. move wrapper out of default location to a random place
+//    3. change permissons of wrapper to root:www 770 to avoid changes by user or webserver
+//    4. add some security meassures, i.e. limit userids where password can be changed
+//    5. allow webserver sudo for wrapper only (see README)
+
+// IMHO the most flexible and secure method for users with interactive shell access is to use ssh with an expect script
+// I modifed the chpasss driver to provide the old password needed, additionally it pass the script response in case of error.
+
+//    1. I wrote a wrapper for the nice expect script provided by this plugin: helpers/chpass-wrapper-expect.py 
+//    2. move wrapper out of default location to a random place
+//    3. change permissons of wrapper to root:www 770 to avoid changes by user or webserver
+//    4. I add some security meassures and password policy, see wrapper for details 
+//    5. remove sudo rules you may have applied (see README)
+"""
+
+# path to ecpect and script name (has to be in the same dir as this script)
+# "which expect" show the path to expect programm
+expect = '/usr/bin/expect'
+script = 'passwd-expect'
+# 0 no checks, 1 >= 8 char, 2 digits, 3 upper and lowercase, 4 special char
+POLICY = 3
+TIMEOUT= 10
+
+import os, sys, pwd, re
+import subprocess, signal
+
+
+# get args for script and extract hostname for us
+hostname='localhost'
+scriptargs = ''
+count=1
+while(count < len(sys.argv)):
+  # get hostname
+  if sys.argv[count] == '-host':
+    hostname = sys.argv[count+1]
+  # local only args, do not pass
+  try:
+    if sys.argv[count] == '-policy':
+      count += 2
+      POLICY=int(sys.argv[count-1])
+      continue
+    if sys.argv[count] == '-timeout':
+      count += 2
+      TIMEOUT=int(sys.argv[count-1])
+      continue
+  except ValueError:
+    continue
+  # pass all other args
+  scriptargs += ' ' + sys.argv[count]
+  count += 1
+
+
+# read username:password\noldpasswd with timeout
+class TimeoutException(Exception):   # Custom exception class
+    pass
+def timeout_handler(signum, frame):   # Custom signal handler
+    raise TimeoutException
+signal.signal(signal.SIGALRM, timeout_handler)
+
+# set timeout 
+signal.alarm(TIMEOUT)
+try:
+    try:
+      username, password = sys.stdin.readline().split(':', 1)
+      oldpassw = sys.stdin.readline()
+    except ValueError, e:
+      sys.exit('Malformed input')
+
+except TimeoutException:
+  sys.exit('Timeout while reading input')
+else:
+  # clear timeout
+  signal.alarm(0)
+
+
+# add user to BLACKLIST and/or /etc/ftpusers to disable password change
+BLACKLIST = [
+    # add blacklisted users here
+    'ftp',
+]
+
+# add /etc/ftpusers to BLACKLIST if exist
+try:
+  with open("/etc/ftpusers", "r") as ins:
+    for line in ins:
+      if line.startswith('#'):
+         continue
+      BLACKLIST.append(line.rstrip('\n'))
+
+except IOError:
+  # only catch error and continue
+  pass
+
+
+# check if user is blacklisted for password change
+if username in BLACKLIST:
+    sys.exit('Changing password for user %s is forbidden (user blacklisted)!' %
+             username)
+
+
+# check if user exit and is allowed to chage password
+if hostname == 'localhost':
+  try:
+    user = pwd.getpwnam(username)
+  except KeyError, e:
+    sys.exit('No such user: %s' % username)
+
+  if user.pw_uid < 1000:
+    sys.exit('Changing the password for user %s is forbidden (system user)!' %
+             username)
+
+elif len(username) < 3:
+  # non local users should have at least 3 charactes
+  sys.exit('Changing the password for user %s is forbidden (short user)!' %
+             username)
+
+
+"""
+    Verify the strength of 'password'
+    A password is considered strong if:
+        8 characters length or more
+        1 digit or more
+        1 symbol or more
+        1 uppercase letter or more
+        1 lowercase letter or more
+"""
+
+# enforcing password policy
+if POLICY > 0:
+  if len(oldpassw) < 3:
+    sys.exit('Old password to short or not known!')
+
+  if len(password) < 8:
+    sys.exit('Password contains less than 8 characters!')
+
+  if re.search(r"[A-Zia-z]", password) is None:
+      sys.exit('Password contains no character!')
+
+if POLICY > 1:
+  # look for digits
+  if re.search(r"\d", password) is None:
+      sys.exit('Password contains no digits!')
+
+if POLICY > 2:
+  # look for uppercase
+  if re.search(r"[A-Z]", password) is None:
+      sys.exit('Password contains no UPPERCASE character!')
+
+  # look for lowercase
+  if re.search(r"[a-z]", password) is None:
+      sys.exit('Password contains no lowercase character!')
+
+if POLICY > 3:
+  # look for symbols
+  if re.search(r"[ !#$%&'()*+,-./[\\\]^_`{|}~"+r'"]', password) is None:
+      sys.exit('Password contains no symbol/special character!')
+# see more options for script in the script itself
+path= os.path.dirname(os.path.realpath(sys.argv[0]))
+
+# script has to be in same directory
+if scriptargs == '': scriptargs = ' -ssh -host ' + hostname
+cmd = expect + ' ' + os.path.dirname(os.path.realpath(sys.argv[0])) + '/' + script + scriptargs + ' -log \|cat'
+
+# set timeout
+signal.alarm(TIMEOUT)
+try:
+  handle = subprocess.Popen( cmd, shell=True, stdin = subprocess.PIPE)
+  handle.communicate('%s\n%s\n%s' % (username, oldpassw.rstrip('\r\n'), password))
+except TimeoutException:
+  sys.exit('Timeout while changing password (wrong old password)')
+else:
+  # clear timeout
+  signal.alarm(0)
+
+
+sys.exit(handle.returncode)
+ 

--- a/plugins/password/helpers/chpass-wrapper-expect.py
+++ b/plugins/password/helpers/chpass-wrapper-expect.py
@@ -10,7 +10,6 @@
 # Parameter:
 # -ssh           use ssh for connetion to host (default)
 # -host hostname connect to hostname (default localhost)
-# - policy #     0-4 enable password local password checks
 # -timeout #     0 - 99 time in s to wait for response
 #
 # all other parameters are passed to passwd-expect, see there.
@@ -121,18 +120,7 @@ if hostname == 'localhost':
     sys.exit('Changing the password for user %s is forbidden (system user)!' %
              username)
 
-elif len(username) < 3:
-  # non local users should have at least 3 charactes
-  sys.exit('Changing the password for user %s is forbidden (short user)!' %
-             username)
-
-# enforcing password policy
-if len(oldpassw) < 3:
-    sys.exit('Old password to short or not known!')
-
-if len(password) < 8:
-    sys.exit('Password contains less than 8 characters!')
-
+ 
 path= os.path.dirname(os.path.realpath(sys.argv[0]))
 
 # script has to be in same directory

--- a/plugins/password/helpers/chpass-wrapper-expect.py
+++ b/plugins/password/helpers/chpass-wrapper-expect.py
@@ -44,8 +44,7 @@
 # "which expect" show the path to expect programm
 expect = '/usr/bin/expect'
 script = 'passwd-expect'
-# 0 no checks, 1 >= 8 char, 2 digits, 3 upper and lowercase, 4 special char
-POLICY = 3
+
 TIMEOUT= 10
 
 import os, sys, pwd, re
@@ -62,10 +61,6 @@ while(count < len(sys.argv)):
     hostname = sys.argv[count+1]
   # local only args, do not pass
   try:
-    if sys.argv[count] == '-policy':
-      count += 2
-      POLICY=int(sys.argv[count-1])
-      continue
     if sys.argv[count] == '-timeout':
       count += 2
       TIMEOUT=int(sys.argv[count-1])
@@ -141,47 +136,13 @@ elif len(username) < 3:
   sys.exit('Changing the password for user %s is forbidden (short user)!' %
              username)
 
-
-"""
-    Verify the strength of 'password'
-    A password is considered strong if:
-        8 characters length or more
-        1 digit or more
-        1 symbol or more
-        1 uppercase letter or more
-        1 lowercase letter or more
-"""
-
 # enforcing password policy
-if POLICY > 0:
-  if len(oldpassw) < 3:
+if len(oldpassw) < 3:
     sys.exit('Old password to short or not known!')
 
-  if len(password) < 8:
+if len(password) < 8:
     sys.exit('Password contains less than 8 characters!')
 
-  if re.search(r"[A-Zia-z]", password) is None:
-      sys.exit('Password contains no character!')
-
-if POLICY > 1:
-  # look for digits
-  if re.search(r"\d", password) is None:
-      sys.exit('Password contains no digits!')
-
-if POLICY > 2:
-  # look for uppercase
-  if re.search(r"[A-Z]", password) is None:
-      sys.exit('Password contains no UPPERCASE character!')
-
-  # look for lowercase
-  if re.search(r"[a-z]", password) is None:
-      sys.exit('Password contains no lowercase character!')
-
-if POLICY > 3:
-  # look for symbols
-  if re.search(r"[ !#$%&'()*+,-./[\\\]^_`{|}~"+r'"]', password) is None:
-      sys.exit('Password contains no symbol/special character!')
-# see more options for script in the script itself
 path= os.path.dirname(os.path.realpath(sys.argv[0]))
 
 # script has to be in same directory

--- a/plugins/password/helpers/chpass-wrapper.py
+++ b/plugins/password/helpers/chpass-wrapper.py
@@ -5,9 +5,6 @@
 #  - file based blacklist (/etc/ftpusers)
 #  - timeout for reading and writing
 
-
-# 0 no checks, 1 >= 8 char, 2 digits, 3 upper and lowercase, 4 special char
-POLICY = 3
 TIMEOUT= 10
 
 import os, sys, pwd, re
@@ -20,10 +17,6 @@ count=1
 while(count < len(sys.argv)):
   # local only args, do not pass
   try:
-    if sys.argv[count] == '-policy':
-      count += 2
-      POLICY=int(sys.argv[count-1])
-      continue
     if sys.argv[count] == '-timeout':
       count += 2
       TIMEOUT=int(sys.argv[count-1])
@@ -94,47 +87,8 @@ elif len(username) < 4:
   sys.exit('Changing the password for user %s is forbidden (short user)!' %
              username)
 
-
-"""
-    Verify the strength of 'password'
-    A password is considered strong if:
-        8 characters length or more
-        1 digit or more
-        1 symbol or more
-        1 uppercase letter or more
-        1 lowercase letter or more
-"""
-
-# enforcing password policy
-if POLICY > 0:
-  if len(oldpassw) < 3:
-    sys.exit('Old password to short or not known!')
-
-  if len(password) < 8:
+if len(password) < 8:
     sys.exit('Password contains less than 8 characters!')
-
-  if re.search(r"[A-Zia-z]", password) is None:
-      sys.exit('Password contains no character!')
-
-if POLICY > 1:
-  # look for digits
-  if re.search(r"\d", password) is None:
-      sys.exit('Password contains no digits!')
-
-if POLICY > 2:
-  # look for uppercase
-  if re.search(r"[A-Z]", password) is None:
-      sys.exit('Password contains no UPPERCASE character!')
-
-  # look for lowercase
-  if re.search(r"[a-z]", password) is None:
-      sys.exit('Password contains no lowercase character!')
-
-if POLICY > 3:
-  # look for symbols
-  if re.search(r"[ !#$%&'()*+,-./[\\\]^_`{|}~"+r'"]', password) is None:
-      sys.exit('Password contains no symbol/special character!')
-
 
 # set timeout
 signal.alarm(TIMEOUT)

--- a/plugins/password/helpers/chpass-wrapper.py
+++ b/plugins/password/helpers/chpass-wrapper.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 #
 # extended wrapper to /user/sbin/chpasswd
-#  - more password and user checks
 #  - file based blacklist (/etc/ftpusers)
 #  - timeout for reading and writing
 
@@ -81,14 +80,6 @@ except KeyError, e:
 if user.pw_uid < 1000:
     sys.exit('Changing the password for user %s is forbidden (system user)!' %
              username)
-
-elif len(username) < 4:
-  # users should have at least 3 charactes
-  sys.exit('Changing the password for user %s is forbidden (short user)!' %
-             username)
-
-if len(password) < 8:
-    sys.exit('Password contains less than 8 characters!')
 
 # set timeout
 signal.alarm(TIMEOUT)

--- a/plugins/password/helpers/chpass-wrapper.py
+++ b/plugins/password/helpers/chpass-wrapper.py
@@ -1,32 +1,150 @@
 #!/usr/bin/env python
+#
+# extended wrapper to /user/sbin/chpasswd
+#  - more password and user checks
+#  - file based blacklist (/etc/ftpusers)
+#  - timeout for reading and writing
 
-import sys
-import pwd
-import subprocess
 
-BLACKLIST = (
-    # add blacklisted users here
-    #'user1',
-)
+# 0 no checks, 1 >= 8 char, 2 digits, 3 upper and lowercase, 4 special char
+POLICY = 3
+TIMEOUT= 10
 
+import os, sys, pwd, re
+import subprocess, signal
+
+
+# get args for script 
+scriptargs = ''
+count=1
+while(count < len(sys.argv)):
+  # local only args, do not pass
+  try:
+    if sys.argv[count] == '-policy':
+      count += 2
+      POLICY=int(sys.argv[count-1])
+      continue
+    if sys.argv[count] == '-timeout':
+      count += 2
+      TIMEOUT=int(sys.argv[count-1])
+      continue
+  except ValueError:
+    continue
+  # pass all other args
+  scriptargs += ' ' + sys.argv[count]
+  count += 1
+
+# read username:password\noldpasswd with timeout
+class TimeoutException(Exception):   # Custom exception class
+    pass
+def timeout_handler(signum, frame):   # Custom signal handler
+    raise TimeoutException
+signal.signal(signal.SIGALRM, timeout_handler)
+
+# set timeout 
+signal.alarm(TIMEOUT)
 try:
-    username, password = sys.stdin.readline().split(':', 1)
-except ValueError, e:
-    sys.exit('Malformed input')
+    try:
+      username, password = sys.stdin.readline().split(':', 1)
+    except ValueError, e:
+      sys.exit('Malformed input')
 
+except TimeoutException:
+  sys.exit('Timeout while reading input')
+else:
+  # clear timeout
+  signal.alarm(0)
+
+# add user to BLACKLIST and/or /etc/ftpusers to disable password change
+BLACKLIST = [
+    # add blacklisted users here
+    'ftp',
+]
+
+# add /etc/ftpusers to BLACKLIST if exist
+try:
+  with open("/etc/ftpusers", "r") as ins:
+    for line in ins:
+      if line.startswith('#'):
+         continue
+      BLACKLIST.append(line.rstrip('\n'))
+
+except IOError:
+  # only catch error and continue
+  pass
+
+# check if user is blacklisted for password change
+if username in BLACKLIST:
+    sys.exit('Changing password for user %s is forbidden (user blacklisted)!' %
+             username)
+
+
+# check if user exit and is allowed to chage password
 try:
     user = pwd.getpwnam(username)
 except KeyError, e:
     sys.exit('No such user: %s' % username)
 
 if user.pw_uid < 1000:
-    sys.exit('Changing the password for user id < 1000 is forbidden')
-
-if username in BLACKLIST:
-    sys.exit('Changing password for user %s is forbidden (user blacklisted)' %
+    sys.exit('Changing the password for user %s is forbidden (system user)!' %
              username)
 
-handle = subprocess.Popen('/usr/sbin/chpasswd', stdin = subprocess.PIPE)
-handle.communicate('%s:%s' % (username, password))
+elif len(username) < 4:
+  # users should have at least 3 charactes
+  sys.exit('Changing the password for user %s is forbidden (short user)!' %
+             username)
+
+
+"""
+    Verify the strength of 'password'
+    A password is considered strong if:
+        8 characters length or more
+        1 digit or more
+        1 symbol or more
+        1 uppercase letter or more
+        1 lowercase letter or more
+"""
+
+# enforcing password policy
+if POLICY > 0:
+  if len(oldpassw) < 3:
+    sys.exit('Old password to short or not known!')
+
+  if len(password) < 8:
+    sys.exit('Password contains less than 8 characters!')
+
+  if re.search(r"[A-Zia-z]", password) is None:
+      sys.exit('Password contains no character!')
+
+if POLICY > 1:
+  # look for digits
+  if re.search(r"\d", password) is None:
+      sys.exit('Password contains no digits!')
+
+if POLICY > 2:
+  # look for uppercase
+  if re.search(r"[A-Z]", password) is None:
+      sys.exit('Password contains no UPPERCASE character!')
+
+  # look for lowercase
+  if re.search(r"[a-z]", password) is None:
+      sys.exit('Password contains no lowercase character!')
+
+if POLICY > 3:
+  # look for symbols
+  if re.search(r"[ !#$%&'()*+,-./[\\\]^_`{|}~"+r'"]', password) is None:
+      sys.exit('Password contains no symbol/special character!')
+
+
+# set timeout
+signal.alarm(TIMEOUT)
+try:
+  handle = subprocess.Popen('/usr/sbin/chpasswd', stdin = subprocess.PIPE)
+  handle.communicate('%s:%s' % (username, password))
+except TimeoutException:
+  sys.exit('Timeout while changing password')
+else:
+  # clear timeout
+  signal.alarm(0)
 
 sys.exit(handle.returncode)


### PR DESCRIPTION
As I already told on the dev mailing list:

I used the password plugin with chasswd and was not pleased to allow the webserver to call "sudo chpasswd".
After some investigation and testing I ended up with a new helper script to  change password via ssh using the provided and excelent expect-passwd method.

Additionally I rewrote the chpasswd driver to provide the old password in a compatible way and extended it to pass error messages back to roundcube.