### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+language: php
+
+sudo: false
+
+matrix:
+  fast_finish: true
+  include:
+    - php: 5.4
+    - php: 5.5
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+      env: CODE_COVERAGE=1
+    - php: 7.2
+
+cache:
+  directories:
+    - $HOME/.composer
+
+install:
+  - if [ "$CODE_COVERAGE" != 1 ]; then phpenv config-rm xdebug.ini || true; fi
+  - cp composer.json-dist composer.json
+  - composer install --prefer-dist
+
+script:
+  - if [ "$CODE_COVERAGE" = 1 ]; then CODE_COVERAGE_ARGS="--coverage-text"; fi; vendor/bin/phpunit -c tests/phpunit.xml $CODE_COVERAGE_ARGS
+
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 Roundcube Webmail 
 =================
-[roundcube.net](http://roundcube.net)
+[roundcube.net](https://roundcube.net)
 
+[![Build Status](https://travis-ci.org/roundcube/roundcubemail.svg?branch=travis)](https://travis-ci.org/roundcube/roundcubemail)
 
 ATTENTION
 ---------
@@ -95,7 +96,7 @@ hello(at)roundcube(dot)net
 [washtml]:      http://www.ubixis.com/washtml/
 [kmgerich]:     http://kmgerich.com/
 [gpl]:          http://www.gnu.org/licenses/
-[license]:      http://roundcube.net/license
-[contrib]:      http://roundcube.net/contribute
-[support]:      http://roundcube.net/support
+[license]:      https://roundcube.net/license
+[contrib]:      https://roundcube.net/contribute
+[support]:      https://roundcube.net/support
 [githubissues]: https://github.com/roundcube/roundcubemail/issues

--- a/composer.json-dist
+++ b/composer.json-dist
@@ -22,7 +22,7 @@
         "endroid/qrcode": "~1.6.5"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.7.15"
+        "phpunit/phpunit": "^4.8.36 || ^5.7.21"
     },
     "suggest": {
         "pear/net_ldap2": "~2.2.0 required for connecting to LDAP",

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -91,4 +91,9 @@
             <file>./../plugins/zipdownload/tests/Zipdownload.php</file>
         </testsuite>
     </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">../program/lib</directory>
+        </whitelist>
+    </filter>
 </phpunit>


### PR DESCRIPTION
Hi, this PR is intended to add Travis continuous integration builds to this github repository.
If this PR is going to be merged, the maintainer should activate travis triggers for pushes and pull-requests.

As you can see in the build done against my fork:
https://travis-ci.org/Slamdunk/roundcubemail/builds/271667707
there are failures that should be addressed, expecially on the newcomer PHP 7.2

This PR is **not** intended to solve the issues, but only to introduce the CI process. New PR will be opened after this one is merged and the triggers are activated; fixing bugs before having a running ci process should be avoided.