### PR TITLE
Add support for Pointer events

### DIFF
--- a/program/js/common.js
+++ b/program/js/common.js
@@ -58,15 +58,15 @@ function roundcube_browser()
   this.dom = document.getElementById ? true : false;
   this.dom2 = document.addEventListener && document.removeEventListener;
 
-  this.webkit = this.agent_lc.indexOf('applewebkit') > 0;
+  this.edge = this.agent_lc.indexOf(' edge/') > 0;
+  this.webkit = !this.edge && this.agent_lc.indexOf('applewebkit') > 0;
   this.ie = (document.all && !window.opera) || (this.win && this.agent_lc.indexOf('trident/') > 0);
-  this.edge = this.agent_lc.indexOf('edge/') > 0;
 
   if (window.opera) {
     this.opera = true; // Opera < 15
     this.vendver = opera.version();
   }
-  else if (!this.ie) {
+  else if (!this.ie && !this.edge) {
     this.chrome = this.agent_lc.indexOf('chrome') > 0;
     this.opera = this.webkit && this.agent.indexOf(' OPR/') > 0; // Opera >= 15
     this.safari = !this.chrome && !this.opera && (this.webkit || this.agent_lc.indexOf('safari') > 0);
@@ -92,6 +92,7 @@ function roundcube_browser()
   this.tablet = /ipad|android|xoom|sch-i800|playbook|tablet|kindle/i.test(this.agent_lc);
   this.mobile = /iphone|ipod|blackberry|iemobile|opera mini|opera mobi|mobile/i.test(this.agent_lc);
   this.touch = this.mobile || this.tablet;
+  this.pointer = typeof window.PointerEvent == "function";
   this.cookies = n.cookieEnabled;
 
   // test for XMLHTTP support


### PR DESCRIPTION
Related to #5781 

Add support in list.js for pointer events. Also add detection for Edge browser.

In IE11/Edge the mousedown event is fired too easily for touch events, This uses the pointerdown and pointerup events to check the length of time the touch was held and act accordingly