### PR TITLE
Fix typos on optional security header comment

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -58,8 +58,8 @@ Header set X-Robots-Tag "noindex, nofollow"
 # replace 'append' with 'merge' for Apache version 2.2.9 and later
 #Header append Cache-Control public env=!NO_CACHE
 
-# Optional security header
-# Only increased security if the browser support those features
+# Optional security headers
+# Only provides increased security if the browser supports those features
 # Be careful! Testing is required! They should be adjusted to your installation / user environment
 
 # HSTS - HTTP Strict Transport Security

--- a/.htaccess
+++ b/.htaccess
@@ -60,7 +60,7 @@ Header set X-Robots-Tag "noindex, nofollow"
 
 # Optional security header
 # Only increased security if the browser support those features
-# Be careful! Testing is required! They should be adusted to your intallation / user environment
+# Be careful! Testing is required! They should be adjusted to your installation / user environment
 
 # HSTS - HTTP Strict Transport Security
 #Header always set Strict-Transport-Security "max-age=31536000; preload" env=HTTPS


### PR DESCRIPTION
Couple of typo's on the `.htaccess` in relation to the optional security headers.