### PR TITLE
Use JQ() instead of Q() in rcmail_js_message_list

### DIFF
--- a/program/steps/mail/func.inc
+++ b/program/steps/mail/func.inc
@@ -513,7 +513,7 @@ function rcmail_js_message_list($a_headers, $insert_top=false, $a_show_cols=null
             else if ($col == 'subject') {
                 $cont = trim(rcube_mime::decode_header($header->$col, $header->charset));
                 if (!$cont) $cont = $RCMAIL->gettext('nosubject');
-                $cont = rcube::Q($cont);
+                $cont = rcube::JQ($cont);
             }
             else if ($col == 'size')
                 $cont = $RCMAIL->show_bytes($header->$col);
@@ -526,10 +526,10 @@ function rcmail_js_message_list($a_headers, $insert_top=false, $a_show_cols=null
                     $last_folder_name = str_replace($delimiter, " \xC2\xBB ", $last_folder_name);
                 }
 
-                $cont = rcube::Q($last_folder_name);
+                $cont = rcube::JQ($last_folder_name);
             }
             else
-                $cont = rcube::Q($header->$col);
+                $cont = rcube::JQ($header->$col);
 
             $a_msg_cols[$col] = $cont;
         }


### PR DESCRIPTION
`rcmail_js_message_list()` returns JS commands to add rows to the message list; it should use `rcube::JQ()` instead of `rcube::Q()` to replace unicode and line separators in the generated string.

This PR fixes this bug: when the message subject contains the LINE_SEPARATOR or PARAGRAPH_SEPARATOR character (`\u2028` or `\u2029`), Roundcube fails to display the message list with a Javascript error. 

Test case: 

    Subject: =?utf-8?Q?PRISM_-_Toolkit_for_evaluating_the_outcomes_and_im?=
    =?utf-8?Q?pacts_=E2=80=A9of_small/medium-sized_conservation_projects?=
