### PR TITLE
accumlated patches from Debian

### DIFF
--- a/bin/cleandb.sh
+++ b/bin/cleandb.sh
@@ -19,7 +19,7 @@
  +-----------------------------------------------------------------------+
 */
 
-define('INSTALL_PATH', realpath(__DIR__ . '/..') . '/' );
+define('INSTALL_PATH', '/var/lib/roundcube/' );
 
 require INSTALL_PATH.'program/include/clisetup.php';
 

--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -1032,7 +1032,7 @@ $config['contact_search_name'] = '{name} <{email}>';
 // ----------------------------------
 
 // Use this charset as fallback for message decoding
-$config['default_charset'] = 'ISO-8859-1';
+$config['default_charset'] = 'UTF-8';
 
 // skin name: folder from skins/
 $config['skin'] = 'larry';

--- a/plugins/http_authentication/logout.html
+++ b/plugins/http_authentication/logout.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>Logout</title>
-<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.6/jquery.min.js"></script>
+<script type="text/javascript" src="../../program/js/jquery.min.js"></script>
 <script type="text/javascript">
 
 // as seen on http://stackoverflow.com/questions/31326/is-there-a-browser-equivalent-to-ies-clearauthenticationcache

--- a/program/include/iniset.php
+++ b/program/include/iniset.php
@@ -36,6 +36,10 @@ if (!defined('RCUBE_LOCALIZATION_DIR')) {
     define('RCUBE_LOCALIZATION_DIR', INSTALL_PATH . 'program/localization/');
 }
 
+if (!defined('DEBIAN_PKG')) {
+    define('DEBIAN_PKG', FALSE);
+}
+
 define('RCUBE_INSTALL_PATH', INSTALL_PATH);
 define('RCUBE_CONFIG_DIR',  RCMAIL_CONFIG_DIR.'/');
 

--- a/program/lib/Roundcube/rcube_db.php
+++ b/program/lib/Roundcube/rcube_db.php
@@ -68,6 +68,7 @@ class rcube_db
         $driver     = strtolower(substr($db_dsnw, 0, strpos($db_dsnw, ':')));
         $driver_map = array(
             'sqlite2' => 'sqlite',
+            'sqlite3' => 'sqlite',
             'sybase'  => 'mssql',
             'dblib'   => 'mssql',
             'mysqli'  => 'mysql',

--- a/skins/classic/common.css
+++ b/skins/classic/common.css
@@ -1198,7 +1198,7 @@ a.rcmContactAddress:hover
   margin-left: auto;
   margin-right: auto;
   margin-top: 50px;
-  width: 400px;
+  width: 420px;
   border: 1px solid #999;
 }
 


### PR DESCRIPTION
Since a while we have some patches in the pipeline to patch rcm. This are a first bunch of patches. It makes sense to review them on a single commit base.

I think at least the last two "make update script work together with debian package manager." and "Set INSTALL_PATH to /var/lib/roundcube/ in bin/cleandb.sh" need to be reworked to enter rcm.

from the postinst script we call update.sh:
```
DEBIAN_PKG=TRUE RCMAIL_CONFIG_DIR=/etc/roundcube /usr/bin/php /usr/share/roundcube/bin/update.sh --version=${OLD_UPSTREAM_VERSION} --accept=true
```

