### PR TITLE
Release 1.3 - Add directory level hashes when storing temp files

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ CHANGELOG Roundcube Webmail
 - Fix broken long filenames when using imap4d server - workaround server bug (#6048)
 - Fix so temp_dir misconfiguration prints an error to the log (#6045)
 - Fix untagged COPYUID responses handling - again (#5982)
+- Improve performances by adding directory level hashes when storing temp files
 
 RELEASE 1.3.3
 -------------

--- a/plugins/filesystem_attachments/filesystem_attachments.php
+++ b/plugins/filesystem_attachments/filesystem_attachments.php
@@ -209,7 +209,7 @@ class filesystem_attachments extends rcube_plugin
         $temp_dir  = $rcmail->config->get('temp_dir');
         $file_path = pathinfo($path, PATHINFO_DIRNAME);
 
-        if ($temp_dir !== $file_path) {
+        if (preg_match('/^' . preg_quote($temp_dir, '/') . '/', $file_path) === 0) {
             // When the configured directory is not writable, or out of open_basedir path
             // tempnam() fallbacks to system temp without a warning.
             // We allow that, but we'll let to know the user about the misconfiguration.

--- a/plugins/filesystem_attachments/filesystem_attachments.php
+++ b/plugins/filesystem_attachments/filesystem_attachments.php
@@ -60,7 +60,7 @@ class filesystem_attachments extends rcube_plugin
         $rcmail = rcube::get_instance();
 
         // use common temp dir for file uploads
-        $temp_dir = $rcmail->config->get('temp_dir');
+        $temp_dir = $rcmail->config->get('temp_dir') . '/' . sprintf("%02d", rand(00, 99)) . '/';
         $tmpfname = tempnam($temp_dir, 'rcmAttmnt');
 
         if (move_uploaded_file($args['path'], $tmpfname) && file_exists($tmpfname)) {
@@ -86,7 +86,7 @@ class filesystem_attachments extends rcube_plugin
 
         if (!$args['path']) {
             $rcmail   = rcube::get_instance();
-            $temp_dir = $rcmail->config->get('temp_dir');
+            $temp_dir = $rcmail->config->get('temp_dir') . '/' . sprintf("%02d", rand(00, 99)) . '/';
             $tmp_path = tempnam($temp_dir, 'rcmAttmnt');
 
             if ($fp = fopen($tmp_path, 'w')) {

--- a/program/include/rcmail.php
+++ b/program/include/rcmail.php
@@ -2214,7 +2214,7 @@ class rcmail extends rcube
 
             // generate image thumbnail for file browser in HTML editor
             if (!empty($_GET['_thumbnail'])) {
-                $temp_dir       = $this->config->get('temp_dir');
+                $temp_dir       = $this->config->get('temp_dir') . '/thumbs/' . sprintf("%02d", rand(00, 99));
                 $thumbnail_size = 80;
                 $mimetype       = $file['mimetype'];
                 $file_ident     = $file['id'] . ':' . $file['mimetype'] . ':' . $file['size'];

--- a/program/steps/mail/get.inc
+++ b/program/steps/mail/get.inc
@@ -76,7 +76,7 @@ if (!empty($_GET['_frame'])) {
 // render thumbnail of an image attachment
 if (!empty($_GET['_thumb']) && $attachment->is_valid()) {
     $thumbnail_size = $RCMAIL->config->get('image_thumbnail_size', 240);
-    $temp_dir       = $RCMAIL->config->get('temp_dir');
+    $temp_dir       = $RCMAIL->config->get('temp_dir') . '/thumbs/' . sprintf("%02d", rand(00, 99));
     $file_ident     = $attachment->ident;
     $cache_basename = $temp_dir . '/' . md5($file_ident . ':' . $RCMAIL->user->ID . ':' . $thumbnail_size);
     $cache_file     = $cache_basename . '.thumb';


### PR DESCRIPTION
For large deployment infrastructure (more than thousand users) it becomes mandatory to improve storing temporary files performances by adding directory level hashes when storing temp files. Most of the filesystems can't handle more than 1.000 files per directory. Plus thumbs and attachments are stored in different directories to allow different retention times when purging files.