### PR TITLE
Release 1.3 - Add TCP source port when logging source IP address

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ CHANGELOG Roundcube Webmail
 - Fix so temp_dir misconfiguration prints an error to the log (#6045)
 - Fix untagged COPYUID responses handling - again (#5982)
 - Add TCP source port when logging source IP address
+- Improve performances by adding directory level hashes when storing temp files
 
 RELEASE 1.3.3
 -------------

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ CHANGELOG Roundcube Webmail
 - Fix broken long filenames when using imap4d server - workaround server bug (#6048)
 - Fix so temp_dir misconfiguration prints an error to the log (#6045)
 - Fix untagged COPYUID responses handling - again (#5982)
+- Add TCP source port when logging source IP address
 
 RELEASE 1.3.3
 -------------

--- a/plugins/filesystem_attachments/filesystem_attachments.php
+++ b/plugins/filesystem_attachments/filesystem_attachments.php
@@ -60,7 +60,7 @@ class filesystem_attachments extends rcube_plugin
         $rcmail = rcube::get_instance();
 
         // use common temp dir for file uploads
-        $temp_dir = $rcmail->config->get('temp_dir');
+        $temp_dir = $rcmail->config->get('temp_dir').'/'.sprintf("%02d", rand(00, 99)).'/';
         $tmpfname = tempnam($temp_dir, 'rcmAttmnt');
 
         if (move_uploaded_file($args['path'], $tmpfname) && file_exists($tmpfname)) {
@@ -86,7 +86,7 @@ class filesystem_attachments extends rcube_plugin
 
         if (!$args['path']) {
             $rcmail   = rcube::get_instance();
-            $temp_dir = $rcmail->config->get('temp_dir');
+            $temp_dir = $rcmail->config->get('temp_dir').'/'.sprintf("%02d", rand(00, 99)).'/';
             $tmp_path = tempnam($temp_dir, 'rcmAttmnt');
 
             if ($fp = fopen($tmp_path, 'w')) {

--- a/program/include/rcmail.php
+++ b/program/include/rcmail.php
@@ -2214,7 +2214,7 @@ class rcmail extends rcube
 
             // generate image thumbnail for file browser in HTML editor
             if (!empty($_GET['_thumbnail'])) {
-                $temp_dir       = $this->config->get('temp_dir');
+                $temp_dir       = $this->config->get('temp_dir') . '/thumbs/' . sprintf("%02d", rand(00, 99));
                 $thumbnail_size = 80;
                 $mimetype       = $file['mimetype'];
                 $file_ident     = $file['id'] . ':' . $file['mimetype'] . ':' . $file['size'];

--- a/program/lib/Roundcube/rcube_utils.php
+++ b/program/lib/Roundcube/rcube_utils.php
@@ -662,7 +662,7 @@ class rcube_utils
             return $_SERVER['HTTP_X_REAL_IP'];
         } else {
             return $_SERVER['HTTP_X_FORWARDED_FOR'];
-	    }
+        }
     }
 
     /**

--- a/program/lib/Roundcube/rcube_utils.php
+++ b/program/lib/Roundcube/rcube_utils.php
@@ -662,7 +662,7 @@ class rcube_utils
             return $_SERVER['HTTP_X_REAL_IP'];
         } else {
             return $_SERVER['HTTP_X_FORWARDED_FOR'];
-        }
+	    }
     }
 
     /**

--- a/program/lib/Roundcube/rcube_utils.php
+++ b/program/lib/Roundcube/rcube_utils.php
@@ -662,7 +662,7 @@ class rcube_utils
             return $_SERVER['HTTP_X_REAL_IP'];
         } else {
             return $_SERVER['HTTP_X_FORWARDED_FOR'];
-	}
+	    }
     }
 
     /**

--- a/program/steps/mail/get.inc
+++ b/program/steps/mail/get.inc
@@ -76,7 +76,7 @@ if (!empty($_GET['_frame'])) {
 // render thumbnail of an image attachment
 if (!empty($_GET['_thumb']) && $attachment->is_valid()) {
     $thumbnail_size = $RCMAIL->config->get('image_thumbnail_size', 240);
-    $temp_dir       = $RCMAIL->config->get('temp_dir');
+    $temp_dir       = $RCMAIL->config->get('temp_dir') . '/thumbs/' . sprintf("%02d", rand(00, 99));
     $file_ident     = $attachment->ident;
     $cache_basename = $temp_dir . '/' . md5($file_ident . ':' . $RCMAIL->user->ID . ':' . $thumbnail_size);
     $cache_file     = $cache_basename . '.thumb';


### PR DESCRIPTION
As a lot of ISP use NAT (CGN, NAT64, ...) to provide Internet, multiple users are hidden behind a single source IP address. To track spammers or to help law enforcement track down intruders, I have made a patch to log the TCP source TCP when users log in. It supports both IPv4 and IPv6.