### PR TITLE
Fix absent directory error in install-jsdeps.sh when processing "maps" section

### DIFF
--- a/bin/install-jsdeps.sh
+++ b/bin/install-jsdeps.sh
@@ -215,6 +215,9 @@ function extract_zipfile($package, $srcfile)
   // unzip the archive and map source to dest files/directories
   else if (!empty($package['map'])) {
     $extract = $CACHEDIR . '/' . $package['lib'] . '-extract';
+    if (!is_dir($extract)) {
+      mkdir($extract, 0774, true);
+    }
     exec(sprintf('%s -o %s -d %s', $UNZIP, escapeshellarg($srcfile), $extract), $out, $retval);
 
     // get the root folder of the extracted package


### PR DESCRIPTION
Currently, the `bin/install-jsdeps.sh` just does not work out-of-the-box and complains about absent directories.

It can be reproduced with this `Dockerfile`:
```Dockerfile
FROM php:7-fpm-alpine

RUN apk add --update file

RUN curl -fL -o /tmp/roundcube.tar.gz \
         https://github.com/roundcube/roundcubemail/releases/download/1.3.0/roundcubemail-1.3.0.tar.gz \
 && tar -xzf /tmp/roundcube.tar.gz -C /tmp/ \
 && cd /tmp/roundcubemail-* \

 && bin/install-jsdeps.sh
```

Running `docker build -t roundcube-test ./` ends with:
```
...
Installing jQuery...
Fetching https://code.jquery.com/jquery-3.2.1.min.js
Wrote file /tmp/roundcubemail-1.3.0/program/js/jquery.min.js
Done.

Installing jsTimezoneDetect...
Fetching https://bitbucket.org/pellepim/jstimezonedetect/raw/6c427658686c664da52c6a87cd62ec910baab276/dist/jstz.min.js
Wrote file /tmp/roundcubemail-1.3.0/program/js/jstz.min.js
Done.

Installing PublicKey.js...
Fetching https://raw.githubusercontent.com/diafygi/publickeyjs/0e011cb18907a1adc0313aa92e69cd8858e1ef66/publickey.js
Wrote file /tmp/roundcubemail-1.3.0/program/js/publickey.js
Done.

Installing tinymce...
Fetching http://download.ephox.com/tinymce/community/tinymce_4.5.7.zip
unzip: can't change directory to '/tmp/roundcubemail-1.3.0/temp/js_cache/tinymce-extract': No such file or directory
Installing files /js/tinymce into /tmp/roundcubemail-1.3.0/program/js/tinymce
mv: can't rename '/js/tinymce': No such file or directory
ERROR: Failed to move js/tinymce into /tmp/roundcubemail-1.3.0/program/js/tinymce; 
ERROR: Failed to write destination file /tmp/roundcubemail-1.3.0/program/js/tinymce/tinymce.min.js
 ---> 32777e6a4fdd
Removing intermediate container 7bfdda5892cd
Successfully built 32777e6a4fdd
```

This PR proposes simple fix for this situation by precreating required temp dirs.