### PR TITLE
create favicon template object

### DIFF
--- a/program/include/rcmail_output_html.php
+++ b/program/include/rcmail_output_html.php
@@ -1239,8 +1239,16 @@ EOF;
                     $title .= $this->get_pagetitle();
                     $content = html::quote($title);
                 }
-                else if ($object == 'favicon' && $file = $this->config->get('favicon', null)) {
-                    $content = html::tag('link', array('rel'  => 'shortcut icon', 'href' => $file));
+                else if ($object == 'favicon') {
+                    $fn = RCUBE_CONFIG_DIR . 'favicon.html';
+                    if (is_readable($fn)) {
+                        $content = file_get_contents($fn);
+                        $content = $this->parse_conditions($content);
+                        $content = $this->parse_xml($content);
+                    }
+                    else if ($file = $this->config->get('favicon', null)) {
+                        $content = html::tag('link', array('rel'  => 'shortcut icon', 'href' => $file));
+                    }
                 }
 
                 // exec plugin hooks for this template object

--- a/program/include/rcmail_output_html.php
+++ b/program/include/rcmail_output_html.php
@@ -1239,6 +1239,9 @@ EOF;
                     $title .= $this->get_pagetitle();
                     $content = html::quote($title);
                 }
+                else if ($object == 'favicon' && $file = $this->config->get('favicon', null)) {
+                    $content = html::tag('link', array('rel'  => 'shortcut icon', 'href' => $file));
+                }
 
                 // exec plugin hooks for this template object
                 $hook = $this->app->plugins->exec_hook("template_object_$object", $attrib + array('content' => $content));

--- a/skins/classic/includes/links.html
+++ b/skins/classic/includes/links.html
@@ -1,5 +1,5 @@
 <link rel="index" href="$__comm_path" />
-<link rel="shortcut icon" href="/images/favicon.ico"/>
+<roundcube:object name="favicon" doctype="html4" />
 <link rel="stylesheet" type="text/css" href="/common.css" />
 <roundcube:if condition="in_array(env:task, array('mail', 'addressbook', 'settings'))" />
 <link rel="stylesheet" type="text/css" href="/<roundcube:var name="env:task" />.css" />

--- a/skins/classic/meta.json
+++ b/skins/classic/meta.json
@@ -2,5 +2,8 @@
 	"name": "Classic",
 	"author": "The Roundcube Dev Team",
 	"license": "Creative Commons Attribution-ShareAlike",
-	"license-url": "http://creativecommons.org/licenses/by-sa/3.0/"
+	"license-url": "http://creativecommons.org/licenses/by-sa/3.0/",
+	"config": {
+		"favicon": "/images/favicon.ico"
+	}
 }

--- a/skins/classic/templates/contactprint.html
+++ b/skins/classic/templates/contactprint.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <title><roundcube:object name="pagetitle" /></title>
-<link rel="shortcut icon" href="/images/favicon.ico"/>
+<roundcube:object name="favicon" doctype="html4" />
 <link rel="stylesheet" type="text/css" href="/print.css" />
 </head>
 <body>

--- a/skins/classic/templates/messageprint.html
+++ b/skins/classic/templates/messageprint.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <title><roundcube:object name="pagetitle" /></title>
-<link rel="shortcut icon" href="/images/favicon.ico"/>
+<roundcube:object name="favicon" doctype="html4" />
 <link rel="stylesheet" type="text/css" href="/print.css" />
 </head>
 <body>

--- a/skins/elastic/meta.json
+++ b/skins/elastic/meta.json
@@ -6,6 +6,7 @@
 	"config": {
 		"layout": "widescreen",
 		"jquery_ui_colors_theme": "bootstrap",
-		"embed_css_location": "/styles/embed.css"
+		"embed_css_location": "/styles/embed.css",
+		"favicon": "/images/favicon.ico"
 	}
 }

--- a/skins/elastic/templates/includes/layout.html
+++ b/skins/elastic/templates/includes/layout.html
@@ -14,7 +14,7 @@
 <head>
 	<title><roundcube:object name="pagetitle" /></title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no, maximum-scale=1.0" id="viewport">
-	<link rel="shortcut icon" href="/images/favicon.ico">
+	<roundcube:object name="favicon" />
 	<link rel="stylesheet" href="/deps/bootstrap.min.css">
 	<roundcube:if condition="config:devel_mode" />
 		<link rel="stylesheet/less" href="/styles/styles.less">

--- a/skins/larry/includes/links.html
+++ b/skins/larry/includes/links.html
@@ -1,5 +1,5 @@
 <meta name="viewport" content="" id="viewport" />
-<link rel="shortcut icon" href="/images/favicon.ico"/>
+<roundcube:object name="favicon" />
 <link rel="stylesheet" type="text/css" href="/styles.css" />
 <roundcube:if condition="in_array(env:task, array('mail','addressbook','settings'))" />
 <link rel="stylesheet" type="text/css" href="/<roundcube:var name="env:task" />.css" />

--- a/skins/larry/meta.json
+++ b/skins/larry/meta.json
@@ -2,5 +2,8 @@
 	"name": "Larry",
 	"author": "FLINT / Büro für Gestaltung, Switzerland",
 	"license": "Creative Commons Attribution-ShareAlike",
-	"license-url": "http://creativecommons.org/licenses/by-sa/3.0/"
+	"license-url": "http://creativecommons.org/licenses/by-sa/3.0/",
+	"config": {
+		"favicon": "/images/favicon.ico"
+	}
 }

--- a/skins/larry/templates/contactprint.html
+++ b/skins/larry/templates/contactprint.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <title><roundcube:object name="pagetitle" /></title>
-<link rel="shortcut icon" href="/images/favicon.ico"/>
+<roundcube:object name="favicon" />
 <link rel="stylesheet" type="text/css" href="/print.css" />
 </head>
 <body>

--- a/skins/larry/templates/messageprint.html
+++ b/skins/larry/templates/messageprint.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <title><roundcube:object name="pagetitle" /></title>
-<link rel="shortcut icon" href="/images/favicon.ico"/>
+<roundcube:object name="favicon" />
 <link rel="stylesheet" type="text/css" href="/print.css" />
 </head>
 <body>


### PR DESCRIPTION
for #5025.

By turning the favicon into a template object will become easier for plugins to workwith. For example to add App Icons to roundcube. Also by using the config in meta.json it means the favicon path is only stored in one place for the older skins making changes easier.