### PR TITLE
Virtualmin driver for password plugin: Simplification

### DIFF
--- a/plugins/password/config.inc.php.dist
+++ b/plugins/password/config.inc.php.dist
@@ -401,16 +401,7 @@ $config['hmailserver_server'] = array(
 
 // Virtualmin Driver options
 // -------------------------
-// Username format:
-// 0: username@domain
-// 1: username%domain
-// 2: username.domain
-// 3: domain.username
-// 4: username-domain
-// 5: domain-username
-// 6: username_domain
-// 7: domain_username
-$config['password_virtualmin_format'] = 0;
+// No settings needed
 
 
 // pw_usermod Driver options

--- a/plugins/password/drivers/virtualmin.php
+++ b/plugins/password/drivers/virtualmin.php
@@ -34,46 +34,28 @@ class rcube_virtualmin_password
     function save($currpass, $newpass)
     {
         $rcmail   = rcmail::get_instance();
-        $format   = $rcmail->config->get('password_virtualmin_format', 0);
         $username = $_SESSION['username'];
-
-        switch ($format) {
-        case 1: // username%domain
-            $domain = substr(strrchr($username, "%"), 1);
-            break;
-        case 2: // username.domain (could be bogus)
-            $pieces = explode(".", $username);
-            $domain = $pieces[count($pieces)-2]. "." . end($pieces);
-            break;
-        case 3: // domain.username (could be bogus)
-            $pieces = explode(".", $username);
-            $domain = $pieces[0]. "." . $pieces[1];
-            break;
-        case 4: // username-domain
-            $domain = substr(strrchr($username, "-"), 1);
-            break;
-        case 5: // domain-username
-            $domain = str_replace(strrchr($username, "-"), "", $username);
-            break;
-        case 6: // username_domain
-            $domain = substr(strrchr($username, "_"), 1);
-            break;
-        case 7: // domain_username
-            $pieces = explode("_", $username);
-            $domain = $pieces[0];
-            break;
-        default: // username@domain
-            $domain = substr(strrchr($username, "@"), 1);
-        }
-
-        if (!$domain) {
-            $domain = $rcmail->user->get_username('domain');
-        }
-
+        $curdir   = RCUBE_PLUGINS_DIR . 'password/helpers';
         $username = escapeshellarg($username);
+
+        // Get the domain using virtualmin CLI:
+        exec("$curdir/chgvirtualminpasswd list-domains --mail-user $username --name-only", $output_domain, $returnvalue);
+
+        if ($returnvalue == 0 && count($output_domain) == 1)
+        {
+            $domain = trim($output_domain[0]);
+        }
+        else {
+            rcube::raise_error(array(
+                'code' => 600,
+                'type' => 'php',
+                'file' => __FILE__, 'line' => __LINE__,
+                'message' => "Password plugin: Unable to execute $curdir/chgvirtualminpasswd or domain for mail-user '$username' not known to Virtualmin"
+                ), true, false);
+        }
+
         $domain   = escapeshellarg($domain);
         $newpass  = escapeshellarg($newpass);
-        $curdir   = RCUBE_PLUGINS_DIR . 'password/helpers';
 
         exec("$curdir/chgvirtualminpasswd modify-user --domain $domain --user $username --pass $newpass", $output, $returnvalue);
 


### PR DESCRIPTION
**Problem/Situation**

The actual version of the virtualmin driver for the password plugin has an option to choose from eight different username schemes. This can be confusing and frustrating during installation/configuration. See a [post on roundcubeforum.net](http://www.roundcubeforum.net/index.php?topic=13322.0) and another pull request #5480 about this driver.

These schemes certainly cover most use cases, but are hard to maintain and did not cover mine (username.domain-without-tld).

**Solution**

Since 2014, the virtualmin command line interface (CLI) has the possibility to list the domains (actually it's always only one) with the `list-domains` command with query option `--mail-user`.

This features was introduced with commit virtualmin/virtualmin-gpl@5dd59dba9b4020f7c7b0e0793ca6aaea5107b44a and thus works for all versions since 4.09. Virtualmin GPL is now at version 5.07 and probably nobody should be using unsupporting versions anymore.

The changes introduces with this pull request make use of this feature and thereby simplify the process a lot.

I also tried to give a more usefull error messages. However, this could still be improved.

I'm pretty sure this would render the above mentioned pull request and all configuration issues around this obsolete.