### PR TITLE
add Elastic deps folder to .gitignore

### DIFF
--- a/skins/elastic/.gitignore
+++ b/skins/elastic/.gitignore
@@ -1,3 +1,4 @@
 styles/styles.css
 styles/print.css
 styles/embed.css
+deps/*


### PR DESCRIPTION
add the deps folder created when install-jsdeps.sh is run to .gitignore