### PR TITLE
(Elastic) small compat fix

### DIFF
--- a/skins/elastic/ui.js
+++ b/skins/elastic/ui.js
@@ -1410,7 +1410,7 @@ function rcube_elastic_ui()
 
             case 'mark':
                 // show the toolbar button for Mailvelope
-                $('a.button.markmessage')[args.status ? 'removeClass' : 'addClass']('disabled');
+                $('#toolbar-menu').find('a.button.markmessage')[args.status ? 'removeClass' : 'addClass']('disabled');
                 break;
             }
         }


### PR DESCRIPTION
some JS in elastic is a little broad when it comes to setting classes on buttons. this small fix just makes sure that the core JS only interacts with the toolbar button in the core and not others (eg from plugins)