### PR TITLE
Added $config['max_upload_size']

### DIFF
--- a/config/config.inc.php.sample
+++ b/config/config.inc.php.sample
@@ -84,3 +84,8 @@ $config['plugins'] = array(
 
 // skin name: folder from skins/
 $config['skin'] = 'larry';
+
+// restrict maximum upload file size
+// if set to a negative value, the maximum file size of attachments is
+// determined by the settings in your php.ini only
+$config['max_upload_size'] = -1;

--- a/program/include/rcmail.php
+++ b/program/include/rcmail.php
@@ -2101,6 +2101,10 @@ class rcmail extends rcube
 
         // find max filesize value
         $max_filesize = rcube_utils::max_upload_size();
+        $max_filesize_config = $this->config->get('max_upload_size');
+        if ($max_filesize_config > 0) {
+            $max_filesize = min($max_filesize, $max_filesize_config);
+        }
         if ($max_size && $max_size < $max_filesize) {
             $max_filesize = $max_size;
         }


### PR DESCRIPTION
The new config value can be used to further restrict the
maximum size of attachments. So you can increase the
post_max_size and upload_max_filesize in php.ini without
affecting RoundCube.

I'm currently running Roundcube with this patch, because
unfortunately -- due to another PHP script -- I need the
_post_max_size_ and _upload_max_filesize_ settings at a
level that my mail server would refuse to handle (and I 
don't want users to try to upload insanely large attachments).

Is there a simpler way to achieve the same functionality?
I can't change these two settings via ini_set() ...