### PR TITLE
small amendment to #5652

### DIFF
--- a/program/js/app.js
+++ b/program/js/app.js
@@ -6253,7 +6253,8 @@ function rcube_webmail()
       delete this.env.contactgroups[key];
     }
 
-    this.list_contacts(prop.source, 0);
+    if (prop.source == this.env.source && prop.id == this.env.group)
+      this.list_contacts(prop.source, 0);
   };
 
   //remove selected contacts from current active group
@@ -6324,7 +6325,7 @@ function rcube_webmail()
       $(this.treelist.get_item(key)).children().first().html(prop.name);
       this.env.contactfolders[key].name = this.env.contactgroups[key].name = prop.name;
 
-      if (prop.id == this.env.group)
+      if (prop.source == this.env.source && prop.id == this.env.group)
         this.set_group_prop(prop);
     }
 


### PR DESCRIPTION
Sorry this is a small amendment to #5652. I realised that the source id must be checked as well as the group id

Also the group-delete action causes the selection to change, and this is only needed if its the current group. Again sorry I didn't pick this up before.