### PR TITLE
replace display_version with display_product_version

### DIFF
--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -439,8 +439,9 @@ $config['login_rate_limit'] = 3;
 // Includes should be interpreted as PHP files
 $config['skin_include_php'] = false;
 
-// display software version on login screen
-$config['display_version'] = false;
+// display product name and software version on login screen
+// 0 - hide product name and version number, 1 - show product name only, 2 - show product name and version number
+$config['display_product_info'] = 1;
 
 // Session lifetime in minutes
 $config['session_lifetime'] = 10;

--- a/program/lib/Roundcube/rcube_config.php
+++ b/program/lib/Roundcube/rcube_config.php
@@ -659,6 +659,12 @@ class rcube_config
             unset($props['preview_pane']);
         }
 
+        // translate old `display_version` settings to `display_product_info`
+        if (isset($props['display_version']) && !isset($props['display_product_info'])) {
+            $props['display_product_info'] = $props['display_version'] ? 2 : 1;
+            unset($props['display_version']);
+        }
+
         return $props;
     }
 

--- a/skins/classic/templates/login.html
+++ b/skins/classic/templates/login.html
@@ -26,7 +26,7 @@
 </noscript>
 
 <div id="login-bottomline">
-  <roundcube:var name="config:product_name"> <roundcube:object name="version" condition="config:display_version" />
+  <roundcube:var name="config:product_name" condition="config:display_product_info &gt; 0"> <roundcube:object name="version" condition="config:display_product_info == 2" />
   <roundcube:if condition="config:support_url" />
     &nbsp;&#9679;&nbsp; <a href="<roundcube:var name='config:support_url' />" target="_blank" class="support-link"><roundcube:label name="support" /></a>
   <roundcube:endif />

--- a/skins/larry/templates/login.html
+++ b/skins/larry/templates/login.html
@@ -26,7 +26,7 @@
 </div>
 
 <div id="bottomline" role="contentinfo">
-	<roundcube:object name="productname" /> <roundcube:object name="version" condition="config:display_version" />
+	<roundcube:object name="productname" condition="config:display_product_info &gt; 0" /> <roundcube:object name="version" condition="config:display_product_info == 2" />
 	<roundcube:if condition="config:support_url" />
 		&nbsp;&#9679;&nbsp; <a href="<roundcube:var name='config:support_url' />" target="_blank" class="support-link"><roundcube:label name="support" /></a>
 	<roundcube:endif />


### PR DESCRIPTION
Currently it is possible to hide the version number on the login screen by config but not the product name. If, for example, the logo already contains the product name then displaying it again is redundant. I did not want to introduce another config option so my idea is to replace display_version with display_product_version and then allow for 3 settings: nothing, product name only (default, just as now), and product and version.