### PR TITLE
fix: unknown content-disposition type should be treated as attachment

### DIFF
--- a/program/lib/Roundcube/rcube_imap.php
+++ b/program/lib/Roundcube/rcube_imap.php
@@ -2109,7 +2109,10 @@ class rcube_imap extends rcube_storage
 
         if (is_array($part[$di]) && count($part[$di]) == 2) {
             $struct->disposition = strtolower($part[$di][0]);
-
+            if ($struct->disposition && $struct->disposition !== 'inline' && $struct->disposition !== 'attachment') {
+                // RFC2183, Section 2.8 - unrecognized type should be treated as "attachment"
+                $struct->disposition = 'attachment';
+            }
             if (is_array($part[$di][1])) {
                 for ($n=0; $n<count($part[$di][1]); $n+=2) {
                     $struct->d_parameters[strtolower($part[$di][1][$n])] = $part[$di][1][$n+1];


### PR DESCRIPTION
ran into an oddly encoded content-disposition header in an email. thunderbird displayed the attachment correctly, while roundcube did not:

content-disposition: *;filename="8608014 2017-09-24.pdf"

usually the * is either "attachment" or "inline" - correcting the content-disposition header inside the email does allow roundcube to display it.

RFC2183, Section 2.8 states that unrecognized content-disposition types should be treated as "attachment", which is what thunderbird appears to be doing. this patch implements the same rfc-compliant behavior. it makes sure disposition is defined before changing it, so as not to impact any sections later on in the lib that set disposition if unset.