### PR TITLE
Set date_default_timezone_set of DateTime object

### DIFF
--- a/program/include/rcmail.php
+++ b/program/include/rcmail.php
@@ -1201,8 +1201,11 @@ class rcmail extends rcube
      */
     public function format_date($date, $format = null, $convert = true)
     {
+        $stz = date_default_timezone_get();
+
         if (is_object($date) && is_a($date, 'DateTime')) {
             $timestamp = $date->format('U');
+            date_default_timezone_set($date->getTimeZone()->getName());
         }
         else {
             if (!empty($date)) {
@@ -1223,8 +1226,6 @@ class rcmail extends rcube
 
         if ($convert) {
             try {
-                // convert to the right timezone
-                $stz = date_default_timezone_get();
                 $tz = new DateTimeZone($this->config->get('timezone'));
                 $date->setTimezone($tz);
                 date_default_timezone_set($tz->getName());
@@ -1258,9 +1259,7 @@ class rcmail extends rcube
         // strftime() format
         if (preg_match('/%[a-z]+/i', $format)) {
             $format = strftime($format, $timestamp);
-            if ($stz) {
-                date_default_timezone_set($stz);
-            }
+            date_default_timezone_set($stz);
             return $today ? ($this->gettext('today') . ' ' . $format) : $format;
         }
 
@@ -1311,13 +1310,10 @@ class rcmail extends rcube
             }
         }
 
-        if ($stz) {
-            date_default_timezone_set($stz);
-        }
+        date_default_timezone_set($stz);
 
         return $out;
     }
-
     /**
      * Return folders list in HTML
      *


### PR DESCRIPTION
I propose this update to guarantee that the out value on date php function of timestamp created on beginning are same of datetime argument object on function when the caller of this function set to not convert to timezone of config file. 

This situation occur on calendar plugin when I'm on GMT -3 and I receive a invite of all day event. 

![captura de tela de 2018-02-20 14-48-01](https://user-images.githubusercontent.com/185643/36439931-172b2028-164d-11e8-9e97-4acc3b2f434a.png)

But how the datetime object is converted to unix timestamp format to after be presented using the date php function, I see that this situation may occur not only of this way above.

The ics files received on gmail invite:
[icss.zip](https://github.com/roundcube/roundcubemail/files/1741247/icss.zip)