### PR TITLE
Add support for PostgreSQL schemas in DSN

### DIFF
--- a/program/lib/Roundcube/rcube_db_pgsql.php
+++ b/program/lib/Roundcube/rcube_db_pgsql.php
@@ -56,6 +56,11 @@ class rcube_db_pgsql extends rcube_db
     {
         $dbh->query("SET NAMES 'utf8'");
         $dbh->query("SET DATESTYLE TO ISO");
+
+        // if ?schema= is set in dsn, set the search_path
+        if ($dsn['schema']) {
+            $dbh->query("SET search_path TO " . $this->quote($dsn['schema']));
+        }
     }
 
     /**


### PR DESCRIPTION
If schema is set in the dsn, set search_path to the schema value.

Example:

$config['db_dsnw'] = 'pgsql://user:pass@localhost/dbname?schema=exampleschema';