### PR TITLE
add originalEvent param to actionafter event

### DIFF
--- a/program/js/app.js
+++ b/program/js/app.js
@@ -1427,7 +1427,7 @@ function rcube_webmail()
 
     if (!aborted && this.triggerEvent('after'+command, props) === false)
       ret = false;
-    this.triggerEvent('actionafter', { props:props, action:command, aborted:aborted, ret:ret });
+    this.triggerEvent('actionafter', { props:props, action:command, aborted:aborted, ret:ret, originalEvent:event});
 
     return ret === false ? false : obj ? false : true;
   };


### PR DESCRIPTION
add the originalEvent as param to the actionafter event. similar to how its on the actionbefore event. useful for event tracking, related to https://github.com/johndoh/roundcube-contextmenu/issues/102