### PR TITLE
Enigma smime signed messages verification

### DIFF
--- a/plugins/enigma/config.inc.php.dist
+++ b/plugins/enigma/config.inc.php.dist
@@ -58,6 +58,13 @@ $config['enigma_attach_pubkey'] = false;
 // When set to 0 passwords will be stored for the whole session.
 $config['enigma_password_time'] = 5;
 
+// Trusted Root CAs
+// When this array is filled with root(!) CA files,
+// enigma will first try to use these CAs to verify a signature.
+// If this fails, verification with default system CAs will still be attempted,
+// but lower trust will be signalled to user.
+$config['enigma_smime_ca'] = array();
+
 // With this option you can lock composing options
 // of the plugin forcing the user to use configured settings.
 // The array accepts: 'sign', 'encrypt', 'pubkey'.

--- a/plugins/enigma/lib/enigma_driver_phpssl.php
+++ b/plugins/enigma/lib/enigma_driver_phpssl.php
@@ -229,6 +229,8 @@ class enigma_driver_phpssl extends enigma_driver
 //        $data->comment     = '';
         $data->email       = $cert['subject']['emailAddress'];
 
+        rcube::write_log('errors', 'Decrypted sig: ' . $data->name);
+
         return $data;
     }
 }

--- a/plugins/enigma/lib/enigma_driver_phpssl.php
+++ b/plugins/enigma/lib/enigma_driver_phpssl.php
@@ -67,6 +67,15 @@ class enigma_driver_phpssl extends enigma_driver
 
         $this->homedir = $homedir;
 
+        #XXX: Workaround for https://bugs.php.net/bug.php?id=75494
+        if (count($this->cainfo) > 0) {
+            $dummy_cert_dir = $this->homedir . '/' . 'cert_dummy';
+            if (!file_exists($dummy_cert_dir)) {
+                mkdir($dummy_cert_dir, 0700);
+            }
+            $this->cainfo[] = $dummy_cert_dir;
+        }
+
     }
 
     function encrypt($text, $keys, $sign_key = null)

--- a/plugins/enigma/lib/enigma_engine.php
+++ b/plugins/enigma/lib/enigma_engine.php
@@ -685,7 +685,24 @@ class enigma_engine
             return;
         }
 
-        // @TODO
+        if ($this->rc->action != 'show' && $this->rc->action != 'preview' && $this->rc->action != 'print') {
+            return;
+        }
+
+        $this->load_smime_driver();
+        $struct = $p['structure'];
+
+        $msg_part = $struct->parts[0];
+
+        $sig = $this->smime_driver->verify($struct, $p['object']);
+
+        if (($sig instanceof enigma_error) && $sig->getCode() != enigma_error::KEYNOTFOUND) {
+            self::raise_error($sig, __LINE__);
+        } else {
+            // Store signature data for display
+            $this->signatures[$struct->mime_id] = $sig;
+            $this->signatures[$msg_part->mime_id] = $sig;
+        }
     }
 
     /**

--- a/plugins/enigma/lib/enigma_error.php
+++ b/plugins/enigma/lib/enigma_error.php
@@ -30,6 +30,7 @@ class enigma_error
     const BADPASS     = 5;
     const EXPIRED     = 6;
     const UNVERIFIED  = 7;
+    const SERVER_VERIFIED  = 8;
 
 
     function __construct($code = null, $message = '', $data = array())

--- a/plugins/enigma/lib/enigma_mime_message.php
+++ b/plugins/enigma/lib/enigma_mime_message.php
@@ -19,6 +19,8 @@ class enigma_mime_message extends Mail_mime
 {
     const PGP_SIGNED    = 1;
     const PGP_ENCRYPTED = 2;
+    const SMIME_SIGNED  = 3;
+    const SMIME_ENCRYPTED = 4;
 
     protected $type;
     protected $message;

--- a/plugins/enigma/lib/enigma_ui.php
+++ b/plugins/enigma/lib/enigma_ui.php
@@ -984,6 +984,12 @@ class enigma_ui
                     $msg = str_replace('$keyid', $sig->id, $msg);
                     $msg = rcube::Q($msg);
                 }
+                else if ($sig->valid === enigma_error::SERVER_VERIFIED) {
+                    $attrib['class'] = 'enigmawarning';
+                    $msg = str_replace('$sender', $sender, $this->enigma->gettext('sigserververified'));
+                    $msg = str_replace('$keyid', $sig->id, $msg);
+                    $msg = rcube::Q($msg);
+                }
                 else if ($sig->valid) {
                     $attrib['class'] = $sig->partial ? 'enigmawarning' : 'enigmanotice';
                     $label = 'sigvalid' . ($sig->partial ? 'partial' : '');

--- a/plugins/enigma/localization/en_US.inc
+++ b/plugins/enigma/localization/en_US.inc
@@ -98,6 +98,7 @@ $messages = array();
 $messages['sigvalid'] = 'Verified signature from $sender.';
 $messages['sigvalidpartial'] = 'Verified signature from $sender, but part of the body was not signed.';
 $messages['siginvalid'] = 'Invalid signature from $sender.';
+$messages['sigserververified'] = 'Server-verified signature. Certificate ID: $keyid.';
 $messages['sigunverified'] = 'Unverified signature. Certificate not verified. Certificate ID: $keyid.';
 $messages['signokey'] = 'Unverified signature. Public key not found. Key ID: $keyid.';
 $messages['sigerror'] = 'Unverified signature. Internal error.';


### PR DESCRIPTION
This is the first step to address #4977.

I made this PR to familiarise myself with the enigma plugin and show a first proof-of-concept.

## Description

It does the following things:

* Hooks up SMIME signature verification logic that already mostly existed in enigma
* Allows the server administrator to specify trusted CA files in enigma plugin config
* Introduces new "server-verified" verification level: If trusted CAs are specified in enigma plugin config, full verification trust (Green bar) is reserved for messages signed with a certificate trusted by one of those CAs; messages signed by a certificate trusted by the default CAs are displayed as "server-verified" with a yellow bar.

What it doesn't do:

* No decryption - so also no verification of encrypted messages
* No encryption
* No user CAs / certificates

What I am finding out here is that the php openssl module is severely limited in what it can do. Things I would like to do but seemingly can't using php openssl:

* Use intermediate certificates as trust anchors
* Retrieve the whole certificate chain used to verify a signature

It may be necessary to invoke an openssl executable directly to actually implement all the features users would expect.

## How to test

Test basic verification:

* Enable the enigma plugin using the code in this branch
* Open a signed (unencrypted!) S/MIME message
* If the root ca for the signature of that message is in your server's cert store, you should see a green signature verification bar

Test verification of configured CAs:

* Set `$config['enigma_smime_ca'] = array('/');` (a directory without certificates)
* The message should now have a yellow signature verification bar
* Set `$config['enigma_smime_ca'] = array('/path/to/ca.cert');` referencing the correct root ca
* The message should now have a green bar again
