### PR TITLE
Password plugin: Added missing default values

### DIFF
--- a/plugins/password/config.inc.php.dist
+++ b/plugins/password/config.inc.php.dist
@@ -448,7 +448,7 @@ $config['password_expect_params'] = '';
 // %t - hostname without the first part
 // %d - domain (http hostname $_SERVER['HTTP_HOST'] without the first part)
 $config['password_smb_host'] = 'localhost';
-// Location of smbpasswd binary
+// Location of smbpasswd binary (default: /usr/bin/smbpasswd)
 $config['password_smb_cmd'] = '/usr/bin/smbpasswd';
 
 // gearman driver options

--- a/plugins/password/config.inc.php.dist
+++ b/plugins/password/config.inc.php.dist
@@ -178,7 +178,7 @@ $config['password_ldap_version'] = '3';
 $config['password_ldap_basedn'] = 'dc=exemple,dc=com';
 
 // LDAP connection method
-// There is two connection method for changing a user's LDAP password.
+// There are two connection methods for changing a user's LDAP password.
 // 'user': use user credential (recommended, require password_confirm_current=true)
 // 'admin': use admin credential (this mode require password_ldap_adminDN and password_ldap_adminPW)
 // Default: 'user'

--- a/plugins/password/drivers/gearman.php
+++ b/plugins/password/drivers/gearman.php
@@ -39,7 +39,7 @@ class rcube_gearman_password
             );
 
             $gmc = new GearmanClient();
-            $gmc->addServer($rcmail->config->get('password_gearman_host'));
+            $gmc->addServer($rcmail->config->get('password_gearman_host', 'localhost'));
 
             $result  = $gmc->doNormal('setPassword', json_encode($payload));
             $success = json_decode($result);

--- a/plugins/password/drivers/ldap.php
+++ b/plugins/password/drivers/ldap.php
@@ -65,10 +65,10 @@ class rcube_ldap_password
             'binddn'    => $binddn,
             'bindpw'    => $bindpw,
             'basedn'    => $rcmail->config->get('password_ldap_basedn'),
-            'host'      => $rcmail->config->get('password_ldap_host'),
-            'port'      => $rcmail->config->get('password_ldap_port'),
+            'host'      => $rcmail->config->get('password_ldap_host', 'localhost'),
+            'port'      => $rcmail->config->get('password_ldap_port', '389'),
             'starttls'  => $rcmail->config->get('password_ldap_starttls'),
-            'version'   => $rcmail->config->get('password_ldap_version'),
+            'version'   => $rcmail->config->get('password_ldap_version', '3'),
         );
 
         // Connecting using the configuration array
@@ -79,13 +79,13 @@ class rcube_ldap_password
             return PASSWORD_CONNECT_ERROR;
         }
 
-        $force        = $rcmail->config->get('password_ldap_force_replace');
-        $pwattr       = $rcmail->config->get('password_ldap_pwattr');
+        $force        = $rcmail->config->get('password_ldap_force_replace', true);
+        $pwattr       = $rcmail->config->get('password_ldap_pwattr', 'userPassword');
         $lchattr      = $rcmail->config->get('password_ldap_lchattr');
         $smbpwattr    = $rcmail->config->get('password_ldap_samba_pwattr');
         $smblchattr   = $rcmail->config->get('password_ldap_samba_lchattr');
         $samba        = $rcmail->config->get('password_ldap_samba');
-        $encodage     = $rcmail->config->get('password_ldap_encodage');
+        $encodage     = $rcmail->config->get('password_ldap_encodage', 'crypt');
 
         // Support multiple userPassword values where desired.
         // multiple encodings can be specified separated by '+' (e.g. "cram-md5+ssha")
@@ -161,10 +161,10 @@ class rcube_ldap_password
 
         $ldapConfig = array (
             'basedn'    => $rcmail->config->get('password_ldap_basedn'),
-            'host'      => $rcmail->config->get('password_ldap_host'),
-            'port'      => $rcmail->config->get('password_ldap_port'),
+            'host'      => $rcmail->config->get('password_ldap_host', 'localhost'),
+            'port'      => $rcmail->config->get('password_ldap_port', '389'),
             'starttls'  => $rcmail->config->get('password_ldap_starttls'),
-            'version'   => $rcmail->config->get('password_ldap_version'),
+            'version'   => $rcmail->config->get('password_ldap_version', '3'),
         );
 
         // allow anonymous searches

--- a/plugins/password/drivers/ldap_simple.php
+++ b/plugins/password/drivers/ldap_simple.php
@@ -59,8 +59,8 @@ class rcube_ldap_simple_password
         $this->_debug("S: OK");
 
         // Set protocol version
-	ldap_set_option($ds, LDAP_OPT_PROTOCOL_VERSION,
-	    $rcmail->config->get('password_ldap_version', '3'));
+        ldap_set_option($ds, LDAP_OPT_PROTOCOL_VERSION,
+            $rcmail->config->get('password_ldap_version', '3'));
 
         // Start TLS
         if ($rcmail->config->get('password_ldap_starttls')) {

--- a/plugins/password/drivers/ldap_simple.php
+++ b/plugins/password/drivers/ldap_simple.php
@@ -37,8 +37,8 @@ class rcube_ldap_simple_password
 
         $this->debug = $rcmail->config->get('ldap_debug');
 
-        $ldap_host = $rcmail->config->get('password_ldap_host');
-        $ldap_port = $rcmail->config->get('password_ldap_port');
+        $ldap_host = $rcmail->config->get('password_ldap_host', 'localhost');
+        $ldap_port = $rcmail->config->get('password_ldap_port', '389');
 
         $this->_debug("C: Connect to $ldap_host:$ldap_port");
 
@@ -59,7 +59,8 @@ class rcube_ldap_simple_password
         $this->_debug("S: OK");
 
         // Set protocol version
-        ldap_set_option($ds, LDAP_OPT_PROTOCOL_VERSION, $rcmail->config->get('password_ldap_version'));
+	ldap_set_option($ds, LDAP_OPT_PROTOCOL_VERSION,
+	    $rcmail->config->get('password_ldap_version', '3'));
 
         // Start TLS
         if ($rcmail->config->get('password_ldap_starttls')) {
@@ -106,11 +107,11 @@ class rcube_ldap_simple_password
         }
 
         $lchattr      = $rcmail->config->get('password_ldap_lchattr');
-        $pwattr       = $rcmail->config->get('password_ldap_pwattr');
+        $pwattr       = $rcmail->config->get('password_ldap_pwattr', 'userPassword');
         $smbpwattr    = $rcmail->config->get('password_ldap_samba_pwattr');
         $smblchattr   = $rcmail->config->get('password_ldap_samba_lchattr');
         $samba        = $rcmail->config->get('password_ldap_samba');
-        $pass_mode    = $rcmail->config->get('password_ldap_encodage');
+        $pass_mode    = $rcmail->config->get('password_ldap_encodage', 'crypt');
         $crypted_pass = password::hash_password($passwd, $pass_mode);
 
         // Support password_ldap_samba option for backward compat.


### PR DESCRIPTION
As discussed in issue #5724

Since `$rcmail->config->get('non_existent')` returns `NULL` I did not add defaults for values defaulting to `NULL` or 'false' – since they already work as expected. But I can change that, if preference for "explicit is better than implicit".

I also had to break the 80 characters per line limit; the alternative was to mess with the indentation.