### PR TITLE
support disabling of specific actions in managesieve plugin

### DIFF
--- a/plugins/managesieve/config.inc.php.dist
+++ b/plugins/managesieve/config.inc.php.dist
@@ -106,3 +106,9 @@ $config['managesieve_notify_methods'] = array('mailto');
 
 // Enables scripts RAW editor feature
 $config['managesieve_raw_editor'] = true;
+
+// Disabled actions
+// Prevent user from performing specific actions:
+// list_sets, enable_disable_set, delete_set, new_set, download_set, new_rule, delete_rule
+// Note: disabling list_sets removes the Filter sets widget from the UI and means the set defined in managesieve_script_name will always be used (and activated)
+$config['managesieve_disabled_actions'] = array();

--- a/plugins/managesieve/lib/Roundcube/rcube_sieve_engine.php
+++ b/plugins/managesieve/lib/Roundcube/rcube_sieve_engine.php
@@ -62,6 +62,7 @@ class rcube_sieve_engine
         2 => 'notifyimportancenormal',
         1 => 'notifyimportancehigh'
     );
+    private $disabled_actions;
 
     const VERSION  = '8.9';
     const PROGNAME = 'Roundcube (Managesieve)';
@@ -91,6 +92,8 @@ class rcube_sieve_engine
             'filtersetform'    => array($this, 'filterset_form'),
             'filterseteditraw' => array($this, 'filterset_editraw'),
         ));
+
+        $this->disabled_actions = $this->rc->config->get('managesieve_disabled_actions', array());
 
         // connect to managesieve server
         $error = $this->connect($_SESSION['username'], $this->rc->decrypt($_SESSION['password']));
@@ -147,6 +150,9 @@ class rcube_sieve_engine
         }
 
         $this->rc->output->set_env('raw_sieve_editor', $this->rc->config->get('managesieve_raw_editor', true));
+        $this->rc->output->set_env('managesieve_disabled_actions', $this->disabled_actions);
+        if (in_array('list_sets', $this->disabled_actions))
+            $this->rc->output->set_env('managesieve_no_set_list', true);
 
         return $error;
     }
