### PR TITLE
limit skins available/shown in the settings section

### DIFF
--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -1056,6 +1056,9 @@ $config['default_charset'] = 'ISO-8859-1';
 // skin name: folder from skins/
 $config['skin'] = 'larry';
 
+// limit skins available/shown in the settings section
+$config['skins_allowed'] = [];
+
 // Enables using standard browser windows (that can be handled as tabs)
 // instead of popup windows
 $config['standard_windows'] = false;

--- a/program/steps/settings/func.inc
+++ b/program/steps/settings/func.inc
@@ -1301,9 +1301,12 @@ function rcmail_user_prefs($current = null)
 
 function rcmail_get_skins()
 {
+    global $RCMAIL;
+
     $path  = RCUBE_INSTALL_PATH . 'skins';
     $skins = array();
     $dir   = opendir($path);
+    $limit = $RCMAIL->config->get('skins_allowed');
 
     if (!$dir) {
         return false;
@@ -1311,7 +1314,8 @@ function rcmail_get_skins()
 
     while (($file = readdir($dir)) !== false) {
         $filename = $path.'/'.$file;
-        if (!preg_match('/^\./', $file) && is_dir($filename) && is_readable($filename)) {
+        if (!preg_match('/^\./', $file) && is_dir($filename) && is_readable($filename)
+            && (!is_array($limit) || !count($limit) || in_array($file, $limit))) {
             $skins[] = $file;
         }
     }


### PR DESCRIPTION
This change allows the admin to limit/reduce the amount of available skins presented to the user in the settings section.

Currently the part is missing that enforces the skin selection when the "current" skin is not on the list of available skins and fall back to the default one.