### PR TITLE
Fixes sieve parsing bug when comments contain empty lines

### DIFF
--- a/plugins/managesieve/lib/Roundcube/rcube_sieve_script.php
+++ b/plugins/managesieve/lib/Roundcube/rcube_sieve_script.php
@@ -590,7 +590,12 @@ class rcube_sieve_script
                     $prefix .= $line . "\n";
                 }
 
-                $position = $endl + 1;
+                // check for empty lines within comments
+                do {
+                    $position = $endl + 1;
+                    $endl = strpos($script, "\n", $position) ?: $length;
+                    $line = substr($script, $position, $endl - $position);
+                } while ($position < $length && preg_match('/^\s*$/', $line));
             }
 
             // handle script header


### PR DESCRIPTION
Sample sieve filter set to reproduce the error:

```sieve
require ["fileinto","envelope","regex","body","relational","subaddress","variables","imap4flags","date","include"];

# simple comment

# another comment
if envelope :detail "to" "addressextension" {
    setflag "\\Flagged";
}

# Spam
if header :is "X-Spam-Flag" "YES" {
 	fileinto "Junk";
  	stop;
}
```

Wihtout removing the empty line between `# simple comment` and `# another comment` the parser produces rubbish.