### PR TITLE
improve detection for Egde browser and add pointer event support (release-1.3) (credit JohnDoe)

### DIFF
--- a/program/js/common.js
+++ b/program/js/common.js
@@ -58,14 +58,15 @@ function roundcube_browser()
   this.dom = document.getElementById ? true : false;
   this.dom2 = document.addEventListener && document.removeEventListener;
 
-  this.webkit = this.agent_lc.indexOf('applewebkit') > 0;
+  this.edge = this.agent_lc.indexOf(' edge/') > 0;
+  this.webkit = !this.edge && this.agent_lc.indexOf('applewebkit') > 0;
   this.ie = (document.all && !window.opera) || (this.win && this.agent_lc.indexOf('trident/') > 0);
 
   if (window.opera) {
     this.opera = true; // Opera < 15
     this.vendver = opera.version();
   }
-  else if (!this.ie) {
+  else if (!this.ie && !this.edge) {
     this.chrome = this.agent_lc.indexOf('chrome') > 0;
     this.opera = this.webkit && this.agent.indexOf(' OPR/') > 0; // Opera >= 15
     this.safari = !this.chrome && !this.opera && (this.webkit || this.agent_lc.indexOf('safari') > 0);
@@ -91,6 +92,7 @@ function roundcube_browser()
   this.tablet = /ipad|android|xoom|sch-i800|playbook|tablet|kindle/i.test(this.agent_lc);
   this.mobile = /iphone|ipod|blackberry|iemobile|opera mini|opera mobi|mobile/i.test(this.agent_lc);
   this.touch = this.mobile || this.tablet;
+  this.pointer = typeof window.PointerEvent == "function";
   this.cookies = n.cookieEnabled;
 
   // test for XMLHTTP support

--- a/program/js/list.js
+++ b/program/js/list.js
@@ -73,6 +73,9 @@ function rcube_list_widget(list, p)
   this.dblclick_time = 500; // default value on MS Windows is 500
   this.row_init = function(){};  // @deprecated; use list.addEventListener('initrow') instead
 
+  this.pointer_touch_start = 0; // start time of the touch event
+  this.pointer_touch_time = 500; // maximum time a touch should be considered a left mouse button event, after this its something else (eg contextmenu event)
+
   // overwrite default paramaters
   if (p && typeof p === 'object')
     for (var n in p)
@@ -161,7 +164,25 @@ init_row: function(row)
           return true;
       });
 
-    if (bw.touch && row.addEventListener) {
+    // for IE and Edge differentiate between touch, touch+hold using pointer events rather than touch
+    if ((bw.ie || bw.edge) && bw.pointer) {
+      $(row).on('pointerdown', function(e) {
+          if (e.pointerType == 'touch') {
+            self.pointer_touch_start = new Date().getTime();
+            return false;
+          }
+        })
+        .on('pointerup', function(e) {
+          if (e.pointerType == 'touch') {
+            var duration = (new Date().getTime() - self.pointer_touch_start);
+            if (duration <= self.pointer_touch_time) {
+              self.drag_row(e, this.uid);
+              return self.click_row(e, this.uid);
+            }
+          }
+        });
+    }
+    else if (bw.touch && row.addEventListener) {
       row.addEventListener('touchstart', function(e) {
         if (e.touches.length == 1) {
           self.touchmoved = false;


### PR DESCRIPTION
add support for pointer events on list widget

use either pointer or touch events, not both

ensure bw.pointer is a boolean

Credit to @JohnDoh - Re-creating patch for release-1.3 branch.