### PR TITLE
remove buildDeps after php extensions have been installed

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,18 +1,34 @@
 FROM php:7.1-apache
 MAINTAINER Thomas Bruederli <thomas@roundcube.net>
 
-RUN apt-get -qq update \
-  && apt-get install -qq \
+RUN buildDeps=" \
+    libfreetype6-dev \
+    libicu-dev \
+    libjpeg62-turbo-dev \
+    libpng-dev \
     libpq-dev \
     libsqlite3-dev \
-    libicu-dev \
-    zlib1g-dev \
-    libpng-dev \
-    libfreetype6-dev \
-    libjpeg62-turbo-dev \
+    zlib1g-dev" \
+  && apt-get -qq update \
+  && apt-get install -qq $buildDeps \
+  && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+  && docker-php-ext-install -j$(nproc) \
+    exif \
+    gd \
+    intl \
+    pdo \
+    pdo_mysql \
+    pdo_pgsql \
+    pdo_sqlite \
+    zip \
+  && apt-mark manual \
+    libfreetype6 \
+    libicu52 \
+    libjpeg62-turbo \
+    libpq5 \
+  && apt-get purge -y --auto-remove $buildDeps \
+  && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
-RUN docker-php-ext-install -j$(nproc) intl exif pdo pdo_mysql pdo_sqlite pdo_pgsql zip
-RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && docker-php-ext-install -j$(nproc) gd
 
 # enable mod_rewrite
 RUN a2enmod rewrite


### PR DESCRIPTION
@thomascube this removes some packages that are only required to build the php extensions. I had to merge the `RUN` statements to keep the variable.