### PR TITLE
Fix support for "x_frame_options" config option

### DIFF
--- a/program/include/rcmail_output_html.php
+++ b/program/include/rcmail_output_html.php
@@ -588,7 +588,7 @@ EOF;
         // allow (legal) iframe content to be loaded
         $iframe = $this->framed || $this->env['framed'];
         if (!headers_sent() && $iframe && ($xopt = $this->app->config->get('x_frame_options', 'sameorigin'))) {
-            if (strtolower($xopt) != 'sameorigin') {
+            if (strtolower($xopt) === 'deny') {
                 header('X-Frame-Options: sameorigin', true);
             }
         }


### PR DESCRIPTION
The only way to embed Roundcube Webmail into iframe is to add x_frame_options into configuration:

`$config['x_frame_options'] = 'allow-from https://example.com/';`

But at the moment the code enforces the value of `sameorigin` when viewing emails regardless of configuration, while should behave that way only in case of restrictive setting.