### PR TITLE
Patched bug where rcube_db::quote() was causing an infinite loop.

### DIFF
--- a/program/lib/Roundcube/rcube_db.php
+++ b/program/lib/Roundcube/rcube_db.php
@@ -135,7 +135,6 @@ class rcube_db
 
         // connect to database
         if ($dbh = $this->conn_create($dsn)) {
-            $this->dbh          = $dbh;
             $this->dbhs[$mode]  = $dbh;
             $this->db_mode      = $mode;
             $this->db_connected = true;
@@ -160,12 +159,12 @@ class rcube_db
 
             $this->conn_prepare($dsn);
 
-            $dbh = new PDO($dsn_string, $dsn['username'], $dsn['password'], $dsn_options);
+            $this->dbh = new PDO($dsn_string, $dsn['username'], $dsn['password'], $dsn_options);
 
             // don't throw exceptions or warnings
-            $dbh->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_SILENT);
+            $this->dbh->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_SILENT);
 
-            $this->conn_configure($dsn, $dbh);
+            $this->conn_configure($dsn, $this->dbh);
         }
         catch (Exception $e) {
             $this->db_error     = true;
@@ -178,7 +177,7 @@ class rcube_db
             return null;
         }
 
-        return $dbh;
+        return $this->dbh;
     }
 
     /**


### PR DESCRIPTION
As rcube_db::quote() checks to see if the connection is up before quoting, this would cause the class to try connect again, as rcube_db::$dbh was not being set until AFTER conn_configure was completed, causing a loop.

So updated rcube_db::$dbh in the rcube::conn_create() function instead allowing access to the new object straight away.