### PR TITLE
check for minified CSS files

### DIFF
--- a/program/lib/Roundcube/rcube_plugin_api.php
+++ b/program/lib/Roundcube/rcube_plugin_api.php
@@ -622,6 +622,12 @@ class rcube_plugin_api
                         $fn = $less;
                     }
                 }
+                else if (!preg_match('/\.min\.css$/', $fn)) {
+                    $min = preg_replace('/\.css$/i', '.min.css', $fn);
+                    if (is_file("$path/plugins/$min")) {
+                        $fn = $min;
+                    }
+                }
 
                 if (!is_file("$path/plugins/$fn")) {
                     return;


### PR DESCRIPTION
if a plugin has minified css files created by the bin/cssshrink.sh script, and the regular files are not present then the CSS is not included. the check added here is based on code in rcmail_output_html::file_mod()