### PR TITLE
Docker PostgreSQL support

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -28,14 +28,15 @@ this option should not be used for production.
 
 The recommended way to run Roundcube is connected to a MySQL database. Specify the following env variables to do so:
 
-`MYSQL_ENV_MYSQL_HOST` - Host (or Docker instance) name of the MySQL service; defaults to `mysql`
+`ROUNDCUBEMAIL_DB_TYPE` - Database provider; currently supported: `mysql`, `pgsql`, `sqlite`
 
-`MYSQL_ENV_MYSQL_USER` - The database username for Roundcube; defaults to `root`
+`ROUNDCUBEMAIL_DB_HOST` - Host (or Docker instance) name of the database service; defaults to `mysql` or `postgres` depending on linked containers.
 
-`MYSQL_ENV_MYSQL_PASSWORD` - The password for the database connection or
-`MYSQL_ENV_MYSQL_ROOT_PASSWORD` - if the database username is `root`
+`ROUNDCUBEMAIL_DB_USER` - The database username for Roundcube; defaults to `root` on `mysql`
 
-`MYSQL_ENV_MYSQL_DATABASE` - The database name for Roundcube to use; defaults to `roundcubemail`
+`ROUNDCUBEMAIL_DB_PASSWORD` - The password for the database connection
+
+`ROUNDCUBEMAIL_DB_NAME` - The database name for Roundcube to use; defaults to `roundcubemail`
 
 Before staring the container, please make sure that the supplied database exists and the given database user has privileges
 to create tables.
@@ -43,7 +44,7 @@ to create tables.
 Run it with a link to the MySQL host and the username/password variables:
 
 ```
-docker run -e MYSQL_ENV_MYSQL_ROOT_PASSWORD=my-secret-password --link=mysql:mysql -d roundcube/roundcubemail
+docker run --link=mysql:mysql -d roundcube/roundcubemail
 ```
 
 ## Building a Docker Container

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -15,9 +15,16 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
     echo >&2 "Complete! ROUNDCUBEMAIL has been successfully copied to $PWD"
   fi
 
-  if [ ! -z "${!MYSQL_ENV_MYSQL_*}" ]; then
+  if [ ! -z "${!POSTGRES_ENV_POSTGRES_*}" ]; then
+    : "${ROUNDCUBEMAIL_DB_TYPE:=pgsql}"
+    : "${ROUNDCUBEMAIL_DB_HOST:=postgres}"
+    : "${ROUNDCUBEMAIL_DB_USER:=${POSTGRES_ENV_POSTGRES_USER}}"
+    : "${ROUNDCUBEMAIL_DB_PASSWORD:=${POSTGRES_ENV_POSTGRES_PASSWORD}}"
+    : "${ROUNDCUBEMAIL_DB_NAME:=${POSTGRES_ENV_POSTGRES_DB:-roundcubemail}}"
+    : "${ROUNDCUBEMAIL_DSNW:=${ROUNDCUBEMAIL_DB_TYPE}://${ROUNDCUBEMAIL_DB_USER}:${ROUNDCUBEMAIL_DB_PASSWORD}@${ROUNDCUBEMAIL_DB_HOST}/${ROUNDCUBEMAIL_DB_NAME}}"
+  elif [ ! -z "${!MYSQL_ENV_MYSQL_*}" ]; then
     : "${ROUNDCUBEMAIL_DB_TYPE:=mysql}"
-    : "${ROUNDCUBEMAIL_DB_HOST:=${MYSQL_ENV_MYSQL_HOST:-mysql}}"
+    : "${ROUNDCUBEMAIL_DB_HOST:=mysql}"
     : "${ROUNDCUBEMAIL_DB_USER:=${MYSQL_ENV_MYSQL_USER:-root}}"
     if [ "$ROUNDCUBEMAIL_DB_USER" = 'root' ]; then
       : "${ROUNDCUBEMAIL_DB_PASSWORD:=${MYSQL_ENV_MYSQL_ROOT_PASSWORD}}"
@@ -28,8 +35,10 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
     : "${ROUNDCUBEMAIL_DSNW:=${ROUNDCUBEMAIL_DB_TYPE}://${ROUNDCUBEMAIL_DB_USER}:${ROUNDCUBEMAIL_DB_PASSWORD}@${ROUNDCUBEMAIL_DB_HOST}/${ROUNDCUBEMAIL_DB_NAME}}"
   else
     # use local SQLite DB in /var/www/html/db
+    : "${ROUNDCUBEMAIL_DB_TYPE:=sqlite}"
     : "${ROUNDCUBEMAIL_DB_DIR:=$PWD/db}"
-    : "${ROUNDCUBEMAIL_DSNW:=sqlite:///$ROUNDCUBEMAIL_DB_DIR/sqlite.db?mode=0646}"
+    : "${ROUNDCUBEMAIL_DB_NAME:=sqlite}"
+    : "${ROUNDCUBEMAIL_DSNW:=${ROUNDCUBEMAIL_DB_TYPE}:///$ROUNDCUBEMAIL_DB_DIR/${ROUNDCUBEMAIL_DB_NAME}.db?mode=0646}"
 
     mkdir -p $ROUNDCUBEMAIL_DB_DIR
     chown www-data:www-data $ROUNDCUBEMAIL_DB_DIR


### PR DESCRIPTION
This adds support for linked PostgreSQL containers.
I also addressed some issues with the current Docker documentation:
- environment variables are inherited from linked containers, so you should not change `[CONATINER]_ENV_` variables
- MYSQL_ENV_MYSQL_HOST does not exist
- linked containers are deprecated, so in future you are forced to configure `ROUNDCUBEMAIL_DB_` variables anyway
- therefore a `case "${ROUNDCUBEMAIL_DB_TYPE}"` might be a better choice?