### PR TITLE
ensure tooltip is only set on toolbar icon

### DIFF
--- a/skins/elastic/ui.js
+++ b/skins/elastic/ui.js
@@ -1167,7 +1167,7 @@ function rcube_elastic_ui()
             case 'reply-list':
                 if (rcmail.env.reply_all_mode == 1) {
                     var label = rcmail.gettext(args.status ? 'replylist' : 'replyall');
-                    $('a.button.reply-all').attr('title', label).find('.inner').text(label);
+                    $('#toolbar-menu a.button.reply-all').attr('title', label).find('.inner').text(label);
                 }
                 break;
 


### PR DESCRIPTION
I'm not sure if its better to fix this in the contextmenu plugin or here.

Elastic adds a tooltip to the reply all icon on the mail toolbar to indicate which type of reply all mode is active. This change ensures the tooltip is only set on the icon in the mail toolbar and not on any other elements in the DOM with the same classes (eg in the contextmenu). The reason is having only 1 item in the contextmenu with a tooltip looks odd imo.