### PR TITLE
Added exec_hook to send error to an external error tracking tool

### DIFF
--- a/program/lib/Roundcube/rcube.php
+++ b/program/lib/Roundcube/rcube.php
@@ -1303,13 +1303,6 @@ class rcube
      */
     public static function raise_error($arg = array(), $log = false, $terminate = false)
     {
-        // send error to external error tracking tool
-        $arg = self::$instance->plugins->exec_hook('raise_error', $arg);
-
-        if ($arg['abort']) {
-          return;
-        }
-
         // handle PHP exceptions
         if ($arg instanceof Exception) {
             $arg = array(
@@ -1335,6 +1328,13 @@ class rcube
         }
 
         $cli = php_sapi_name() == 'cli';
+
+        $arg['cli'] = $cli;
+        $arg['log'] = $log;
+        $arg['terminate'] = $terminate;
+
+        // send error to external error tracking tool
+        $arg = self::$instance->plugins->exec_hook('raise_error', $arg);
 
         // installer
         if (!$cli && class_exists('rcmail_install', false)) {

--- a/program/lib/Roundcube/rcube.php
+++ b/program/lib/Roundcube/rcube.php
@@ -1304,7 +1304,11 @@ class rcube
     public static function raise_error($arg = array(), $log = false, $terminate = false)
     {
         // send error to external error tracking tool
-        self::$instance->plugins->exec_hook('send_to_external_error_tracking', $arg);
+        $arg = self::$instance->plugins->exec_hook('raise_error', $arg);
+
+        if ($arg['abort']) {
+          return;
+        }
 
         // handle PHP exceptions
         if ($arg instanceof Exception) {

--- a/program/lib/Roundcube/rcube.php
+++ b/program/lib/Roundcube/rcube.php
@@ -1303,6 +1303,10 @@ class rcube
      */
     public static function raise_error($arg = array(), $log = false, $terminate = false)
     {
+        // send error to external error tracking tool
+        self::$instance->plugins->exec_hook('send_to_external_error_tracking', $arg);
+
+        // handle PHP exceptions
         if ($arg instanceof Exception) {
             $arg = array(
                 'code' => $arg->getCode(),


### PR DESCRIPTION
I'm working with roundcube and I felt the need of a hook to send a log to my error tracking tool when rouncube handles an exception. So I add a hook to do it in using a plugin.

issue  #6199