### PR TITLE
Add rules for automatic identity creation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 CHANGELOG Roundcube Webmail
 ===========================
-
+- Add rules for automatic identity creation (for modifying usernames in generated email addresses)
 - Changed defaults for smtp_user (%u), smtp_pass (%p) and smtp_port (587)
 - Composer: Fix certificate validation errors by using packagist only (#5148)
 - Enigma: Add button to send mail unencrypted if no key was found (#5913)

--- a/config/config.inc.php.sample
+++ b/config/config.inc.php.sample
@@ -84,3 +84,9 @@ $config['plugins'] = array(
 
 // skin name: folder from skins/
 $config['skin'] = 'larry';
+
+// Automatic identity creation rules
+// Replace _ in usernames with . (john_doe -> john.doe)
+// $config['user_to_email_regex'] = '/_/';
+// $config['user_to_email_pattern'] = '.';
+

--- a/program/lib/Roundcube/rcube_user.php
+++ b/program/lib/Roundcube/rcube_user.php
@@ -646,8 +646,13 @@ class rcube_user
             $email_list  = $data['email_list'];
 
             if (empty($email_list)) {
-                if (empty($user_email)) {
-                    $user_email = strpos($data['user'], '@') ? $user : sprintf('%s@%s', $data['user'], $mail_domain);
+		if (empty($user_email)) {
+			if (array_key_exists('user_to_email_regex', $config) && array_key_exists('user_to_email_pattern', $config)) {
+			$username = preg_replace($config['user_to_email_regex'], $config['user_to_email_pattern'], $data['user']);
+                        $user_email = strpos($username, '@') ? $username : sprintf('%s@%s', $username, $mail_domain);
+                    } else {
+                        $user_email = strpos($data['user'], '@') ? $user : sprintf('%s@%s', $data['user'], $mail_domain);
+                    }
                 }
                 $email_list[] = $user_email;
             }


### PR DESCRIPTION
Add rules for modifying usernames in generated email addresses
when the identity is automatically created for new user.

Example: Add configuration parameters for replaceing '_' in
usernames with '.' (john_doe -> john.doe)

$config['user_to_email_regex'] = '/_/';
$config['user_to_email_pattern'] = '.';