### PR TITLE
newmail_notifier plugin: don't notify for junked messages.

### DIFF
--- a/plugins/newmail_notifier/newmail_notifier.php
+++ b/plugins/newmail_notifier/newmail_notifier.php
@@ -66,7 +66,7 @@ class newmail_notifier extends rcube_plugin
 
                 if (!empty($this->opt)) {
                     // Get folders to skip checking for
-                    $exceptions = array('drafts_mbox', 'sent_mbox', 'trash_mbox');
+                    $exceptions = array('drafts_mbox', 'sent_mbox', 'trash_mbox', 'junk_mbox');
                     foreach ($exceptions as $folder) {
                         $folder = $this->rc->config->get($folder);
                         if (strlen($folder) && $folder != 'INBOX') {


### PR DESCRIPTION
I don't think users need to be notified of new mail in their junk folder.

When the mail server filters spam directly into the junk folder, but leaves it marked unread, so you can check for false positives every now and then.