### PR TITLE
fix issue #6219

### DIFF
--- a/program/lib/Roundcube/rcube_config.php
+++ b/program/lib/Roundcube/rcube_config.php
@@ -469,10 +469,10 @@ class rcube_config
      */
     public function all()
     {
-        $props = $this->prop;
+        $props = array();
 
-        foreach ($props as $prop_name => $prop_value) {
-            $props[$prop_name] = $this->getenv_default('ROUNDCUBE_' . strtoupper($prop_name), $prop_value);
+        foreach ($this->prop as $prop_name => $prop_value) {
+            $props[$prop_name] = $this->get($prop_name, $prop_value);
         }
 
         $rcube  = rcube::get_instance();


### PR DESCRIPTION
I think the rcube_config::all should reference to rcube_config::get
This is also interessting for the single-hooks of config