### PR TITLE
Create hook on move_messages

### DIFF
--- a/program/lib/Roundcube/rcube_imap.php
+++ b/program/lib/Roundcube/rcube_imap.php
@@ -2651,6 +2651,11 @@ class rcube_imap extends rcube_storage
         }
 
         // move messages
+        $this->plugins->exec_hook('move_message', array(
+            'uids'  => $uids,
+            'from_mbox' => $from_mbox,
+            'to_mbox' => $to_mbox
+        ));
         $moved = $this->conn->move($uids, $from_mbox, $to_mbox);
 
         // when moving to Trash we make sure the folder exists


### PR DESCRIPTION
- Motivation
  When we move messages there is no hook to use to make some changes

- Issue: [6475](https://github.com/roundcube/roundcubemail/issues/6475)