### PR TITLE
Privacy: Remove roundcube version string in header

### DIFF
--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -688,7 +688,7 @@ $config['max_group_members'] = 0;
 $config['product_name'] = 'Roundcube Webmail';
 
 // Add this user-agent to message headers when sending
-$config['useragent'] = 'Roundcube Webmail/'.RCUBE_VERSION;
+$config['useragent'] = 'Roundcube Webmail';
 
 // try to load host-specific configuration
 // see https://github.com/roundcube/roundcubemail/wiki/Configuration:-Multi-Domain-Setup


### PR DESCRIPTION
Avoid unnecessary information leakage.

Less metadata for NSA & Friends.