### PR TITLE
for reply to all, also skip VERP style Sender: address

### DIFF
--- a/program/include/rcmail_sendmail.php
+++ b/program/include/rcmail_sendmail.php
@@ -1032,7 +1032,7 @@ class rcmail_sendmail
                 if ($v = $message->headers->get('Sender', false)) {
                     // Skip common mailing lists addresses: *-bounces@ and *-request@ (#1490452)
                     if (empty($message->headers->others['list-post'])
-                        || !preg_match('/-(bounces|request)@/', $v)
+                        || !preg_match('/(-(bounces|request)|\+[^@=]+=[A-Za-z0-9.\-]+)@/', $v)
                     ) {
                         $fvalue .= (!empty($fvalue) ? $separator : '') . $v;
                     }


### PR DESCRIPTION
Some mail lists uses VERP style E-mail address for Sender: header, like
`Sender: "List name" <listaname-bounce+foo=example.com@bar.example.org>`
to analyze bounce mail.

I'm grad if roundcubemail ommit those VERP style E-mail address for Cc:, when we uses "reply to all".

So I've added regex pattern to match them.
(Acutually, I didn't  examine this pattern in master branch, but I examined in release-1.3 branch, program/steps/mail/compose.inc)