### PR TITLE
extend disabled_actions config

### DIFF
--- a/program/include/rcmail_output_html.php
+++ b/program/include/rcmail_output_html.php
@@ -1358,12 +1358,14 @@ EOF;
         }
 
         $command = $attrib['command'];
+        $action = $command ?: $attrib['name'];
 
         if ($attrib['task']) {
-            $element = $command = $attrib['task'] . '.' . $command;
+            $command = $attrib['task'] . '.' . $command;
+            $element = $attrib['task'] . '.' . $action;
         }
         else {
-            $element = ($this->env['task'] ? $this->env['task'] . '.' : '') . $command;
+            $element = ($this->env['task'] ? $this->env['task'] . '.' : '') . $action;
         }
 
         if ($disabled_actions === null) {
@@ -1371,7 +1373,7 @@ EOF;
         }
 
         // remove buttons for disabled actions
-        if (in_array($element, $disabled_actions)) {
+        if (in_array($element, $disabled_actions) || in_array($action, $disabled_actions)) {
             return '';
         }
 


### PR DESCRIPTION
Occasionally there are buttons in the skin that do not have a command attribute. Things that do skin actions like opening popups. My idea is to fall back to the button name when no command is present so that these buttons can still be disabled via config.

In addition I added a check that ignores the $task so if you want to disable a button that is in multiple tasks or you want to remove something that a plugin might add in mutiple tasks or if you are just not so good at Roundcube and don't understand about the tasks.