### PR TITLE
Add TCP source port when logging source IP address

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -60,6 +60,7 @@ CHANGELOG Roundcube Webmail
 - Fix broken long filenames when using imap4d server - workaround server bug (#6048)
 - Fix so temp_dir misconfiguration prints an error to the log (#6045)
 - Fix untagged COPYUID responses handling - again (#5982)
+- Add TCP source port when logging source IP address
 
 RELEASE 1.3.3
 -------------

--- a/program/lib/Roundcube/rcube_utils.php
+++ b/program/lib/Roundcube/rcube_utils.php
@@ -611,20 +611,38 @@ class rcube_utils
      */
     public static function remote_ip()
     {
-        $address = $_SERVER['REMOTE_ADDR'];
+        // IPv4
+        if (strpos($_SERVER['REMOTE_ADDR'], ':') === false) {
+            $address = $_SERVER['REMOTE_ADDR'] . ':' . $_SERVER['REMOTE_PORT'];
+        // IPv6
+        } else {
+            $address = '[' . $_SERVER['REMOTE_ADDR'] . ']:' . $_SERVER['REMOTE_PORT'];
+        }
 
         // append the NGINX X-Real-IP header, if set
         if (!empty($_SERVER['HTTP_X_REAL_IP'])) {
-            $remote_ip[] = 'X-Real-IP: ' . $_SERVER['HTTP_X_REAL_IP'];
+            // IPv4
+            if (strpos($_SERVER['HTTP_X_REAL_IP'], ':') === false) {
+                $remote_ip[] = 'X-Real-IP: ' . $_SERVER['HTTP_X_REAL_IP'] . ':' . $_SERVER['HTTP_X_REAL_PORT'];
+            // IPv6
+            } else {
+                $remote_ip[] = 'X-Real-IP: [' . $_SERVER['HTTP_X_REAL_IP'] . ']:' . $_SERVER['HTTP_X_REAL_PORT'];
+            }
         }
 
-        // append the X-Forwarded-For header, if set
-        if (!empty($_SERVER['HTTP_X_FORWARDED_FOR'])) {
-            $remote_ip[] = 'X-Forwarded-For: ' . $_SERVER['HTTP_X_FORWARDED_FOR'];
+        // append the X-Forwarded-For header, if set and different from X-Real-IP one
+        if (!empty($_SERVER['HTTP_X_FORWARDED_FOR']) and (strcmp($_SERVER['HTTP_X_FORWARDED_FOR'], $_SERVER['HTTP_X_REAL_IP']) !== 0)) {
+            // IPv4
+            if (strpos($_SERVER['HTTP_X_REAL_IP'], ':') === false) {
+                $remote_ip[] = 'X-Forwarded-For: ' . $_SERVER['HTTP_X_FORWARDED_FOR'] . ':' . $_SERVER['HTTP_X_FORWARDED_PORT'];
+            // IPv6
+            } else {
+                $remote_ip[] = 'X-Forwarded-For: [' . $_SERVER['HTTP_X_FORWARDED_FOR'] . ']:' . $_SERVER['HTTP_X_FORWARDED_PORT'];
+            }
         }
 
         if (!empty($remote_ip)) {
-            $address .= '(' . implode(',', $remote_ip) . ')';
+            $address .= ' (' . implode(',', $remote_ip) . ')';
         }
 
         return $address;
@@ -655,11 +673,11 @@ class rcube_utils
             }
         }
 
-        if (!empty($_SERVER['REMOTE_ADDR'])) {
-            return $_SERVER['REMOTE_ADDR'];
+        if (!empty($_SERVER['HTTP_X_REAL_IP'])) {
+            return $_SERVER['HTTP_X_REAL_IP'];
+        } else {
+            return $_SERVER['HTTP_X_FORWARDED_FOR'];
         }
-
-        return '';
     }
 
     /**


### PR DESCRIPTION
As a lot of ISP use NAT (CGN, NAT64, ...) to provide Internet, multiple users are hidden behind a single source IP address. To track spammers or to help law enforcement track down intruders, I have made a patch to log the TCP source TCP when users log in. It supports both IPv4 and IPv6.