### PR TITLE
unify content frame (watermark) template objects

### DIFF
--- a/plugins/enigma/lib/enigma_ui.php
+++ b/plugins/enigma/lib/enigma_ui.php
@@ -87,7 +87,6 @@ class enigma_ui
 
             $this->rc->output->add_handlers(array(
                     'keyslist'     => array($this, 'tpl_keys_list'),
-                    'keyframe'     => array($this, 'tpl_key_frame'),
                     'countdisplay' => array($this, 'tpl_keys_rowcount'),
                     'searchform'   => array($this->rc->output, 'search_form'),
             ));
@@ -189,18 +188,6 @@ class enigma_ui
 
         $this->add_css();
         $this->add_js();
-    }
-
-    /**
-     * Template object for key info/edit frame.
-     *
-     * @param array Object attributes
-     *
-     * @return string HTML output
-     */
-    function tpl_key_frame($attrib)
-    {
-        return $this->rc->output->frame($attrib, true);
     }
 
     /**

--- a/plugins/enigma/skins/classic/templates/keys.html
+++ b/plugins/enigma/skins/classic/templates/keys.html
@@ -60,7 +60,7 @@
 </script>
 
 <div id="enigmacontent-box">
-    <roundcube:object name="keyframe" id="keyframe" width="100%" height="100%" frameborder="0" src="/watermark.html" />
+    <roundcube:object name="contentframe" id="keyframe" width="100%" height="100%" frameborder="0" src="roundcube:watermark" />
 </div>
 
 </div>

--- a/plugins/enigma/skins/classic/templates/keys.html
+++ b/plugins/enigma/skins/classic/templates/keys.html
@@ -60,7 +60,7 @@
 </script>
 
 <div id="enigmacontent-box">
-    <roundcube:object name="contentframe" id="keyframe" width="100%" height="100%" frameborder="0" src="roundcube:watermark" />
+    <roundcube:object name="contentframe" id="keyframe" width="100%" height="100%" frameborder="0" src="env:blankpage" />
 </div>
 
 </div>

--- a/plugins/enigma/skins/elastic/templates/keys.html
+++ b/plugins/enigma/skins/elastic/templates/keys.html
@@ -69,7 +69,7 @@
 		</div>
 	</div>
 	<div class="iframe-wrapper">
-		<roundcube:object name="contentframe" id="keyframe" src="roundcube:watermark" />
+		<roundcube:object name="contentframe" id="keyframe" src="env:blankpage" />
 	</div>
 </div>
 

--- a/plugins/enigma/skins/elastic/templates/keys.html
+++ b/plugins/enigma/skins/elastic/templates/keys.html
@@ -69,7 +69,7 @@
 		</div>
 	</div>
 	<div class="iframe-wrapper">
-		<roundcube:object name="keyframe" id="keyframe" src="/watermark.html" />
+		<roundcube:object name="contentframe" id="keyframe" src="roundcube:watermark" />
 	</div>
 </div>
 

--- a/plugins/enigma/skins/larry/templates/keys.html
+++ b/plugins/enigma/skins/larry/templates/keys.html
@@ -63,7 +63,7 @@
 
         <div id="enigmacontent-box" class="uibox">
             <div class="iframebox">
-                <roundcube:object name="contentframe" id="keyframe" width="100%" height="100%" frameborder="0" src="roundcube:watermark" />
+                <roundcube:object name="contentframe" id="keyframe" width="100%" height="100%" frameborder="0" src="env:blankpage" />
             </div>
         </div>
     </div>

--- a/plugins/enigma/skins/larry/templates/keys.html
+++ b/plugins/enigma/skins/larry/templates/keys.html
@@ -63,7 +63,7 @@
 
         <div id="enigmacontent-box" class="uibox">
             <div class="iframebox">
-                <roundcube:object name="keyframe" id="keyframe" width="100%" height="100%" frameborder="0" src="/watermark.html" />
+                <roundcube:object name="contentframe" id="keyframe" width="100%" height="100%" frameborder="0" src="roundcube:watermark" />
             </div>
         </div>
     </div>

--- a/plugins/help/help.php
+++ b/plugins/help/help.php
@@ -74,11 +74,11 @@ class help extends rcube_plugin
 
         // register UI objects
         $rcmail->output->add_handlers(array(
-            'contentframe' => array($this, 'content_frame'),
             'helpcontent'  => array($this, 'help_content'),
             'tablink'      => array($this, 'tablink'),
         ));
 
+        $rcmail->output->set_env('help_links', $this->help_metadata());
         $rcmail->output->send(!empty($_GET['_content']) ? 'help.content' : 'help.help');
     }
 
@@ -112,17 +112,6 @@ class help extends rcube_plugin
         $attrib['onclick'] = sprintf("return show_help_content('%s', event)", $attrib['action']);
 
         return $rcmail->output->button($attrib);
-    }
-
-    function content_frame($attrib)
-    {
-        $rcmail  = rcmail::get_instance();
-        $content = $this->help_metadata();
-        $src     = $content[$rcmail->action] ?: $content['index'];
-
-        $rcmail->output->set_env('help_links', $content);
-
-        return $rcmail->output->frame($attrib, true);
     }
 
     function help_metadata()

--- a/plugins/help/skins/classic/templates/help.html
+++ b/plugins/help/skins/classic/templates/help.html
@@ -41,7 +41,7 @@ function help_init_settings_tabs()
 </div>
 
 <div id="mainscreen" class="box help-box">
-<roundcube:object name="contentframe" id="helpcontentframe" width="100%" height="100%" frameborder="0" src="/watermark.html" />
+<roundcube:object name="contentframe" id="helpcontentframe" width="100%" height="100%" frameborder="0" src="roundcube:watermark" />
 </div>
 
 </body>

--- a/plugins/help/skins/classic/templates/help.html
+++ b/plugins/help/skins/classic/templates/help.html
@@ -41,7 +41,7 @@ function help_init_settings_tabs()
 </div>
 
 <div id="mainscreen" class="box help-box">
-<roundcube:object name="contentframe" id="helpcontentframe" width="100%" height="100%" frameborder="0" src="roundcube:watermark" />
+<roundcube:object name="contentframe" id="helpcontentframe" width="100%" height="100%" frameborder="0" src="env:blankpage" />
 </div>
 
 </body>

--- a/plugins/help/skins/elastic/templates/help.html
+++ b/plugins/help/skins/elastic/templates/help.html
@@ -24,7 +24,7 @@
 		<span class="header-title"><roundcube:label name="help.help" /></span>
 	</div>
 	<div class="iframe-wrapper">
-		<roundcube:object name="contentframe" id="helpcontentframe" src="roundcube:watermark" title="arialabelhelpcontent" />
+		<roundcube:object name="contentframe" id="helpcontentframe" src="env:blankpage" title="arialabelhelpcontent" />
 	</div>
 </div>
 

--- a/plugins/help/skins/elastic/templates/help.html
+++ b/plugins/help/skins/elastic/templates/help.html
@@ -24,7 +24,7 @@
 		<span class="header-title"><roundcube:label name="help.help" /></span>
 	</div>
 	<div class="iframe-wrapper">
-		<roundcube:object name="contentframe" id="helpcontentframe" src="/watermark.html" title="arialabelhelpcontent" />
+		<roundcube:object name="contentframe" id="helpcontentframe" src="roundcube:watermark" title="arialabelhelpcontent" />
 	</div>
 </div>
 

--- a/plugins/help/skins/larry/templates/help.html
+++ b/plugins/help/skins/larry/templates/help.html
@@ -19,7 +19,7 @@
 
 <div id="pluginbody" class="uibox offset">
 	<div class="iframebox help_<roundcube:var name='env:action' />">
-		<roundcube:object name="contentframe" id="helpcontentframe" style="width:100%; height:100%" frameborder="0" src="roundcube:watermark" />
+		<roundcube:object name="contentframe" id="helpcontentframe" style="width:100%; height:100%" frameborder="0" src="env:blankpage" />
 	</div>
 </div>
 

--- a/plugins/help/skins/larry/templates/help.html
+++ b/plugins/help/skins/larry/templates/help.html
@@ -19,7 +19,7 @@
 
 <div id="pluginbody" class="uibox offset">
 	<div class="iframebox help_<roundcube:var name='env:action' />">
-		<roundcube:object name="contentframe" id="helpcontentframe" style="width:100%; height:100%" frameborder="0" src="/watermark.html" />
+		<roundcube:object name="contentframe" id="helpcontentframe" style="width:100%; height:100%" frameborder="0" src="roundcube:watermark" />
 	</div>
 </div>
 

--- a/plugins/managesieve/lib/Roundcube/rcube_sieve_engine.php
+++ b/plugins/managesieve/lib/Roundcube/rcube_sieve_engine.php
@@ -84,7 +84,6 @@ class rcube_sieve_engine
         $this->rc->output->add_handlers(array(
             'filterslist'      => array($this, 'filters_list'),
             'filtersetslist'   => array($this, 'filtersets_list'),
-            'filterframe'      => array($this, 'filter_frame'),
             'filterform'       => array($this, 'filter_form'),
             'filtersetform'    => array($this, 'filterset_form'),
             'filterseteditraw' => array($this, 'filterset_editraw'),
@@ -1318,11 +1317,6 @@ class rcube_sieve_engine
         }
 
         return $out;
-    }
-
-    function filter_frame($attrib)
-    {
-        return $this->rc->output->frame($attrib, true);
     }
 
     function filterset_editraw($attrib)

--- a/plugins/managesieve/skins/classic/templates/managesieve.html
+++ b/plugins/managesieve/skins/classic/templates/managesieve.html
@@ -61,7 +61,7 @@
 </script>
 
 <div id="filter-box">
-  <roundcube:object name="contentframe" id="filter-frame" width="100%" height="100%" frameborder="0" src="roundcube:watermark" />
+  <roundcube:object name="contentframe" id="filter-frame" width="100%" height="100%" frameborder="0" src="env:blankpage" />
 </div>
 
 </div>

--- a/plugins/managesieve/skins/classic/templates/managesieve.html
+++ b/plugins/managesieve/skins/classic/templates/managesieve.html
@@ -61,7 +61,7 @@
 </script>
 
 <div id="filter-box">
-  <roundcube:object name="filterframe" id="filter-frame" width="100%" height="100%" frameborder="0" src="/watermark.html" />
+  <roundcube:object name="contentframe" id="filter-frame" width="100%" height="100%" frameborder="0" src="roundcube:watermark" />
 </div>
 
 </div>

--- a/plugins/managesieve/skins/elastic/templates/managesieve.html
+++ b/plugins/managesieve/skins/elastic/templates/managesieve.html
@@ -53,7 +53,7 @@
 	</div>
 	<h2 id="aria-label-filterframe" class="voice"><roundcube:label name="managesieve.arialabelfilterform" /></h2>
 	<div class="iframe-wrapper">
-		<roundcube:object name="filterframe" id="filter-box" src="/watermark.html" title="managesieve.arialabelfilterform"
+		<roundcube:object name="contentframe" id="filter-box" src="roundcube:watermark" title="managesieve.arialabelfilterform"
 			aria-labelledby="aria-label-filterform" />
 	</div>
 </div>

--- a/plugins/managesieve/skins/elastic/templates/managesieve.html
+++ b/plugins/managesieve/skins/elastic/templates/managesieve.html
@@ -53,7 +53,7 @@
 	</div>
 	<h2 id="aria-label-filterframe" class="voice"><roundcube:label name="managesieve.arialabelfilterform" /></h2>
 	<div class="iframe-wrapper">
-		<roundcube:object name="contentframe" id="filter-box" src="roundcube:watermark" title="managesieve.arialabelfilterform"
+		<roundcube:object name="contentframe" id="filter-box" src="env:blankpage" title="managesieve.arialabelfilterform"
 			aria-labelledby="aria-label-filterform" />
 	</div>
 </div>

--- a/plugins/managesieve/skins/larry/templates/managesieve.html
+++ b/plugins/managesieve/skins/larry/templates/managesieve.html
@@ -42,7 +42,7 @@
 <div id="filter-box" class="uibox contentbox">
   <div class="iframebox" role="complementary" aria-labelledby="aria-label-filterform">
     <h2 id="aria-label-filterframe" class="voice"><roundcube:label name="managesieve.arialabelfilterform" /></h2>
-    <roundcube:object name="contentframe" id="filter-frame" style="width:100%; height:100%" frameborder="0" src="roundcube:watermark" title="managesieve.arialabelfilterform" />
+    <roundcube:object name="contentframe" id="filter-frame" style="width:100%; height:100%" frameborder="0" src="env:blankpage" title="managesieve.arialabelfilterform" />
   </div>
 </div>
 

--- a/plugins/managesieve/skins/larry/templates/managesieve.html
+++ b/plugins/managesieve/skins/larry/templates/managesieve.html
@@ -42,7 +42,7 @@
 <div id="filter-box" class="uibox contentbox">
   <div class="iframebox" role="complementary" aria-labelledby="aria-label-filterform">
     <h2 id="aria-label-filterframe" class="voice"><roundcube:label name="managesieve.arialabelfilterform" /></h2>
-    <roundcube:object name="filterframe" id="filter-frame" style="width:100%; height:100%" frameborder="0" src="/watermark.html" title="managesieve.arialabelfilterform" />
+    <roundcube:object name="contentframe" id="filter-frame" style="width:100%; height:100%" frameborder="0" src="roundcube:watermark" title="managesieve.arialabelfilterform" />
   </div>
 </div>
 

--- a/program/include/rcmail_output_html.php
+++ b/program/include/rcmail_output_html.php
@@ -58,6 +58,16 @@ class rcmail_output_html extends rcmail_output
         'messageprint' => 'printmessage',
     );
 
+    // deprecated names of template objects used before 1.4
+    protected $deprecated_template_objects = array(
+        'addressframe'        => 'contentframe',
+        'messagecontentframe' => 'contentframe',
+        'prefsframe'          => 'contentframe',
+        'folderframe'         => 'contentframe',
+        'identityframe'       => 'contentframe',
+        'responseframe'       => 'contentframe',
+    );
+
     /**
      * Constructor
      */
