### PR TITLE
managesieve: only float buttons on long pages

### DIFF
--- a/plugins/managesieve/skins/larry/templates/filteredit.html
+++ b/plugins/managesieve/skins/larry/templates/filteredit.html
@@ -15,7 +15,7 @@
 
 <roundcube:if condition="env:task != 'mail'" />
 <div id="footer">
-<div class="footerleft formbuttons floating">
+<div class="footerleft formbuttons">
 <roundcube:button command="plugin.managesieve-save" type="input" class="button mainaction" label="save" />
 <label for="disabled">
 <input type="checkbox" id="disabled" name="_disabled" value="1" />
@@ -27,6 +27,8 @@
 
 </form>
 </div>
+
+<roundcube:include file="/includes/footer.html" />
 
 </body>
 </html>


### PR DESCRIPTION
On large screens, when you have a simple rule, there can be a lot of white space between the details of the rule and the save button:

![managesieve1](https://user-images.githubusercontent.com/88682/29652764-dd7a7e6e-889e-11e7-974c-02351875673d.png)

by adding the standard Larry footer code then the `floating` class gets added only when the content of the page is long enough to need a scroll bar. Otherwise the save button is shown directly under the actions section.

as far as I can see there are no conflicts between the managesieve JS and the standard Larry UI JS added by footer.html