### PR TITLE
It's better to remove '//IGNORE' from $iconv_options and let mbstring to convert non-strict characters

### DIFF
--- a/program/lib/Roundcube/rcube_charset.php
+++ b/program/lib/Roundcube/rcube_charset.php
@@ -212,6 +212,7 @@ class rcube_charset
             $aliases = array(
                 'WINDOWS-1257' => 'ISO-8859-13',
                 'US-ASCII'     => 'ASCII',
+                'ISO-2022-JP'  => 'ISO-2022-JP-MS',
             );
 
             $mb_from = $aliases[$from] ?: $from;

--- a/program/lib/Roundcube/rcube_charset.php
+++ b/program/lib/Roundcube/rcube_charset.php
@@ -170,7 +170,7 @@ class rcube_charset
      */
     public static function convert($str, $from, $to = null)
     {
-        static $iconv_options = null;
+        static $iconv_options = '';
         static $mbstring_sc   = null;
 
         $to   = empty($to) ? RCUBE_CHARSET : strtoupper($to);
@@ -186,24 +186,9 @@ class rcube_charset
             return $str;
         }
 
-        if ($iconv_options === null) {
-            if (function_exists('iconv')) {
-                // ignore characters not available in output charset
-                $iconv_options = '//IGNORE';
-                if (iconv('', $iconv_options, '') === false) {
-                    // iconv implementation does not support options
-                    $iconv_options = '';
-                }
-            }
-            else {
-                $iconv_options = false;
-            }
-        }
-
         // convert charset using iconv module
-        if ($iconv_options !== false && $from != 'UTF7-IMAP' && $to != 'UTF7-IMAP') {
-            // throw an exception if iconv reports an illegal character in input
-            // it means that input string has been truncated
+        if ($from != 'UTF7-IMAP' && $to != 'UTF7-IMAP') {
+            // throw an exception if iconv fails
             set_error_handler(array('rcube_charset', 'error_handler'), E_NOTICE);
             try {
                 $out = iconv($from, $to . $iconv_options, $str);
@@ -232,7 +217,7 @@ class rcube_charset
             $mb_from = $aliases[$from] ?: $from;
             $mb_to   = $aliases[$to] ?: $to;
 
-            // Do the same as //IGNORE with iconv
+            // Ignore characters not available in output charset
             mb_substitute_character('none');
 
             // throw an exception if mbstring reports an illegal character in input

--- a/tests/Framework/Charset.php
+++ b/tests/Framework/Charset.php
@@ -179,7 +179,7 @@ class Framework_Charset extends PHPUnit_Framework_TestCase
     function data_detect_with_lang()
     {
         return array(
-            array('顯示名稱,主要', 'zh_TW', 'BIG-5'),
+            array(base64_decode('xeOl3KZXutkspUStbg=='), 'zh_TW', 'BIG-5'),
         );
     }
 

--- a/tests/Framework/Charset.php
+++ b/tests/Framework/Charset.php
@@ -70,6 +70,7 @@ class Framework_Charset extends PHPUnit_Framework_TestCase
             array('aż', 'a', 'UTF-8', 'US-ASCII'),
             array('&BCAEMARBBEEESwQ7BDoEOA-', 'Рассылки', 'UTF7-IMAP', 'UTF-8'),
             array('Рассылки', '&BCAEMARBBEEESwQ7BDoEOA-', 'UTF-8', 'UTF7-IMAP'),
+            array(base64_decode('GyRCLWo7M3l1OSk2SBsoQg=='), '㈱山﨑工業', 'ISO-2022-JP', 'UTF8'),
         );
     }
 


### PR DESCRIPTION
We sometimes get broken character encodings such as:
Subject: =?iso-2022-jp?B?GyRCLWo7M3l1OSk2SBsoQgo=?=

This actually is not a strict ISO-2022-JP string, but a CP50220 string that
is a variant of ISO-2022-JP with extended characters proposed by Microsoft.

https://www.iana.org/assignments/charset-reg/CP50220

iconv can not handle these encodings well.

Example:

    $ echo '㈱山﨑工業' \
        | nkf --ic=UTF-8 --oc=ISO-2022-JP \
        | iconv -f ISO-2022-JP -t UTF-8//IGNORE

    $B-j;3yu9)6H

Remove '//IGNORE' from $iconv_options to produce:

    $ echo '㈱山﨑工業' \
        | nkf --ic=UTF-8 --oc=ISO-2022-JP \
        | php -r '
            $stdin = fgets(STDIN);
            mb_substitute_character('none');
            echo mb_convert_encoding($stdin, "UTF-8", "ISO-2022-JP");'

    山工業

Add alias from ISO-2022-JP to ISO-2022-JP-MS to produce:

    $ echo '㈱山﨑工業' \
        | nkf --ic=UTF-8 --oc=ISO-2022-JP \
        | php -r '
            $stdin = fgets(STDIN);
            mb_substitute_character('none');
            echo mb_convert_encoding($stdin, "UTF-8", "ISO-2022-JP-MS");'

    ㈱山﨑工業