@@ -1168,6 +1178,11 @@ EOF;
                 $object  = strtolower($attrib['name']);
                 $content = '';
 
+                // correct deprecated object names
+                if ($this->deprecated_template_objects[$object]) {
+                    $object = $this->deprecated_template_objects[$object];
+                }
+
                 // we are calling a class/method
                 if (($handler = $this->object_handlers[$object]) && is_array($handler)) {
                     if (is_callable($handler)) {
@@ -1238,6 +1253,17 @@ EOF;
                         $title = '';
                     $title .= $this->get_pagetitle();
                     $content = html::quote($title);
+                }
+                else if ($object == 'contentframe') {
+                    if (empty($attrib['id'])) {
+                        $attrib['id'] = 'rcm' . $this->env['task'] . 'frame';
+                    }
+
+                    if ($attrib['src'] == 'roundcube:watermark') {
+                        $attrib['src'] = $this->config->get('watermark_url', '/watermark.html');
+                    }
+
+                    $content = $this->frame($attrib, true);
                 }
 
                 // exec plugin hooks for this template object

--- a/program/include/rcmail_output_html.php
+++ b/program/include/rcmail_output_html.php
@@ -1306,9 +1306,8 @@ EOF;
                     }
 
                     // parse variables
-                    if (strpos($attrib['src'], ':') !== false) {
-                        $var = explode(':', $attrib['src']);
-                        $attrib['src'] = $this->parse_variable($var[0], $var[1]);
+                    if (preg_match('/^(config|env):([a-z0-9_]+)$/i', $attrib['src'], $matches)) {
+                        $attrib['src'] = $this->parse_variable($matches[1], $matches[2]);
                     }
 
                     $content = $this->frame($attrib, true);

--- a/program/steps/addressbook/func.inc
+++ b/program/steps/addressbook/func.inc
@@ -117,7 +117,6 @@ $OUTPUT->add_handlers(array(
     'savedsearchlist'     => 'rcmail_savedsearch_list',
     'addresslist'         => 'rcmail_contacts_list',
     'addresslisttitle'    => 'rcmail_contacts_list_title',
-    'addressframe'        => 'rcmail_contact_frame',
     'recordscountdisplay' => 'rcmail_rowcount_display',
     'searchform'          => array($OUTPUT, 'search_form')
 ));
@@ -452,18 +451,6 @@ function rcmail_contacts_list_title($attrib)
     $OUTPUT->add_label('contacts','uponelevel');
 
     return html::tag($attrib['tag'], $attrib, $RCMAIL->gettext($attrib['label']), html::$common_attrib);
-}
-
-
-// similar function as /steps/settings/identities.inc::rcmail_identity_frame()
-function rcmail_contact_frame($attrib)
-{
-    global $OUTPUT;
-
-    if (!$attrib['id'])
-        $attrib['id'] = 'rcmcontactframe';
-
-    return $OUTPUT->frame($attrib, true);
 }
 
 

