### PR TITLE
Fix preg_match in guess_type function

### DIFF
--- a/program/lib/Roundcube/rcube_config.php
+++ b/program/lib/Roundcube/rcube_config.php
@@ -110,13 +110,13 @@ class rcube_config
 
         // array requires hint to be passed.
 
-        if (preg_match('/^[-+]?(\d+(\.\d*)?|\.\d+)([eE][-+]?\d+)?$/', $value) !== false) {
+        if (preg_match('/^[-+]?(\d+(\.\d*)?|\.\d+)([eE][-+]?\d+)?$/', $value)) {
             $type = 'double';
         }
-        else if (preg_match('/^\d+$/', $value) !== false) {
+        else if (preg_match('/^\d+$/', $value)) {
             $type = 'integer';
         }
-        else if (preg_match('/(t(rue)?)|(f(alse)?)/i', $value) !== false) {
+        else if (preg_match('/^(t(rue)?)|(f(alse)?)$/i', $value)) {
             $type = 'boolean';
         }
 


### PR DESCRIPTION
preg_match returns only false if the regex could not be compiled -> every call did return type 'double'.
I fixed also the the boolean regex since it matched if there was an "t" or "f" in a string...
  