### PR TITLE
make settings list html more consistent

### DIFF
--- a/program/js/app.js
+++ b/program/js/app.js
@@ -502,7 +502,7 @@ function rcube_webmail()
         break;
 
       case 'settings':
-        this.enable_command('preferences', 'identities', 'responses', 'save', 'folders', true);
+        this.enable_command('show', 'save', true);
 
         if (this.env.action == 'identities') {
           this.enable_command('add', this.env.identities_level < 2);
@@ -907,6 +907,9 @@ function rcube_webmail()
           cid = props ? props : this.get_single_cid();
           if (cid && !(this.env.action == 'show' && cid == this.env.cid))
             this.load_contact(cid, 'show');
+        }
+        else if (this.task == 'settings') {
+          this.goto_url('settings/' + props, {_framed: 0});
         }
         break;
 
@@ -1408,14 +1411,6 @@ function rcube_webmail()
 
       case 'delete-photo':
         this.replace_contact_photo('-del-');
-        break;
-
-      // user settings commands
-      case 'preferences':
-      case 'identities':
-      case 'responses':
-      case 'folders':
-        this.goto_url('settings/' + command, {_framed: 0});
         break;
 
       case 'undo':

--- a/program/steps/settings/func.inc
+++ b/program/steps/settings/func.inc
@@ -1390,10 +1390,10 @@ function rcmail_settings_tabs($attrib)
     $attrib += array('tagname' => 'span', 'idprefix' => 'settingstab', 'selclass' => 'selected');
 
     $default_actions = array(
-        array('command' => 'preferences', 'type' => 'link', 'label' => 'preferences', 'title' => 'editpreferences'),
-        array('command' => 'folders',     'type' => 'link', 'label' => 'folders',     'title' => 'managefolders'),
-        array('command' => 'identities',  'type' => 'link', 'label' => 'identities',  'title' => 'manageidentities'),
-        array('command' => 'responses',   'type' => 'link', 'label' => 'responses',   'title' => 'manageresponses'),
+        array('action' => 'preferences', 'type' => 'link', 'label' => 'preferences', 'title' => 'editpreferences'),
+        array('action' => 'folders',     'type' => 'link', 'label' => 'folders',     'title' => 'managefolders'),
+        array('action' => 'identities',  'type' => 'link', 'label' => 'identities',  'title' => 'manageidentities'),
+        array('action' => 'responses',   'type' => 'link', 'label' => 'responses',   'title' => 'manageresponses'),
     );
 
     $disabled_actions = (array) $RCMAIL->config->get('disabled_actions');
@@ -1410,20 +1410,29 @@ function rcmail_settings_tabs($attrib)
     $tabs     = array();
 
     foreach ($plugin['actions'] as $action) {
-        $task_action = $action['command'] ? $action['command'] : $action['action'];
-        if (in_array('settings.' . $task_action, $disabled_actions)) {
+        if (!$action['command'] && $action['action']) {
+            $action['prop'] = $action['action'];
+            $action['command'] = 'show';
+        }
+        else if ($action['command'] != 'show') {
+            // Backwards compatibility, show command added in 1.4
+            $action['prop'] = $action['command'];
+            $action['command'] = 'show';
+        }
+
+        $cmd = $action['prop'] ?: $action['action'];
+        $id  = $action['id'] ?: $cmd;
+
+        if (in_array('settings.' . $cmd, $disabled_actions)) {
             continue;
         }
 
-        if (!$action['command'] && !$action['href'] && $action['action']) {
-            $action['href'] = $RCMAIL->url(array('_action' => $action['action']));
+        if (!$action['href']) {
+            $action['href'] = $RCMAIL->url(array('_action' => $cmd));
         }
 
         $button = $OUTPUT->button($action + array('type' => 'link'));
         $attr   = $attrib;
-
-        $cmd = $action['action'] ?: $action['command'];
-        $id  = $action['id'] ?: $cmd;
 
         if (!empty($id)) {
             $attr['id'] = preg_replace('/[^a-z0-9]/i', '', $attrib['idprefix'] . $id);


### PR DESCRIPTION
In the settings list (preferences/folders/identities etc) some elements have `onclick` some have `href` and some have both. This is not limited to core vs plugin entries. For example `preferences` has `href` and `onclick` while `responses` has only `onclick`.