### PR TITLE
.user.ini for php-fpm

### DIFF
--- a/.user.ini
+++ b/.user.ini
@@ -1,0 +1,21 @@
+; This file is read and processed by the CGI/FastCGI SAPI
+; PHP settings in .htaccess are only available to the PHP Apache module
+; also see: http://php.net/manual/en/configuration.file.per-user.php
+
+display_errors=Off
+log_errors=On
+;error_log=logs/errors
+
+upload_max_filesize=5M
+post_max_size=6M
+memory_limit=64M
+
+zlib.output_compression=Off
+suhosin.session.encrypt=Off
+
+;session.cookie_path=/
+;session.hash_function=sha256
+session.auto_start=Off
+session.gc_maxlifetime=21600
+session.gc_divisor=500
+session.gc_probability=1


### PR DESCRIPTION
PHP settings in .htaccess are ignored by php-fpm. They have to
be put in a file called .user.ini

see #5846