### PR TITLE
Unset HTTP Referer when following external links

### DIFF
--- a/program/lib/Roundcube/rcube_output.php
+++ b/program/lib/Roundcube/rcube_output.php
@@ -190,6 +190,9 @@ abstract class rcube_output
 
         // Request browser to disable DNS prefetching (CVE-2010-0464)
         header("X-DNS-Prefetch-Control: off");
+     
+        // Request browser disable Referer (sic) header
+        header("Referrer-Policy: same-origin");
 
         // send CSRF and clickjacking protection headers
         if ($xframe = $this->app->config->get('x_frame_options', 'sameorigin')) {


### PR DESCRIPTION
Keep user’s webmail provider private by unsetting the `Referer`
header when clicking through to or requesting any external resources.

https://www.w3.org/TR/referrer-policy/#referrer-policy-header
https://www.w3.org/TR/referrer-policy/#referrer-policy-same-origin