### PR TITLE
php log_driver: Pass all logs to php's configured error_log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Added option to define font list and font-size list for HTML editor - available_fonts/available_font_sizes (#5700)
 - Support for HAproxy protocol header in IMAP connections (#8625)
 - Change 'smtp_log' option default value to False
+- Add 'php' log_driver value (#6138)
 - Delete messages directly from Junk on folder purge if delete_junk is enabled (#8766)
 - Hide information about quota, when there is no quota (#8994)
 - Set timeout=30, connect_timeout=5, read_timeout=120 as defaults for HTTP client (#8865)

--- a/INSTALL
+++ b/INSTALL
@@ -71,6 +71,7 @@ and configure your installation to be not surprised by default behaviour.
 Roundcube writes internal errors to the 'errors.log' log file located in the logs
 directory which can be configured in config/config.inc.php. If you want ordinary
 PHP errors to be logged there as well, set error_log in php.ini or .htaccess file.
+Examine the log_driver config value for other options.
 
 Roundcube forces display_errors=Off and log_errors=On.
 

--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -70,7 +70,7 @@ $config['db_max_allowed_packet'] = null;
 // LOGGING/DEBUGGING
 // ----------------------------------
 
-// log driver:  'syslog', 'stdout' or 'file'.
+// log driver:  'syslog', 'stdout', 'file', or 'php'.
 $config['log_driver'] = 'file';
 
 // date format for log entries

--- a/installer/config.php
+++ b/installer/config.php
@@ -200,11 +200,11 @@ echo $input_ilevel->show($RCI->getprop('identities_level'), 0);
 
 <?php
 $select_log_driver = new html_select(['name' => '_log_driver', 'id' => 'cfglogdriver']);
-$select_log_driver->add(['file', 'syslog', 'stdout'], ['file', 'syslog', 'stdout']);
+$select_log_driver->add(['file', 'syslog', 'stdout', 'php'], ['file', 'syslog', 'stdout', 'php']);
 echo $select_log_driver->show($RCI->getprop('log_driver', 'file'));
 ?>
 
-<div>How to do logging? 'file' - write to files in the log directory, 'syslog' - use the syslog facility, 'stdout' writes to the process' STDOUT file descriptor.</div>
+<div>How to do logging? 'file' - write to files in the log directory, 'syslog' - use the syslog facility, 'stdout' writes to the process' STDOUT file descriptor, 'php' writes to php's configured error_log facility.</div>
 </dd>
 
 <dt class="propname">log_dir</dt>

--- a/installer/test.php
+++ b/installer/test.php
@@ -103,7 +103,7 @@ if ($RCI->configured && ($messages = $RCI->check_config())) {
 <?php
 
 $dirs = [!empty($RCI->config['temp_dir']) ? $RCI->config['temp_dir'] : 'temp'];
-if ($RCI->config['log_driver'] != 'syslog') {
+if ($RCI->config['log_driver'] != 'syslog' && $RCI->config['log_driver'] != 'php') {
     $dirs[] = $RCI->config['log_dir'] ?: 'logs';
 }
 

--- a/program/lib/Roundcube/rcube.php
+++ b/program/lib/Roundcube/rcube.php
@@ -1345,6 +1345,12 @@ class rcube
             return file_put_contents($stdout, $line, \FILE_APPEND) !== false;
         }
 
+        // write to php's configured error_log (or that which is configured in .htaccess)
+        if ($log_driver == 'php') {
+            $line = "{$name}: {$line}";
+            return error_log($line);
+        }
+
         // log_driver == 'file' is assumed here
 
         $line = sprintf("[%s]: %s\n", $date, $line);

--- a/program/lib/Roundcube/rcube_config.php
+++ b/program/lib/Roundcube/rcube_config.php
@@ -243,7 +243,7 @@ class rcube_config
             $error_log .= $this->prop['log_file_ext'] ?? '.log';
         }
 
-        if ($error_log && $error_log != 'stdout') {
+        if ($error_log && ($error_log != 'stdout' && $error_log != 'php')) {
             ini_set('error_log', $error_log);
         }
 


### PR DESCRIPTION
As a sysadmin, it's super annoying to find that application X's php errors are not going to their expected location. In my case, that would be what I configured in php.ini or .htaccess.

With this, users are not forced into choosing an additional error_log file. They can choose 'php' for log_driver and let php's configured error_log function as they'd expect.

As an added bonus it also allows the error_log override in .htaccess to take effect (if configured) and route ALL log messages to the expected file (roundcube _internal_ and _php_).

If you want to go overboard with overrides, you could also add a 'sapi' value with:
`return error_log($line, 4);`