### PR TITLE
Managesieve allowed hosts

### DIFF
--- a/plugins/managesieve/config.inc.php.dist
+++ b/plugins/managesieve/config.inc.php.dist
@@ -121,3 +121,10 @@ $config['managesieve_raw_editor'] = true;
 // list_sets, enable_disable_set, delete_set, new_set, download_set, new_rule, delete_rule
 // Note: disabling list_sets removes the Filter sets widget from the UI and means the set defined in managesieve_script_name will always be used (and activated)
 $config['managesieve_disabled_actions'] = array();
+
+// Allowed hosts
+// Only activate managesieve for selected hosts
+// If this is not set, existing behaviour is maintained.
+// If set, managesieve will work only for hosts contained in the managesieve_allowed_hosts array
+// $config['managesieve_allowed_hosts'] = array('host1.mydomain.com','host2.mydomain.com');
+

--- a/plugins/managesieve/managesieve.php
+++ b/plugins/managesieve/managesieve.php
@@ -101,7 +101,13 @@ class managesieve extends rcube_plugin
     function settings_actions($args)
     {
         $this->load_config();
-
+        
+        if( $this->rc->config->get('managesieve_allowed_hosts') !== null  &&
+           ! in_array( $this->rc->user->data['mail_host'],
+                      $this->rc->config->get('managesieve_allowed_hosts') ) ){
+                return;
+        }
+        
         $vacation_mode = (int) $this->rc->config->get('managesieve_vacation');
         $forward_mode = (int) $this->rc->config->get('managesieve_forward');
 


### PR DESCRIPTION
Allow activation of the plugin only for selected hosts. This is useful for cases where some IMAP hosts support the ManageSieve protocol, but some others don't. Using roundcube with the managesieve plugin is problematic in those cases, as it presents to the user a sieve filter interface even for those hosts that do not support the protocol.