### PR TITLE
Use better entropy sources in gen_message_id()

### DIFF
--- a/program/lib/Roundcube/rcube.php
+++ b/program/lib/Roundcube/rcube.php
@@ -1552,7 +1552,7 @@ class rcube
      */
     public function gen_message_id($sender = null)
     {
-        $local_part  = md5(uniqid('rcube'.mt_rand(), true));
+        $local_part  = base_convert(microtime(true), 10, 36).'.'.rcube_utils::random_bytes(16);
         $domain_part = '';
 
         if ($sender && preg_match('/@([^\s]+\.[a-z0-9-]+)/', $sender, $m)) {


### PR DESCRIPTION
While collisions are unlikely, it might be a good idea to use random_bytes, when it's available.
Also add base 36 encoded time stamp to the local part.

The best practices for message ids seem to be:
*    Append "<".
*    Get the current (wall-clock) time in the highest resolution to which you have access (most systems can give it to you in milliseconds, but seconds will do);
*    Generate 64 bits of randomness from a good, well-seeded random number generator;
*    Convert these two numbers to base 36 (0-9 and A-Z) and append the first number, a ".", the second number, and an "@". This makes the left hand side of the message ID be only about 21 characters long.
*    Append the FQDN of the local host, or the host name in the user's return address.
*    Append ">". 

https://www.jwz.org/doc/mid.html