### PR TITLE
Fix regression when JAR_DIR is a relative path

### DIFF
--- a/bin/jsshrink.sh
+++ b/bin/jsshrink.sh
@@ -37,7 +37,7 @@ if [ ! -r "$JAR_DIR/compiler.jar" ]; then
 		echo "Please download $CLOSURE_COMPILER_URL and extract compiler.jar to $JAR_DIR/."
 		exit 1
 	fi
-	(cd $JAR_DIR && unzip -p "/tmp/$$.zip" "*.jar" > "$JAR_DIR/compiler.jar")
+	unzip -p "/tmp/$$.zip" "*.jar" > "$JAR_DIR/compiler.jar"
 	rm -f "/tmp/$$.zip"
 fi
 


### PR DESCRIPTION
Having a relative JAR_DIR used to work. In any case, the `cd $JAR_DIR` is redundant.