### PR TITLE
allow plugins to prevent multiple execution of getselection JS event

### DIFF
--- a/program/js/list.js
+++ b/program/js/list.js
@@ -1282,12 +1282,11 @@ clear_selection: function(id, no_event)
  */
 get_selection: function(deep)
 {
-  var res;
+  var res = $.merge([], this.selection);
 
-  if (res = this.triggerEvent('getselection', deep))
-    return res;
-
-  res = $.merge([], this.selection);
+  var props = {deep: deep, res: res};
+  if (this.triggerEvent('getselection', props) === false)
+    return props.res;
 
   // return children of selected threads even if only root is selected
   if (deep !== false && res.length) {


### PR DESCRIPTION
PR for #6192

Note: this is a breaking change. Plugins that use the getselection event will need updating to use props.res but at the time of writing the getselection event only exists in git-master version of Roundcube, it has not been released yet. For example:
```js
rcmail.message_list.addEventListener('getselection', function() {
  var res;

  /* plugin code */

  return res;
}
```
becomes:
```js
rcmail.message_list.addEventListener('getselection', function(props) {
  var res;

  /* plugin code */

  props.res = res;
  return false;
}
```