### PR TITLE
Split steps to install jsdeps

### DIFF
--- a/bin/install-jsdeps.sh
+++ b/bin/install-jsdeps.sh
@@ -44,9 +44,13 @@ if (empty($UNZIP)) {
 if (empty($FILEINFO)) {
   die("ERROR: Required program 'file' not found\n");
 }
+
 $CACHEDIR = sys_get_temp_dir();
 
-if (is_writeable(INSTALL_PATH . 'temp/js_cache') || @mkdir(INSTALL_PATH . 'temp/js_cache', 0774, true)) {
+if (getenv("CACHEDIR") != false && is_writeable(getenv("CACHEDIR"))) {
+  $CACHEDIR = getenv("CACHEDIR");
+}
+else if (is_writeable(INSTALL_PATH . 'temp/js_cache') || @mkdir(INSTALL_PATH . 'temp/js_cache', 0774, true)) {
   $CACHEDIR = INSTALL_PATH . 'temp/js_cache';
 }
 


### PR DESCRIPTION
For building Debian packages, we can't download the jsdeps during the building phase. That's why we need to split the get and extract steps. Also for Debian packages, there is a default place, where 3rdparty code should be put.