### PR TITLE
Allow for free-form flag filter action

### DIFF
--- a/plugins/managesieve/lib/Roundcube/rcube_sieve_engine.php
+++ b/plugins/managesieve/lib/Roundcube/rcube_sieve_engine.php
@@ -2133,6 +2133,12 @@ class rcube_sieve_engine
                 ))
                 . rcube::Q($this->plugin->gettext('flag'.$fidx)) .'<br>';
         }
+
+        $flags_target = array_filter($flags_target, function($v) use($flags) {
+            return !in_array_nocase($v, $flags);
+        });
+        $flout .= $this->list_input($id, 'action_flags', $flags_target, true,
+            $this->error_class($id, 'action', 'flags', 'action_flags'));
         $out .= html::div(array(
                 'id'    => 'action_flags' . $id,
                 'style' => 'display:' . (preg_match('/^(set|add|remove)flag$/', $action['type']) ? 'inline' : 'none'),


### PR DESCRIPTION
This small patch adds a text input field to the managesieve plugin, allowing a user-defined flag (actually keyword in this case) to be set on a message, along with the default IMAP existing flags.

Signed-off-by: Daniele Ricci <daniele.athome@gmail.com>