### PR TITLE
Fix multiple VCard field search: Empty result set

### DIFF
--- a/program/lib/Roundcube/rcube_contacts.php
+++ b/program/lib/Roundcube/rcube_contacts.php
@@ -380,7 +380,7 @@ class rcube_contacts extends rcube_addressbook
                             foreach ((array)$row[$col] as $value) {
                                 if ($this->compare_search_value($colname, $value, $search, $mode)) {
                                     $found[$colname] = true;
-                                    break 2;
+                                    break;
                                 }
                             }
                         }


### PR DESCRIPTION
Came across this in a roundcube instance that uses custom VCard fields. These are exposed as fulltext_cols and are visible on the advanced search interface.

However, when running an advanced search with conditions set against two or more of the custom VCard fields, an empty result set is produced.