### PR TITLE
Show percentage of the highest used quota in the summary

### DIFF
--- a/program/lib/Roundcube/rcube_imap_generic.php
+++ b/program/lib/Roundcube/rcube_imap_generic.php
@@ -3139,23 +3139,19 @@ class rcube_imap_generic
                             $all[$quota_root][$type]['used']  = intval($used);
                             $all[$quota_root][$type]['total'] = intval($total);
                         }
-                    }
 
-                    if (empty($all[$quota_root]['storage'])) {
-                        continue;
-                    }
-
-                    $used  = $all[$quota_root]['storage']['used'];
-                    $total = $all[$quota_root]['storage']['total'];
-                    $free  = $total - $used;
-
-                    // calculate lowest available space from all storage quotas
-                    if ($free < $min_free) {
-                        $min_free          = $free;
-                        $result['used']    = $used;
-                        $result['total']   = $total;
-                        $result['percent'] = min(100, round(($used/max(1,$total))*100));
-                        $result['free']    = 100 - $result['percent'];
+                        $used  = $all[$quota_root][$type]['used'];
+                        $total = $all[$quota_root][$type]['total'];
+                        $percent = min(100, round(($used/max(1,$total))*100));
+                        $free  = $total - $used;
+    
+                        if ((!$result || $percent >= $result['percent']) && $free < $min_free) {
+                            $min_free          = $free;
+                            $result['used']    = $used;
+                            $result['total']   = $total;
+                            $result['percent'] = $percent;
+                            $result['free']    = 100 - $result['percent'];
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Users get surprised when summary shows 0%, but clicking details reveal that there is another quota that is already 100% used.

#### before 
<img width="399" alt="screen shot 2018-05-04 at 15 29 29" src="https://user-images.githubusercontent.com/1481324/39912269-dba900ee-5506-11e8-8c7e-9d2578394c81.png">

#### after
<img width="343" alt="screen shot 2018-05-11 at 10 27 11" src="https://user-images.githubusercontent.com/1481324/39912270-dbc5d5a2-5506-11e8-9dc0-7d5280474aa7.png">
