### PR TITLE
add charset to watermark.html

### DIFF
--- a/skins/classic/watermark.html
+++ b/skins/classic/watermark.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
+  <meta http-equiv="content-type" content="text/html; charset=utf-8">
   <title></title>
   <style type="text/css">
     html, body { height: 100%; background-color: #F2F2F2; margin: 0; }

--- a/skins/larry/watermark.html
+++ b/skins/larry/watermark.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+<meta charset="utf-8">
 <title></title>
 <style type="text/css">
 


### PR DESCRIPTION
this is trival but the console in firefox gives a warning because there is no charset defined for watermark.html: 

```The character encoding of a framed document was not declared. The document may appear different if viewed without the document framing it.```

so I've added a utf-8 charset to the HTML.