### PR TITLE
Fix scroll in Edge browser

### DIFF
--- a/skins/larry/mail.css
+++ b/skins/larry/mail.css
@@ -16,7 +16,7 @@
 	left: 0;
 	width: 200px;
 	bottom: 0;
-	z-index: 2;
+	z-index: 4;
 }
 
 #mailview-right {


### PR DESCRIPTION
I was unable to scroll the left pane.
With the z-index set to 4 the expected behavior is achieved.

Edge:
"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.79 Safari/537.36 Edge/14.14393"