### PR TITLE
a device can't be both a table and a mobile

### DIFF
--- a/program/js/common.js
+++ b/program/js/common.js
@@ -89,8 +89,8 @@ function roundcube_browser()
   if (this.safari && (/;\s+([a-z]{2})-[a-z]{2}\)/.test(this.agent_lc)))
     this.lang = RegExp.$1;
 
-  this.tablet = /ipad|android|xoom|sch-i800|playbook|tablet|kindle/i.test(this.agent_lc);
   this.mobile = /iphone|ipod|blackberry|iemobile|opera mini|opera mobi|mobile/i.test(this.agent_lc);
+  this.tablet = !this.mobile && /ipad|android|xoom|sch-i800|playbook|tablet|kindle/i.test(this.agent_lc);
   this.touch = this.mobile || this.tablet;
   this.pointer = typeof window.PointerEvent == "function";
   this.cookies = n.cookieEnabled;


### PR DESCRIPTION
the smasung browser on my phone is detected as both a mobile and a table because the UA string has `android` and `mobile` in it. i think a device is either a mobile or a tablet so this change prevents both from being true.