### PR TITLE
avoid date parsing hang when listing messages with broken headers

### DIFF
--- a/program/lib/Roundcube/rcube_imap_generic.php
+++ b/program/lib/Roundcube/rcube_imap_generic.php
@@ -2500,6 +2500,13 @@ class rcube_imap_generic
                         list($field, $string) = explode(':', $str, 2);
 
                         $field  = strtolower($field);
+                        if ($field == 'date') {
+                            $newlinepos = strpos($string,"\n");
+                            if ($newlinepos) {
+                                // ensure Date string is only a single line so that parsing doesn't hang
+                                $string = substr($string,0,$newlinepos);
+                            }
+                        }
                         $string = preg_replace('/\n[\t\s]*/', ' ', trim($string));
 
                         switch ($field) {


### PR DESCRIPTION
https://github.com/roundcube/roundcubemail/issues/6087

my test case had a HUGE number of users that were getting appended to the Date header; it's possible that a small number of users would not break date parsing. even if it wasn't hanging and could parse it, this patch will make $result[$id]->date have only the date string.