### PR TITLE
SRI + XHTML

### DIFF
--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -645,6 +645,16 @@ $config['assets_path'] = '';
 // PHP code about the location of asset files in filesystem
 $config['assets_dir'] = '';
 
+// Add SRI (Subresource Integrity) tags to assets
+// This currently works by reading the files in asset_dir
+// during page serve time and appending a corresponding
+// SHA-384 hash tag.
+// Warning: Because the hash is calculated every time a
+// page is served, enabling this option may result in
+// decreased performance.
+// See https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity
+// for more information on SRI
+$config['assets_sri'] = false;
 
 // ----------------------------------
 // PLUGINS

--- a/program/include/rcmail_output_html.php
+++ b/program/include/rcmail_output_html.php
@@ -770,7 +770,7 @@ EOF;
         }
 
         list($file) = explode('?', $path, 2);
-        if (!empty($file) && is_readable($file)) {
+        if (!empty($file) && is_readable($this->assets_dir . $file)) {
 	    $content = @file_get_contents($this->assets_dir . $file);
 	    if ($content !== false) {
 	        return 'sha384-'.base64_encode(hash('sha384', $content, true));

--- a/program/include/rcmail_output_html.php
+++ b/program/include/rcmail_output_html.php
@@ -85,7 +85,7 @@ class rcmail_output_html extends rcmail_output
         $this->set_env('skin', $skin);
 
         $this->set_assets_path($this->config->get('assets_path'), $this->config->get('assets_dir'));
-        $this->assets_sri = $this->config->get('assets_sri');
+        $this->assets_sri = $this->config->get('assets_sri') && in_array('sha384', hash_algos(), true);
 
         if (!empty($_REQUEST['_extwin']))
             $this->set_env('extwin', 1);

--- a/program/include/rcmail_output_html.php
+++ b/program/include/rcmail_output_html.php
@@ -46,6 +46,7 @@ class rcmail_output_html extends rcmail_output
     protected $body   = '';
     protected $base_path = '';
     protected $assets_path;
+    protected $assets_sri = false;
     protected $assets_dir = RCUBE_INSTALL_PATH;
     protected $devel_mode = false;
 
@@ -84,6 +85,7 @@ class rcmail_output_html extends rcmail_output
         $this->set_env('skin', $skin);
 
         $this->set_assets_path($this->config->get('assets_path'), $this->config->get('assets_dir'));
+        $this->assets_sri = $this->config->get('assets_sri');
 
         if (!empty($_REQUEST['_extwin']))
             $this->set_env('extwin', 1);
@@ -756,6 +758,29 @@ EOF;
     }
 
     /**
+     * Get the sha384 hash for local assets
+     */
+    public function asset_sri($path)
+    {
+        // iframe content can't be in a different domain
+        // @TODO: check if assests are on a different domain
+
+        if (!$this->assets_sri || in_array($path[0], array('?', '/', '.')) || strpos($path, '://')) {
+            return false;
+        }
+
+        list($file) = explode('?', $path, 2);
+        if (!empty($file) && is_readable($file)) {
+	    $content = @file_get_contents($this->assets_dir . $file);
+	    if ($content !== false) {
+	        return 'sha384-'.base64_encode(hash('sha384', $content, true));
+	    }
+	}
+
+        return false;
+    }
+
+    /**
      * Modify path by adding URL prefix if configured
      */
     public function asset_url($path)
@@ -802,7 +827,7 @@ EOF;
     protected function fix_paths($output)
     {
         return preg_replace_callback(
-            '!(src|href|background)=(["\']?)([a-z0-9/_.-]+)(["\'\s>])!i',
+            '!(src|href|background)=(["\']?)([a-z0-9/_.-]+)\2([\s>]?)!i',
             array($this, 'file_callback'), $output);
     }
 
@@ -826,7 +851,34 @@ EOF;
             $file = $this->file_mod($file);
         }
 
-        return $matches[1] . '=' . $matches[2] . $file . $matches[4];
+        return $matches[1] . '=' . $matches[2] . $file . $matches[2] . $matches[4];
+    }
+
+    /**
+     * Add SRI tags to assets
+     */
+    protected function include_assets_sri($output)
+    {
+        return preg_replace_callback(
+            '!(src|href|background)=(["\']?)([a-z0-9/_.?=-]+)\2([\s>])?!i',
+            array($this, 'sri_callback'), $output);
+    }
+
+    /**
+     * Callback function for preg_replace_callback in include_assets_sri()
+     *
+     * @return string Parsed string
+     */
+    protected function sri_callback($matches)
+    {
+        $attrs = '';
+        $sri = $this->asset_sri($matches[3]);
+
+	if (!empty($sri)) {
+	    $attrs = ' integrity="' . $sri . '" crossorigin="anonymous"';
+	}
+
+        return $matches[1] . '=' . $matches[2] . $matches[3] . $matches[2] . $attrs . $matches[4];
     }
 
     /**
@@ -835,7 +887,7 @@ EOF;
     protected function fix_assets_paths($output)
     {
         return preg_replace_callback(
-            '!(src|href|background)=(["\']?)([a-z0-9/_.?=-]+)(["\'\s>])!i',
+            '!(src|href|background)=(["\']?)([a-z0-9/_.?=-]+)\2([\s>])?!i',
             array($this, 'assets_callback'), $output);
     }
 
@@ -848,7 +900,7 @@ EOF;
     {
         $file = $this->asset_url($matches[3]);
 
-        return $matches[1] . '=' . $matches[2] . $file . $matches[4];
+        return $matches[1] . '=' . $matches[2] . $file . $matches[2] . $matches[4];
     }
 
     /**
@@ -1678,6 +1730,10 @@ EOF;
         }
 
         $output = $this->parse_with_globals($this->fix_paths($output));
+
+        if ($this->assets_sri) {
+            $output = $this->include_assets_sri($output);
+        }
 
         if ($this->assets_path) {
             $output = $this->fix_assets_paths($output);

--- a/program/lib/Roundcube/html.php
+++ b/program/lib/Roundcube/html.php
@@ -86,7 +86,7 @@ class html
             return '<' . $tagname  . self::attrib_string($attrib, $allowed) . '>' . $content . $suffix;
         }
         else {
-            return '<' . $tagname  . self::attrib_string($attrib, $allowed) . '>' . $suffix;
+            return '<' . $tagname  . self::attrib_string($attrib, $allowed) . '/>' . $suffix;
         }
     }
 
@@ -99,6 +99,7 @@ class html
     {
         $doctypes = array(
             'html5'        => '<!DOCTYPE html>',
+            'xhtml-html5'  => '<!DOCTYPE html>',
             'xhtml'        => '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">',
             'xhtml-trans'  => '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">',
             'xhtml-strict' => '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">',


### PR DESCRIPTION
I've written a patch that does the following:

1) Impment support for subresource requrest integrity (off by default)
2) Fixes some of the regexes used for matching tag attributes (the current expression would match `src="a'`; now, it enforces that the same quotation style be used)
3) Fixed the missing "/" at the end of tags that aren't closed, useful for XHTML compliance
4) Added the xhtml-html5 doctype to support xhtml5

