### PR TITLE
managesieve: fix bug when opening exists rule

### DIFF
--- a/plugins/managesieve/managesieve.js
+++ b/plugins/managesieve/managesieve.js
@@ -677,7 +677,7 @@ function rule_header_select(id)
     dateheader.style.display = h == 'date' ? '' : 'none';
 
   $('[value="exists"],[value="notexists"]', rule).prop('disabled', h == 'string');
-  if (!rule.val() || rule.val().match(/^(exists|notexists)$/))
+  if (!rule.val() && !rule.val().match(/^(exists|notexists)$/))
     rule.val('contains');
 
   rule_op_select(op, id, h);


### PR DESCRIPTION
if you create a rule in managesieve and set the test the to exists.

For example Subject Exists. Save it. navigate away and then open that rule up again the form will load with Subject Contains.

This is a little tweak just to make it load the form with Subject Exists.