### PR TITLE
Add GeoIP and verbose datas when logging user sendmail

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -60,6 +60,7 @@ CHANGELOG Roundcube Webmail
 - Fix broken long filenames when using imap4d server - workaround server bug (#6048)
 - Fix so temp_dir misconfiguration prints an error to the log (#6045)
 - Fix untagged COPYUID responses handling - again (#5982)
+- Add GeoIP and verbose datas when logging user sendmail
 
 RELEASE 1.3.3
 -------------

--- a/program/lib/Roundcube/rcube.php
+++ b/program/lib/Roundcube/rcube.php
@@ -1687,12 +1687,21 @@ class rcube
                 // get all recipient addresses
                 $mailto = implode(',', $a_recipients);
                 $mailto = rcube_mime::decode_address_list($mailto, null, false, null, true);
+                $geoip = geoip_record_by_name(rcube_utils::remote_addr());
+                $geostring = '';
+                if (is_array($geoip)) {
+                    $geostring = implode('/', array_slice($geoip, 0, 6));
+                }
 
-                self::write_log('sendmail', sprintf("User %s [%s]; Message %s for %s; %s",
+                self::write_log('sendmail', sprintf("IP: %s GeoIP: %s UA: %s Login: %s From: %s To: %s Subject: %s MID: %s SMTP: %s",
+                    rcube_utils::remote_ip(),
+                    $geostring,
+                    $_SERVER['HTTP_USER_AGENT'],
                     $this->user->get_username(),
-                    rcube_utils::remote_addr(),
-                    $headers['Message-ID'],
+                    $headers['From'],
                     implode(', ', $mailto),
+                    rcube_mime::decode_header($headers['Subject']),
+                    $headers['Message-ID'],
                     !empty($response) ? join('; ', $response) : ''));
             }
         }


### PR DESCRIPTION
Add GeoIP, UserAgent and verbose datas when logging user sendmail in order to accurately track spammers when they script RoundCubeMail to send spams.