### PR TITLE
Mark as JUNK marks the email as SEEN

### DIFF
--- a/plugins/markasjunk/markasjunk.php
+++ b/plugins/markasjunk/markasjunk.php
@@ -54,7 +54,7 @@ class markasjunk extends rcube_plugin
     function request_action()
     {
         $this->add_texts('localization');
-
+        
         $read_on_junk = (bool) $rcmail->config->get('read_on_junk');
 
         $rcmail  = rcmail::get_instance();
@@ -64,6 +64,7 @@ class markasjunk extends rcube_plugin
             $storage->unset_flag($uids, 'NONJUNK', $mbox);
             $storage->set_flag($uids, 'JUNK', $mbox);
             
+            // flag email as seen if configured
             if ($read_on_junk) {
                 $storage->set_flag($uids, 'SEEN', $mbox);
             }

--- a/plugins/markasjunk/markasjunk.php
+++ b/plugins/markasjunk/markasjunk.php
@@ -55,12 +55,18 @@ class markasjunk extends rcube_plugin
     {
         $this->add_texts('localization');
 
+        $read_on_junk   = (bool) $rcmail->config->get('read_on_junk');
+
         $rcmail  = rcmail::get_instance();
         $storage = $rcmail->get_storage();
 
         foreach (rcmail::get_uids(null, null, $multifolder, rcube_utils::INPUT_POST) as $mbox => $uids) {
             $storage->unset_flag($uids, 'NONJUNK', $mbox);
             $storage->set_flag($uids, 'JUNK', $mbox);
+            
+            if ($read_on_junk) {
+                $storage->set_flag($uids, 'SEEN', $mbox);
+            }
         }
 
         if (($junk_mbox = $rcmail->config->get('junk_mbox'))) {

--- a/plugins/markasjunk/markasjunk.php
+++ b/plugins/markasjunk/markasjunk.php
@@ -55,7 +55,7 @@ class markasjunk extends rcube_plugin
     {
         $this->add_texts('localization');
 
-        $read_on_junk   = (bool) $rcmail->config->get('read_on_junk');
+        $read_on_junk = (bool) $rcmail->config->get('read_on_junk');
 
         $rcmail  = rcmail::get_instance();
         $storage = $rcmail->get_storage();


### PR DESCRIPTION
With this little change, the MarkAsJunk plugin can be configured to mark the email as read / seen as well.