### PR TITLE
managesieve: larry skin tweaks

### DIFF
--- a/plugins/managesieve/skins/larry/managesieve.css
+++ b/plugins/managesieve/skins/larry/managesieve.css
@@ -109,15 +109,13 @@ div.rulerow, div.actionrow
   padding: 2px;
   white-space: nowrap;
   border: 1px solid white;
+  background-color: #eee;
 }
 
 div.rulerow:hover, div.actionrow:hover
 {
-  padding: 2px;
-  white-space: nowrap;
   background-color: #D9ECF4;
   border: 1px solid #BBD3DA;
-  border-radius: 4px;
 }
 
 div.rulerow table, div.actionrow table
@@ -325,7 +323,18 @@ span.sieve.error
 
 fieldset
 {
-  border-radius: 4px;
+  border: 0;
+  padding: 0;
+  margin-bottom: 20px;
+}
+
+fieldset > legend
+{
+  display: block;
+  font-size: 14px;
+  font-weight: bold;
+  padding-bottom: 10px;
+  margin-bottom: 0;
 }
 
 /* smart multi-row input field */


### PR DESCRIPTION
a few small tweaks to make the larry skin of the managesieve plugin look a bit more like the rest of larry.

1) use the grey background for the table rows (like on the preferences screen for example)
2) style the <fieldset> and <legend> to match core