--- a/program/steps/mail/func.inc
+++ b/program/steps/mail/func.inc
@@ -125,7 +125,6 @@ $OUTPUT->add_handlers(array(
     'messagecountdisplay' => 'rcmail_messagecount_display',
     'listmenulink'        => 'rcmail_options_menu_link',
     'mailboxname'         => 'rcmail_mailbox_name_display',
-    'messagecontentframe' => 'rcmail_messagecontent_frame',
     'messageimportform'   => 'rcmail_message_import_form',
     'searchfilter'        => 'rcmail_search_filter',
     'searchinterval'      => 'rcmail_search_interval',
@@ -681,20 +680,6 @@ function rcmail_options_menu_link($attrib = array())
             'title'    => $title,
             'tabindex' => '0',
     ), $inner);
-}
-
-/**
- * Return an HTML iframe for loading mail content
- */
-function rcmail_messagecontent_frame($attrib)
-{
-    global $OUTPUT;
-
-    if (empty($attrib['id'])) {
-        $attrib['id'] = 'rcmailcontentwindow';
-    }
-
-    return $OUTPUT->frame($attrib, true);
 }
 
 function rcmail_messagecount_display($attrib)

--- a/program/steps/settings/folders.inc
+++ b/program/steps/settings/folders.inc
@@ -188,7 +188,6 @@ $OUTPUT->add_label('deletefolderconfirm', 'purgefolderconfirm', 'folderdeleting'
 // register UI objects
 $OUTPUT->add_handlers(array(
     'foldersubscription' => 'rcmail_folder_subscriptions',
-    'folderframe'        => 'rcmail_folder_frame',
     'folderfilter'       => 'rcmail_folder_filter',
     'quotadisplay'       => array($RCMAIL, 'quota_display'),
     'searchform'         => array($OUTPUT, 'search_form'),
@@ -416,17 +415,6 @@ function rcmail_folder_tree_element($folders, &$key, &$js_folders)
     }
 
     return html::tag('li', $attribs, $content);
-}
-
-function rcmail_folder_frame($attrib)
-{
-    global $OUTPUT;
-
-    if (!$attrib['id']) {
-        $attrib['id'] = 'rcmfolderframe';
-    }
-
-    return $OUTPUT->frame($attrib, true);
 }
 
 function rcmail_folder_filter($attrib)

--- a/program/steps/settings/func.inc
+++ b/program/steps/settings/func.inc
@@ -26,7 +26,6 @@ if (!$OUTPUT->ajax_call) {
 // register UI objects
 $OUTPUT->add_handlers(array(
     'settingstabs'   => 'rcmail_settings_tabs',
-    'prefsframe'     => 'rcmail_preferences_frame',
     'sectionslist'   => 'rcmail_sections_list',
     'identitieslist' => 'rcmail_identities_list',
 ));
@@ -48,19 +47,6 @@ $RCMAIL->register_action_map(array(
     'delete-identity' => 'identities.inc',
     'upload-display'  => 'upload.inc',
 ));
-
-
-// similar function as /steps/settings/identities.inc::rcmail_identity_frame()
-function rcmail_preferences_frame($attrib)
-{
-    global $OUTPUT;
-
-    if (!$attrib['id']) {
-        $attrib['id'] = 'rcmprefsframe';
-    }
-
-    return $OUTPUT->frame($attrib, true);
-}
 
 
 function rcmail_sections_list($attrib)

--- a/program/steps/settings/identities.inc
+++ b/program/steps/settings/identities.inc
@@ -46,21 +46,7 @@ define('IDENTITIES_LEVEL', intval($RCMAIL->config->get('identities_level', 0)));
 $OUTPUT->set_pagetitle($RCMAIL->gettext('identities'));
 $OUTPUT->include_script('list.js');
 
-$OUTPUT->add_handler('identityframe', 'rcmail_identity_frame');
 $OUTPUT->set_env('identities_level', IDENTITIES_LEVEL);
 $OUTPUT->add_label('deleteidentityconfirm');
 
 $OUTPUT->send('identities');
-
-
-// similar function as /steps/addressbook/func.inc::rcmail_contact_frame()
-function rcmail_identity_frame($attrib)
-{
-    global $OUTPUT;
-
-    if (!$attrib['id']) {
-        $attrib['id'] = 'rcmIdentityFrame';
-    }
-
-    return $OUTPUT->frame($attrib, true);
-}

--- a/program/steps/settings/responses.inc
+++ b/program/steps/settings/responses.inc
@@ -78,7 +78,6 @@ $OUTPUT->set_pagetitle($RCMAIL->gettext('responses'));
 $OUTPUT->include_script('list.js');
 
 $OUTPUT->add_handlers(array(
-    'responseframe' => 'rcmail_response_frame',
     'responseslist' => 'rcmail_responses_list',
 ));
 $OUTPUT->add_label('deleteresponseconfirm');
@@ -114,18 +113,4 @@ function rcmail_responses_list($attrib)
     $OUTPUT->set_env('readonly_responses', $readonly_responses);
 
     return $out;
-}
-
-// similar function as /steps/addressbook/func.inc::rcmail_contact_frame()
-function rcmail_response_frame($attrib)
-{
-    global $OUTPUT;
-
-    if (!$attrib['id']) {
-        $attrib['id'] = 'rcmResponseFrame';
-    }
-
-    $OUTPUT->set_env('contentframe', $attrib['id']);
-
-    return $OUTPUT->frame($attrib, true);
 }

--- a/skins/classic/templates/addressbook.html
+++ b/skins/classic/templates/addressbook.html
@@ -115,7 +115,7 @@
 </script>
 
 <div id="contacts-box">
-<roundcube:object name="addressframe" id="contact-frame" width="100%" height="100%" frameborder="0" src="/watermark.html" />
+<roundcube:object name="contentframe" id="contact-frame" width="100%" height="100%" frameborder="0" src="roundcube:watermark" />
 </div>
 
 </div>

--- a/skins/classic/templates/addressbook.html
+++ b/skins/classic/templates/addressbook.html
@@ -115,7 +115,7 @@
 </script>
 
 <div id="contacts-box">
-<roundcube:object name="contentframe" id="contact-frame" width="100%" height="100%" frameborder="0" src="roundcube:watermark" />
+<roundcube:object name="contentframe" id="contact-frame" width="100%" height="100%" frameborder="0" src="env:blankpage" />
 </div>
 
 </div>

--- a/skins/classic/templates/folders.html
+++ b/skins/classic/templates/folders.html
@@ -54,7 +54,7 @@
 </script>
 
 <div id="folder-box">
-    <roundcube:object name="folderframe" id="folder-frame" width="100%" height="100%" frameborder="0" src="/watermark.html" />
+    <roundcube:object name="contentframe" id="folder-frame" width="100%" height="100%" frameborder="0" src="roundcube:watermark" />
 </div>
 
 </div>

--- a/skins/classic/templates/folders.html
+++ b/skins/classic/templates/folders.html
@@ -54,7 +54,7 @@
 </script>
 
 <div id="folder-box">
-    <roundcube:object name="contentframe" id="folder-frame" width="100%" height="100%" frameborder="0" src="roundcube:watermark" />
+    <roundcube:object name="contentframe" id="folder-frame" width="100%" height="100%" frameborder="0" src="env:blankpage" />
 </div>
 
 </div>

--- a/skins/classic/templates/identities.html
+++ b/skins/classic/templates/identities.html
@@ -35,7 +35,7 @@
 </script>
 
 <div id="identity-box">
-  <roundcube:object name="contentframe" id="identity-frame" width="100%" height="100%" frameborder="0" src="roundcube:watermark" />
+  <roundcube:object name="contentframe" id="identity-frame" width="100%" height="100%" frameborder="0" src="env:blankpage" />
 </div>
 
 </div>

--- a/skins/classic/templates/identities.html
+++ b/skins/classic/templates/identities.html
@@ -35,7 +35,7 @@
 </script>
 
 <div id="identity-box">
-  <roundcube:object name="identityframe" id="identity-frame" width="100%" height="100%" frameborder="0" src="/watermark.html" />
+  <roundcube:object name="contentframe" id="identity-frame" width="100%" height="100%" frameborder="0" src="roundcube:watermark" />
 </div>
 
 </div>

--- a/skins/classic/templates/mail.html
+++ b/skins/classic/templates/mail.html
@@ -84,7 +84,7 @@
 </div>
 
 <div id="mailpreviewframe">
-<roundcube:object name="contentframe" id="messagecontframe" width="100%" height="100%" frameborder="0" src="roundcube:watermark" />
+<roundcube:object name="contentframe" id="messagecontframe" width="100%" height="100%" frameborder="0" src="env:blankpage" />
 </div>
 
 </div>

--- a/skins/classic/templates/mail.html
+++ b/skins/classic/templates/mail.html
@@ -84,7 +84,7 @@
 </div>
 
 <div id="mailpreviewframe">
-<roundcube:object name="messagecontentframe" id="messagecontframe" width="100%" height="100%" frameborder="0" src="/watermark.html" />
+<roundcube:object name="contentframe" id="messagecontframe" width="100%" height="100%" frameborder="0" src="roundcube:watermark" />
 </div>
 
 </div>

--- a/skins/classic/templates/responses.html
+++ b/skins/classic/templates/responses.html
@@ -35,7 +35,7 @@
 </script>
 
 <div id="response-box">
-  <roundcube:object name="contentframe" id="response-frame" width="100%" height="100%" frameborder="0" src="roundcube:watermark" />
+  <roundcube:object name="contentframe" id="response-frame" width="100%" height="100%" frameborder="0" src="env:blankpage" />
 </div>
 
 </div>

--- a/skins/classic/templates/responses.html
+++ b/skins/classic/templates/responses.html
@@ -35,7 +35,7 @@
 </script>
 
 <div id="response-box">
-  <roundcube:object name="responseframe" id="response-frame" width="100%" height="100%" frameborder="0" src="/watermark.html" />
+  <roundcube:object name="contentframe" id="response-frame" width="100%" height="100%" frameborder="0" src="roundcube:watermark" />
 </div>
 
 </div>

--- a/skins/classic/templates/settings.html
+++ b/skins/classic/templates/settings.html
@@ -30,7 +30,7 @@
 </script>
 
 <div id="prefs-box">
-<roundcube:object name="prefsframe" id="prefs-frame" width="100%" height="100%" frameborder="0" src="/watermark.html" />
+<roundcube:object name="contentframe" id="prefs-frame" width="100%" height="100%" frameborder="0" src="roundcube:watermark" />
 </div>
 
 </div>

--- a/skins/classic/templates/settings.html
+++ b/skins/classic/templates/settings.html
@@ -30,7 +30,7 @@
 </script>
 
 <div id="prefs-box">
-<roundcube:object name="contentframe" id="prefs-frame" width="100%" height="100%" frameborder="0" src="roundcube:watermark" />
+<roundcube:object name="contentframe" id="prefs-frame" width="100%" height="100%" frameborder="0" src="env:blankpage" />
 </div>
 
 </div>

--- a/skins/elastic/templates/addressbook.html
+++ b/skins/elastic/templates/addressbook.html
@@ -86,7 +86,7 @@
 	</div>
 	<h2 id="aria-label-contact-frame" class="voice"><roundcube:label name="contactproperties" /></h2>
 	<div class="iframe-wrapper">
-		<roundcube:object name="addressframe" id="contact-frame" src="/watermark.html" title="contactproperties"
+		<roundcube:object name="contentframe" id="contact-frame" src="roundcube:watermark" title="contactproperties"
 			aria-labelledby="aria-label-contact-frame" />
 	</div>
 </div>

--- a/skins/elastic/templates/addressbook.html
+++ b/skins/elastic/templates/addressbook.html
@@ -86,7 +86,7 @@
 	</div>
 	<h2 id="aria-label-contact-frame" class="voice"><roundcube:label name="contactproperties" /></h2>
 	<div class="iframe-wrapper">
-		<roundcube:object name="contentframe" id="contact-frame" src="roundcube:watermark" title="contactproperties"
+		<roundcube:object name="contentframe" id="contact-frame" src="env:blankpage" title="contactproperties"
 			aria-labelledby="aria-label-contact-frame" />
 	</div>
 </div>

--- a/skins/elastic/templates/folders.html
+++ b/skins/elastic/templates/folders.html
@@ -48,7 +48,7 @@
 		</div>
 	</div>
 	<div class="iframe-wrapper">
-		<roundcube:object name="folderframe" id="preferences-frame" src="/watermark.html" />
+		<roundcube:object name="contentframe" id="preferences-frame" src="roundcube:watermark" />
 	</div>
 </div>
 

--- a/skins/elastic/templates/folders.html
+++ b/skins/elastic/templates/folders.html
@@ -48,7 +48,7 @@
 		</div>
 	</div>
 	<div class="iframe-wrapper">
-		<roundcube:object name="contentframe" id="preferences-frame" src="roundcube:watermark" />
+		<roundcube:object name="contentframe" id="preferences-frame" src="env:blankpage" />
 	</div>
 </div>
 

--- a/skins/elastic/templates/identities.html
+++ b/skins/elastic/templates/identities.html
@@ -38,7 +38,7 @@
 		</div>
 	</div>
 	<div class="iframe-wrapper">
-		<roundcube:object name="identityframe" id="preferences-frame" src="/watermark.html" title="arialabelidentityeditfrom" />
+		<roundcube:object name="contentframe" id="preferences-frame" src="roundcube:watermark" title="arialabelidentityeditfrom" />
 	</div>
 </div>
 

--- a/skins/elastic/templates/identities.html
+++ b/skins/elastic/templates/identities.html
@@ -38,7 +38,7 @@
 		</div>
 	</div>
 	<div class="iframe-wrapper">
-		<roundcube:object name="contentframe" id="preferences-frame" src="roundcube:watermark" title="arialabelidentityeditfrom" />
+		<roundcube:object name="contentframe" id="preferences-frame" src="env:blankpage" title="arialabelidentityeditfrom" />
 	</div>
 </div>
 

--- a/skins/elastic/templates/mail.html
+++ b/skins/elastic/templates/mail.html
@@ -69,10 +69,10 @@
 	</div>
 	<h2 id="aria-label-mailpreviewframe" class="voice"><roundcube:label name="arialabelmailpreviewframe" /></h2>
 	<div class="iframe-wrapper">
-		<roundcube:object name="messagecontentframe"
+		<roundcube:object name="contentframe"
 			id="messagecontframe"
 			aria-labelledby="aria-label-mailpreviewframe"
-			src="/watermark.html"
+			src="roundcube:watermark"
 			title="arialabelmailpreviewframe"
 		/>
 	</div>

--- a/skins/elastic/templates/mail.html
+++ b/skins/elastic/templates/mail.html
@@ -72,7 +72,7 @@
 		<roundcube:object name="contentframe"
 			id="messagecontframe"
 			aria-labelledby="aria-label-mailpreviewframe"
-			src="roundcube:watermark"
+			src="env:blankpage"
 			title="arialabelmailpreviewframe"
 		/>
 	</div>

--- a/skins/elastic/templates/responses.html
+++ b/skins/elastic/templates/responses.html
@@ -36,7 +36,7 @@
 		</div>
 	</div>
 	<div class="iframe-wrapper">
-		<roundcube:object name="contentframe" id="preferences-frame" src="roundcube:watermark" title="arialabelresonseeditfrom" />
+		<roundcube:object name="contentframe" id="preferences-frame" src="env:blankpage" title="arialabelresonseeditfrom" />
 	</div>
 </div>
 

--- a/skins/elastic/templates/responses.html
+++ b/skins/elastic/templates/responses.html
@@ -36,7 +36,7 @@
 		</div>
 	</div>
 	<div class="iframe-wrapper">
-		<roundcube:object name="responseframe" id="preferences-frame" src="/watermark.html" title="arialabelresonseeditfrom" />
+		<roundcube:object name="contentframe" id="preferences-frame" src="roundcube:watermark" title="arialabelresonseeditfrom" />
 	</div>
 </div>
 

--- a/skins/elastic/templates/settings.html
+++ b/skins/elastic/templates/settings.html
@@ -22,7 +22,7 @@
 		<span class="header-title"></span>
 	</div>
 	<div class="iframe-wrapper">
-		<roundcube:object name="contentframe" id="preferences-frame" src="roundcube:watermark" title="arialabelpreferencesform" />
+		<roundcube:object name="contentframe" id="preferences-frame" src="env:blankpage" title="arialabelpreferencesform" />
 	</div>
 </div>
 

--- a/skins/elastic/templates/settings.html
+++ b/skins/elastic/templates/settings.html
@@ -22,7 +22,7 @@
 		<span class="header-title"></span>
 	</div>
 	<div class="iframe-wrapper">
-		<roundcube:object name="prefsframe" id="preferences-frame" src="/watermark.html" title="arialabelpreferencesform" />
+		<roundcube:object name="contentframe" id="preferences-frame" src="roundcube:watermark" title="arialabelpreferencesform" />
 	</div>
 </div>
 

--- a/skins/larry/templates/addressbook.html
+++ b/skins/larry/templates/addressbook.html
@@ -122,7 +122,7 @@
 
 <div id="contacts-box" class="uibox">
 	<div class="iframebox">
-		<roundcube:object name="addressframe" id="contact-frame" style="width:100%; height:100%" frameborder="0" src="/watermark.html" title="contactproperties" />
+		<roundcube:object name="contentframe" id="contact-frame" style="width:100%; height:100%" frameborder="0" src="roundcube:watermark" title="contactproperties" />
 	</div>
 </div>
 

--- a/skins/larry/templates/addressbook.html
+++ b/skins/larry/templates/addressbook.html
@@ -122,7 +122,7 @@
 
 <div id="contacts-box" class="uibox">
 	<div class="iframebox">
-		<roundcube:object name="contentframe" id="contact-frame" style="width:100%; height:100%" frameborder="0" src="roundcube:watermark" title="contactproperties" />
+		<roundcube:object name="contentframe" id="contact-frame" style="width:100%; height:100%" frameborder="0" src="env:blankpage" title="contactproperties" />
 	</div>
 </div>
 

--- a/skins/larry/templates/folders.html
+++ b/skins/larry/templates/folders.html
@@ -55,7 +55,7 @@
 
 <div id="folder-details" class="uibox contentbox">
 	<div class="iframebox">
-		<roundcube:object name="contentframe" id="preferences-frame" style="width:100%; height:100%" frameborder="0" src="roundcube:watermark" />
+		<roundcube:object name="contentframe" id="preferences-frame" style="width:100%; height:100%" frameborder="0" src="env:blankpage" />
 	</div>
 </div>
 

--- a/skins/larry/templates/folders.html
+++ b/skins/larry/templates/folders.html
@@ -55,7 +55,7 @@
 
 <div id="folder-details" class="uibox contentbox">
 	<div class="iframebox">
-		<roundcube:object name="folderframe" id="preferences-frame" style="width:100%; height:100%" frameborder="0" src="/watermark.html" />
+		<roundcube:object name="contentframe" id="preferences-frame" style="width:100%; height:100%" frameborder="0" src="roundcube:watermark" />
 	</div>
 </div>
 

--- a/skins/larry/templates/identities.html
+++ b/skins/larry/templates/identities.html
@@ -27,7 +27,7 @@
 
 <div id="identity-details" class="uibox contentbox">
 	<div class="iframebox">
-		<roundcube:object name="contentframe" id="preferences-frame" style="width:100%; height:100%" frameborder="0" src="roundcube:watermark" title="arialabelidentityeditfrom" />
+		<roundcube:object name="contentframe" id="preferences-frame" style="width:100%; height:100%" frameborder="0" src="env:blankpage" title="arialabelidentityeditfrom" />
 	</div>
 </div>
 

--- a/skins/larry/templates/identities.html
+++ b/skins/larry/templates/identities.html
@@ -27,7 +27,7 @@
 
 <div id="identity-details" class="uibox contentbox">
 	<div class="iframebox">
-		<roundcube:object name="identityframe" id="preferences-frame" style="width:100%; height:100%" frameborder="0" src="/watermark.html" title="arialabelidentityeditfrom" />
+		<roundcube:object name="contentframe" id="preferences-frame" style="width:100%; height:100%" frameborder="0" src="roundcube:watermark" title="arialabelidentityeditfrom" />
 	</div>
 </div>
 

--- a/skins/larry/templates/mail.html
+++ b/skins/larry/templates/mail.html
@@ -147,7 +147,7 @@
 
 <div id="mailpreviewframe" class="iframebox" role="complementary" aria-labelledby="aria-label-mailpreviewframe">
 <h2 id="aria-label-mailpreviewframe" class="voice"><roundcube:label name="arialabelmailpreviewframe" /></h2>
-<roundcube:object name="contentframe" id="messagecontframe" style="width:100%; height:100%" frameborder="0" src="roundcube:watermark" title="arialabelmailpreviewframe" />
+<roundcube:object name="contentframe" id="messagecontframe" style="width:100%; height:100%" frameborder="0" src="env:blankpage" title="arialabelmailpreviewframe" />
 </div>
 
 </div><!-- end mailview-bottom -->

--- a/skins/larry/templates/mail.html
+++ b/skins/larry/templates/mail.html
@@ -147,7 +147,7 @@
 
 <div id="mailpreviewframe" class="iframebox" role="complementary" aria-labelledby="aria-label-mailpreviewframe">
 <h2 id="aria-label-mailpreviewframe" class="voice"><roundcube:label name="arialabelmailpreviewframe" /></h2>
-<roundcube:object name="messagecontentframe" id="messagecontframe" style="width:100%; height:100%" frameborder="0" src="/watermark.html" title="arialabelmailpreviewframe" />
+<roundcube:object name="contentframe" id="messagecontframe" style="width:100%; height:100%" frameborder="0" src="roundcube:watermark" title="arialabelmailpreviewframe" />
 </div>
 
 </div><!-- end mailview-bottom -->

--- a/skins/larry/templates/responses.html
+++ b/skins/larry/templates/responses.html
@@ -28,7 +28,7 @@
 
 <div id="response-details" class="uibox contentbox">
 	<div class="iframebox">
-		<roundcube:object name="responseframe" id="preferences-frame" style="width:100%; height:100%" frameborder="0" src="/watermark.html" title="arialabelresonseeditfrom" />
+		<roundcube:object name="contentframe" id="preferences-frame" style="width:100%; height:100%" frameborder="0" src="roundcube:watermark" title="arialabelresonseeditfrom" />
 	</div>
 </div>
 

--- a/skins/larry/templates/responses.html
+++ b/skins/larry/templates/responses.html
@@ -28,7 +28,7 @@
 
 <div id="response-details" class="uibox contentbox">
 	<div class="iframebox">
-		<roundcube:object name="contentframe" id="preferences-frame" style="width:100%; height:100%" frameborder="0" src="roundcube:watermark" title="arialabelresonseeditfrom" />
+		<roundcube:object name="contentframe" id="preferences-frame" style="width:100%; height:100%" frameborder="0" src="env:blankpage" title="arialabelresonseeditfrom" />
 	</div>
 </div>
 

--- a/skins/larry/templates/settings.html
+++ b/skins/larry/templates/settings.html
@@ -25,7 +25,7 @@
 
 <div id="preferences-box" class="uibox contentbox" role="main">
 	<div class="iframebox">
-		<roundcube:object name="contentframe" id="preferences-frame" style="width:100%; height:100%" frameborder="0" src="roundcube:watermark" title="arialabelpreferencesform" />
+		<roundcube:object name="contentframe" id="preferences-frame" style="width:100%; height:100%" frameborder="0" src="env:blankpage" title="arialabelpreferencesform" />
 	</div>
 </div>
 

--- a/skins/larry/templates/settings.html
+++ b/skins/larry/templates/settings.html
@@ -25,7 +25,7 @@
 
 <div id="preferences-box" class="uibox contentbox" role="main">
 	<div class="iframebox">
-		<roundcube:object name="prefsframe" id="preferences-frame" style="width:100%; height:100%" frameborder="0" src="/watermark.html" title="arialabelpreferencesform" />
+		<roundcube:object name="contentframe" id="preferences-frame" style="width:100%; height:100%" frameborder="0" src="roundcube:watermark" title="arialabelpreferencesform" />
 	</div>
 </div>
 


### PR DESCRIPTION
There are currently 6 different template objects used in the core + those in plugins to create the content frame with the watermark screen in. The idea behind this PR is to replace these similar objects with a single object all templates can use.