### PR TITLE
Add special chars as exception at spellcheck

### DIFF
--- a/program/lib/Roundcube/rcube_spellchecker.php
+++ b/program/lib/Roundcube/rcube_spellchecker.php
@@ -255,7 +255,7 @@ class rcube_spellchecker
     }
 
     /**
-     * Check if the specified word is an exception according to 
+     * Check if the specified word is an exception according to
      * spellcheck options.
      *
      * @param string  $word  The word
@@ -265,11 +265,11 @@ class rcube_spellchecker
     public function is_exception($word)
     {
         // Contain only symbols (e.g. "+9,0", "2:2")
-        if (!$word || preg_match('/^[0-9@#$%^&_+~*<>=:;?!,.-]+$/', $word))
+        if (!$word || preg_match('/^[0-9@#$%^&_+~*<>=:;?!,.-ºª°]+$/', $word))
             return true;
 
         // Contain symbols (e.g. "g@@gle"), all symbols excluding separators
-        if (!empty($this->options['ignore_syms']) && preg_match('/[@#$%^&_+~*=-]/', $word))
+        if (!empty($this->options['ignore_syms']) && preg_match('/[@#$%^&_+~*=-ºª°]/', $word))
             return true;
 
         // Contain numbers (e.g. "g00g13")


### PR DESCRIPTION
We are facing a problem that sometimes it's a little bit difficult to be reproduced.
Sometimes an error occurs and sometimes not.
We are using spell checker (pspell) and when trying to send an email with some specific special chars like º or ª, it crashes and we are unable to send emails. We realize that this error occurs on pspell_suggest() function from pspell's library. In the is_exception() function there is no condition that can handle those special chars.
So, it was added those chars as exception.