### PR TITLE
Add optional SSL/TLS redirect to .htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -34,6 +34,12 @@ RewriteRule ^/?(\.git|\.tx|SQL|bin|config|logs|temp|tests|program\/(include|lib|
 RewriteRule ^/vendor\/bin\/.* - [F]
 # - deny access to some documentation files
 RewriteRule /?(README\.md|composer\.json-dist|composer\.json|package\.xml|jsdeps.json|Dockerfile)$ - [F]
+
+# Optional SSL/TLS redirect
+# All plain HTTP requests to Roundcube will be rewritten to HTTPS
+# You may also want to consider enabling the HSTS header if you enable this
+#RewriteCond %{HTTPS} off
+#RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
 </IfModule>
 
 <IfModule mod_deflate.c>


### PR DESCRIPTION
This adds an optional RewriteRule for essentially running Roundcube under HTTPS. Given that the SSL setup of different configurations (or the lack of), this is commented out by default, but I thought might be useful to have?

The RewriteRule should be fairly flexible. In my case, I have Roundcube deployed with DirectAdmin and its `/roundcube` path is accessible via the server hostname, as well as individual client domains. Having this code deployed, allows the client domains to utilise there own SSL certificate to run Roundcube under SSL and automatically redirect plain HTTP requests to the `/roundcube` path.

Hope this might be useful!

