### PR TITLE
Parse all quotas from GETQUOTAROOT

### DIFF
--- a/program/lib/Roundcube/rcube_imap_generic.php
+++ b/program/lib/Roundcube/rcube_imap_generic.php
@@ -3130,8 +3130,9 @@ class rcube_imap_generic
                 if (preg_match('/^\* QUOTA /', $line)) {
                     list(, , $quota_root) = $this->tokenizeResponse($line, 3);
 
-                    while ($line) {
-                        list($type, $used, $total) = $this->tokenizeResponse($line, 1);
+                    $quotas = $this->tokenizeResponse($line, 1);
+                    foreach (array_chunk($quotas, 3) as $quota) {
+                        list($type, $used, $total) = $quota;
                         $type = strtolower($type);
 
                         if ($type && $total) {


### PR DESCRIPTION
RoundCube was parsing only the first quota triplet for every Quota Root.
This PR fixes it and in result displays all the enabled quotas.

<img width="399" alt="screen shot 2018-05-04 at 15 29 29" src="https://user-images.githubusercontent.com/1481324/39646253-7adafc5e-4fe3-11e8-9036-6cb17ac227d1.png">
