### PR TITLE
'imap_log_session' option doesn't work

### DIFF
--- a/program/lib/Roundcube/rcube.php
+++ b/program/lib/Roundcube/rcube.php
@@ -481,8 +481,8 @@ class rcube
      */
     public function storage_log_session($args)
     {
-        if (!empty($args['session']) && session_id()) {
-            $this->write_log('imap_session', $args['session']);
+        if (!empty($args['user']) && session_id()) {
+            $this->write_log('imap_session', $args['user']);
         }
     }
 


### PR DESCRIPTION
Hi.

I found that the IMAP session user is not logged correctly and will be fixed with this patch.

Thank you,
