### PR TITLE
Add Log to STDOUT Feature

### DIFF
--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -66,7 +66,7 @@ $config['db_max_allowed_packet'] = null;
 // system error reporting, sum of: 1 = log; 4 = show
 $config['debug_level'] = 1;
 
-// log driver:  'syslog' or 'file'.
+// log driver:  'syslog', 'stdout' or 'file'.
 $config['log_driver'] = 'file';
 
 // date format for log entries

--- a/installer/config.php
+++ b/installer/config.php
@@ -216,11 +216,11 @@ echo '<label for="cfgdebug4">Print errors (to the browser)</label><br />';
 <?php
 
 $select_log_driver = new html_select(array('name' => '_log_driver', 'id' => "cfglogdriver"));
-$select_log_driver->add(array('file', 'syslog'), array('file', 'syslog'));
+$select_log_driver->add(array('file', 'syslog', 'stdout'), array('file', 'syslog', 'stdout'));
 echo $select_log_driver->show($RCI->getprop('log_driver', 'file'));
 
 ?>
-<div>How to do logging? 'file' - write to files in the log directory, 'syslog' - use the syslog facility.</div>
+<div>How to do logging? 'file' - write to files in the log directory, 'syslog' - use the syslog facility, 'stdout' writes to the process' STDOUT file descriptor.</div>
 </dd>
 
 <dt class="propname">log_dir</dt>

--- a/program/lib/Roundcube/rcube.php
+++ b/program/lib/Roundcube/rcube.php
@@ -1221,6 +1221,13 @@ class rcube
             return syslog($prio, $line);
         }
 
+        // write message with file name when configured to log to STDOUT
+        if ($log_driver == 'stdout') {
+            $stdout = "php://stdout";
+            $line = "$name: $line";
+            return file_put_contents($stdout, $line, FILE_APPEND) !== false;
+        }
+
         // log_driver == 'file' is assumed here
 
         $line = sprintf("[%s]: %s\n", $date, $line);


### PR DESCRIPTION
I've written this feature addition in order to scratch my own personal itch. When running roundcube under Docker, logs can either go to syslog or file. Since PHP-FPM creates worker pools with restricted permissions, there is no way to symlink a log file to PID 1's STDOUT, so Docker can't log roundcube logs. syslog works, but the whole idea of a docker container is to not have multiple processes running in a container.

This code allows roundcube to write straight to STDOUT, which PHP-FPM can grab when configured with `catch_workers_output = true` and output to the Docker container's STDOUT when php-fpm is run with the `-F` and `-O` options like so: `php-fpm -F -O`.

I would love to have this merged into master if you find it of use. I'm currently running this code against the 1.2.4 tag (cbd35626f7db7855f3b5e2db00d28ecc1554e9f4) without issue.

I've tried to put in some documentation where I could find it. If there is another area of documentation that could be buffed up to include this, point me in the right direction and I don't mind adding it to the PR.

Thanks for your consideration!