@@ -288,17 +294,22 @@ class rcube_sieve_engine
             $fid = (int) rcube_utils::get_input_value('_fid', rcube_utils::INPUT_POST);
 
             if ($action == 'delete' && !$error) {
-                if (isset($this->script[$fid])) {
-                    if ($this->sieve->script->delete_rule($fid))
-                        $result = $this->save_script();
+                if (!in_array('delete_rule', $this->disabled_actions)) {
+                    if (isset($this->script[$fid])) {
+                        if ($this->sieve->script->delete_rule($fid))
+                            $result = $this->save_script();
 
-                    if ($result === true) {
-                        $this->rc->output->show_message('managesieve.filterdeleted', 'confirmation');
-                        $this->rc->output->command('managesieve_updatelist', 'del', array('id' => $fid));
+                        if ($result === true) {
+                            $this->rc->output->show_message('managesieve.filterdeleted', 'confirmation');
+                            $this->rc->output->command('managesieve_updatelist', 'del', array('id' => $fid));
+                        }
+                        else {
+                            $this->rc->output->show_message('managesieve.filterdeleteerror', 'error');
+                        }
                     }
-                    else {
-                        $this->rc->output->show_message('managesieve.filterdeleteerror', 'error');
-                    }
+                }
+                else {
+                    $this->rc->output->show_message('managesieve.disabledaction', 'error');
                 }
             }
             else if ($action == 'move' && !$error) {
@@ -366,60 +377,77 @@ class rcube_sieve_engine
                 }
             }
             else if ($action == 'setact' && !$error) {
-                $script_name = rcube_utils::get_input_value('_set', rcube_utils::INPUT_POST, true);
-                $result = $this->activate_script($script_name);
-                $kep14  = $this->rc->config->get('managesieve_kolab_master');
+                if (!in_array('enable_disable_set', $this->disabled_actions)) {
+                    $script_name = rcube_utils::get_input_value('_set', rcube_utils::INPUT_POST, true);
+                    $result = $this->activate_script($script_name);
+                    $kep14  = $this->rc->config->get('managesieve_kolab_master');
 
-                if ($result === true) {
-                    $this->rc->output->set_env('active_sets', $this->active);
-                    $this->rc->output->show_message('managesieve.setactivated', 'confirmation');
-                    $this->rc->output->command('managesieve_updatelist', 'setact',
-                        array('name' => $script_name, 'active' => true, 'all' => !$kep14));
+                    if ($result === true) {
+                        $this->rc->output->set_env('active_sets', $this->active);
+                        $this->rc->output->show_message('managesieve.setactivated', 'confirmation');
+                        $this->rc->output->command('managesieve_updatelist', 'setact',
+                            array('name' => $script_name, 'active' => true, 'all' => !$kep14));
+                    }
+                    else {
+                        $this->rc->output->show_message('managesieve.setactivateerror', 'error');
+                    }
                 }
                 else {
-                    $this->rc->output->show_message('managesieve.setactivateerror', 'error');
+                    $this->rc->output->show_message('managesieve.disabledaction', 'error');
                 }
             }
             else if ($action == 'deact' && !$error) {
-                $script_name = rcube_utils::get_input_value('_set', rcube_utils::INPUT_POST, true);
-                $result = $this->deactivate_script($script_name);
+                if (!in_array('enable_disable_set', $this->disabled_actions)) {
+                    $script_name = rcube_utils::get_input_value('_set', rcube_utils::INPUT_POST, true);
+                    $result = $this->deactivate_script($script_name);
 
-                if ($result === true) {
-                    $this->rc->output->set_env('active_sets', $this->active);
-                    $this->rc->output->show_message('managesieve.setdeactivated', 'confirmation');
-                    $this->rc->output->command('managesieve_updatelist', 'setact',
-                        array('name' => $script_name, 'active' => false));
+                    if ($result === true) {
+                        $this->rc->output->set_env('active_sets', $this->active);
+                        $this->rc->output->show_message('managesieve.setdeactivated', 'confirmation');
+                        $this->rc->output->command('managesieve_updatelist', 'setact',
+                            array('name' => $script_name, 'active' => false));
+                    }
+                    else {
+                        $this->rc->output->show_message('managesieve.setdeactivateerror', 'error');
+                    }
                 }
                 else {
-                    $this->rc->output->show_message('managesieve.setdeactivateerror', 'error');
+                    $this->rc->output->show_message('managesieve.disabledaction', 'error');
                 }
             }
             else if ($action == 'setdel' && !$error) {
-                $script_name = rcube_utils::get_input_value('_set', rcube_utils::INPUT_POST, true);
-                $result = $this->remove_script($script_name);
+                if (!in_array('delete_set', $this->disabled_actions)) {
+                    $script_name = rcube_utils::get_input_value('_set', rcube_utils::INPUT_POST, true);
+                    $result = $this->remove_script($script_name);
 
-                if ($result === true) {
-                    $this->rc->output->show_message('managesieve.setdeleted', 'confirmation');
-                    $this->rc->output->command('managesieve_updatelist', 'setdel',
-                        array('name' => $script_name));
-                    $this->rc->session->remove('managesieve_current');
+                    if ($result === true) {
+                        $this->rc->output->show_message('managesieve.setdeleted', 'confirmation');
+                        $this->rc->output->command('managesieve_updatelist', 'setdel',
+                            array('name' => $script_name));
+                        $this->rc->session->remove('managesieve_current');
+                    }
+                    else {
+                        $this->rc->output->show_message('managesieve.setdeleteerror', 'error');
+                    }
                 }
                 else {
-                    $this->rc->output->show_message('managesieve.setdeleteerror', 'error');
+                    $this->rc->output->show_message('managesieve.disabledaction', 'error');
                 }
             }
             else if ($action == 'setget') {
-                $this->rc->request_security_check(rcube_utils::INPUT_GET);
+                if (!in_array('download_set', $this->disabled_actions)) {
+                    $this->rc->request_security_check(rcube_utils::INPUT_GET);
 
-                $script_name = rcube_utils::get_input_value('_set', rcube_utils::INPUT_GPC, true);
-                $script      = $this->sieve->get_script($script_name);
+                    $script_name = rcube_utils::get_input_value('_set', rcube_utils::INPUT_GPC, true);
+                    $script      = $this->sieve->get_script($script_name);
 
-                if ($script !== false) {
-                    $this->rc->output->download_headers($script_name . '.txt', array('length' => strlen($script)));
-                    echo $script;
+                    if ($script !== false) {
+                        $this->rc->output->download_headers($script_name . '.txt', array('length' => strlen($script)));
+                        echo $script;
+                    }
+
+                    exit;
                 }
-
-                exit;
             }
             else if ($action == 'list') {
                 $result = $this->list_rules();
@@ -547,7 +575,10 @@ class rcube_sieve_engine
             $name_uc    = mb_strtolower($name);
             $list       = $this->list_scripts();
 
-            if (!$name) {
+            if (in_array('new_set', $this->disabled_actions)) {
+                $error = 'managesieve.disabledaction';
+            }
+            else if (!$name) {
                 $this->errors['name'] = $this->plugin->gettext('cannotbeempty');
             }
             else if (mb_strlen($name) > 128) {
@@ -1406,6 +1437,12 @@ class rcube_sieve_engine
 
         $fid = rcube_utils::get_input_value('_fid', rcube_utils::INPUT_GPC);
         $scr = isset($this->form) ? $this->form : $this->script[$fid];
+
+        // do not allow creation of new rules
+        if ($fid == null && in_array('new_rule', $this->disabled_actions)) {
+            $this->rc->output->show_message('managesieve.disabledaction', 'error');
+            return;
+        }
 
         $hiddenfields = new html_hiddenfield(array('name' => '_task', 'value' => $this->rc->task));
         $hiddenfields->add(array('name' => '_action', 'value' => 'plugin.managesieve-save'));
@@ -2469,6 +2506,17 @@ class rcube_sieve_engine
             $exceptions = $this->rc->config->get('managesieve_filename_exceptions');
             if (!empty($exceptions)) {
                 $this->list = array_diff($this->list, (array)$exceptions);
+            }
+        }
+
+        // When no script listing allowed limit the list to the defined script
+        if (in_array('list_sets', $this->disabled_actions)) {
+            $script_name = $this->rc->config->get('managesieve_script_name', 'roundcube');
+            $this->list = array_intersect($this->list, array($script_name));
+            $this->active = null;
+            if (in_array($script_name, $this->list)) {
+                // Because its the only allowed script make sure its active
+                $this->activate_script($script_name);
             }
         }
 

--- a/plugins/managesieve/localization/en_GB.inc
+++ b/plugins/managesieve/localization/en_GB.inc
@@ -237,4 +237,6 @@ $messages['saveerror'] = 'Unable to save data. Server error occurred.';
 $messages['vacationsaved'] = 'Vacation data saved successfully.';
 $messages['emptyvacationbody'] = 'Body of vacation message is required!';
 $messages['duplicate.conflict.err'] = 'Both header and unique identifier are not allowed.';
+$messages['disabledaction'] = 'Action not permitted.';
+
 ?>

--- a/plugins/managesieve/localization/en_US.inc
+++ b/plugins/managesieve/localization/en_US.inc
@@ -241,5 +241,6 @@ $messages['saveerror'] = 'Unable to save data. Server error occurred.';
 $messages['vacationsaved'] = 'Vacation data saved successfully.';
 $messages['emptyvacationbody'] = 'Body of vacation message is required!';
 $messages['duplicate.conflict.err'] = 'Both header and unique identifier are not allowed.';
+$messages['disabledaction'] = 'Action not permitted.';
 
 ?>

--- a/plugins/managesieve/managesieve.js
+++ b/plugins/managesieve/managesieve.js
@@ -56,7 +56,8 @@ if (window.rcmail) {
         sieve_raw_editor_init();
       }
       else {
-        rcmail.enable_command('plugin.managesieve-add', 'plugin.managesieve-setadd', !rcmail.env.sieveconnerror);
+        rcmail.enable_command('plugin.managesieve-add', !rcmail.env.sieveconnerror && $.inArray('new_rule', rcmail.env.managesieve_disabled_actions) == -1);
+        rcmail.enable_command('plugin.managesieve-setadd', !rcmail.env.sieveconnerror && $.inArray('new_set', rcmail.env.managesieve_disabled_actions) == -1);
       }
 
       var setcnt, set = rcmail.env.currentset;
@@ -92,8 +93,9 @@ if (window.rcmail) {
 
         setcnt = rcmail.filtersets_list.rowcount;
         rcmail.enable_command('plugin.managesieve-set', true);
-        rcmail.enable_command('plugin.managesieve-setact', 'plugin.managesieve-setget', setcnt > 0);
-        rcmail.enable_command('plugin.managesieve-setdel', setcnt > 1);
+        rcmail.enable_command('plugin.managesieve-setact', setcnt > 0 && $.inArray('enable_disable_set', rcmail.env.managesieve_disabled_actions) == -1);
+        rcmail.enable_command('plugin.managesieve-setget', setcnt > 0 && $.inArray('download_set', rcmail.env.managesieve_disabled_actions) == -1);
+        rcmail.enable_command('plugin.managesieve-setdel', setcnt > 1 && $.inArray('delete_set', rcmail.env.managesieve_disabled_actions) == -1);
         rcmail.enable_command('plugin.managesieve-seteditraw', setcnt > 0 && rcmail.env.raw_sieve_editor);
 
         // Fix dragging filters over sets list
@@ -145,7 +147,9 @@ rcube_webmail.prototype.managesieve_select = function(list)
   }
 
   var has_id = typeof(id) != 'undefined' && id != null;
-  this.enable_command('plugin.managesieve-act', 'plugin.managesieve-del', has_id);
+
+  this.enable_command('plugin.managesieve-act', has_id);
+  this.enable_command('plugin.managesieve-del', has_id && $.inArray('delete_rule', rcmail.env.managesieve_disabled_actions) == -1);
 };
 
 // Set selection
@@ -153,8 +157,9 @@ rcube_webmail.prototype.managesieve_setselect = function(list)
 {
   this.show_contentframe(false);
   this.filters_list.clear(true);
-  this.enable_command('plugin.managesieve-setdel', list.rowcount > 1);
-  this.enable_command('plugin.managesieve-setact', 'plugin.managesieve-setget', list.rowcount > 0);
+  this.enable_command('plugin.managesieve-setdel', list.rowcount > 1 && $.inArray('delete_set', rcmail.env.managesieve_disabled_actions) == -1);
+  this.enable_command('plugin.managesieve-setact', list.rowcount > 0 && $.inArray('enable_disable_set', rcmail.env.managesieve_disabled_actions) == -1);
+  this.enable_command('plugin.managesieve-setget', list.rowcount > 0 && $.inArray('delete_set', rcmail.env.managesieve_disabled_actions) == -1);
   this.enable_command('plugin.managesieve-seteditraw', list.rowcount > 0 && this.env.raw_sieve_editor);
 
   var id = list.get_single_selection();
@@ -299,7 +304,8 @@ rcube_webmail.prototype.managesieve_updatelist = function(action, o)
       list.insert_row(row.get(0));
       list.highlight_row(o.id);
 
-      this.enable_command('plugin.managesieve-del', 'plugin.managesieve-act', true);
+      this.enable_command('plugin.managesieve-del', $.inArray('delete_rule', rcmail.env.managesieve_disabled_actions) == -1);
+      this.enable_command('plugin.managesieve-act', true);
 
       break;
 

--- a/plugins/managesieve/skins/classic/managesieve.css
+++ b/plugins/managesieve/skins/classic/managesieve.css
@@ -19,6 +19,11 @@
   left: 205px;
 }
 
+#filtersscreen.nosetlist
+{
+  left: 0;
+}
+
 #filterslistbox
 {
   position: absolute;

--- a/plugins/managesieve/skins/classic/templates/managesieve.html
+++ b/plugins/managesieve/skins/classic/templates/managesieve.html
@@ -7,7 +7,9 @@
 <script type="text/javascript" src="/splitter.js"></script>
 
 <style type="text/css">
+<roundcube:if condition="!env:managesieve_no_set_list" />
 #filterslistbox { width: <roundcube:exp expression="!empty(cookie:sieveviewsplitter) ? cookie:sieveviewsplitter-5 : 210" />px; }
+<roundcube:endif />
 #filter-box { left: <roundcube:exp expression="!empty(cookie:sieveviewsplitter) ? cookie:sieveviewsplitter+5 : 220" />px; }
 #filtersetslistbox { width: <roundcube:exp expression="!empty(cookie:sieveviewsplitter2) ? cookie:sieveviewsplitter2-5 : 175" />px; }
 #filtersscreen { left: <roundcube:exp expression="!empty(cookie:sieveviewsplitter2) ? cookie:sieveviewsplitter2+5 : 185" />px; }
@@ -21,7 +23,7 @@
 <roundcube:include file="/includes/settingstabs.html" />
 
 <div id="mainscreen">
-
+<roundcube:if condition="!env:managesieve_no_set_list" />
 <div id="filtersetslistbox">
 <div id="filtersetslist-title" class="boxtitle"><roundcube:label name="managesieve.filtersets" /></div>
 <div class="boxlistcontent">
@@ -34,6 +36,9 @@
 </div>
 
 <div id="filtersscreen">
+<roundcube:else />
+<div id="filtersscreen" class="nosetlist">
+<roundcube:endif />
 <div id="filterslistbox">
 <div class="boxtitle"><roundcube:label name="managesieve.filters" /></div>
 <div class="boxlistcontent">
@@ -46,8 +51,10 @@
 </div>
 
 <script type="text/javascript">
+  <roundcube:if condition="!env:managesieve_no_set_list" />
   var sieveviewsplit2 = new rcube_splitter({id:'sieveviewsplitter2', p1: 'filtersetslistbox', p2: 'filtersscreen', orientation: 'v', relative: true, start: 200});
   rcmail.add_onload('sieveviewsplit2.init()');
+  <roundcube:endif />
 
   var sieveviewsplit = new rcube_splitter({id:'sieveviewsplitter', p1: 'filterslistbox', p2: 'filter-box', orientation: 'v', relative: true, start: 215});
   rcmail.add_onload('sieveviewsplit.init()');

--- a/plugins/managesieve/skins/larry/managesieve.css
+++ b/plugins/managesieve/skins/larry/managesieve.css
@@ -16,6 +16,11 @@
   left: 162px;
 }
 
+#filtersscreen.nosetlist
+{
+  left: 0;
+}
+
 #filterslistbox
 {
   position: absolute;

--- a/plugins/managesieve/skins/larry/templates/managesieve.html
+++ b/plugins/managesieve/skins/larry/templates/managesieve.html
@@ -15,6 +15,7 @@
 <roundcube:include file="/includes/settingstabs.html" />
 
 <div id="settings-right" role="main">
+<roundcube:if condition="!env:managesieve_no_set_list" />
 <div id="filtersetslistbox" class="uibox listbox" aria-labelledby="aria-label-filtersets">
 <h2 class="boxtitle" id="aria-label-filtersets"><roundcube:label name="managesieve.filtersets" /></h2>
 <div class="scroller withfooter">
@@ -24,8 +25,10 @@
   <roundcube:button command="plugin.managesieve-setadd" type="link" title="managesieve.filtersetadd" class="listbutton add disabled" classAct="listbutton add" innerClass="inner" content="+" /><roundcube:button name="filtersetmenulink" id="filtersetmenulink" type="link" title="moreactions" class="listbutton groupactions" onclick="return UI.toggle_popup('filtersetmenu', event)" innerClass="inner" content="&#9881;" aria-haspopup="true" aria-expanded="false" aria-owns="filtersetmenu-menu" />
 </div>
 </div>
-
 <div id="filtersscreen">
+<roundcube:else />
+<div id="filtersscreen" class="nosetlist">
+<roundcube:endif />
 <div id="filterslistbox" class="uibox listbox" aria-labelledby="aria-label-filters">
 <h2 class="boxtitle" id="aria-label-filters"><roundcube:label name="managesieve.filters" /></h2>
 <div class="scroller withfooter">
@@ -72,8 +75,10 @@
 <roundcube:include file="/includes/footer.html" />
 
 <script type="text/javascript">
+  <roundcube:if condition="!env:managesieve_no_set_list" />
   new rcube_splitter({ id:'managesievesplitter1', p1:'#filtersetslistbox', p2:'#filtersscreen',
           orientation:'v', relative:true, start:156, min:120, size:12 }).init();
+  <roundcube:endif />
   new rcube_splitter({ id:'managesievesplitter2', p1:'#filterslistbox', p2:'#filter-box',
           orientation:'v', relative:true, start:186, min:120, size:12 }).init();
 </script>


### PR DESCRIPTION
For feature request #5496

I have extended the managesieve plugin to support disabling of actions. As part of if you can also disable the listing of scripts.

When the listing of scripts is disabled then the script defined in managesieve_script_name is always used and it is enabled as well.