### PR TITLE
store menu buttos by menu id

### DIFF
--- a/program/js/app.js
+++ b/program/js/app.js
@@ -47,7 +47,7 @@ function rcube_webmail()
   this.group2expand = {};
   this.http_request_jobs = {};
   this.menu_stack = [];
-  this.menu_buttons = [];
+  this.menu_buttons = {};
   this.entity_selectors = [];
   this.image_style = {};
 
@@ -139,7 +139,7 @@ function rcube_webmail()
     });
 
     if (commands.length)
-      this.menu_buttons.push([button, commands]);
+      this.menu_buttons[menu_id] = [button, commands];
 
     this.set_menu_buttons();
   };

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -125,21 +125,24 @@ function rcube_webmail()
   // register a button with popup menu, to set its state according to the state of all commands in the menu
   this.register_menu_button = function(button, menu_id)
   {
-    var commands = [];
+    if (!this.menu_buttons[menu_id]) {
+      this.menu_buttons[menu_id] = [[], []];
+      var commands = [];
 
-    $('#' + menu_id).find('a').each(function() {
-      var command, link = $(this), onclick = link.attr('onclick');
+      $('#' + menu_id).find('a').each(function() {
+        var command, link = $(this), onclick = link.attr('onclick');
 
-      if (onclick && String(onclick).match(/rcmail\.command\(\'([^']+)/))
-        command = RegExp.$1;
-      else
-        command = function() { return link.is('.active'); };
+        if (onclick && String(onclick).match(/rcmail\.command\(\'([^']+)/))
+          command = RegExp.$1;
+        else
+          command = function() { return link.is('.active'); };
 
-      commands.push(command);
-    });
+        ref.menu_buttons[menu_id][1].push(command);
+      });
+    }
 
-    if (commands.length)
-      this.menu_buttons[menu_id] = [button, commands];
+    if (ref.menu_buttons[menu_id][1].length)
+      this.menu_buttons[menu_id][0].push(button);
 
     this.set_menu_buttons();
   };

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -125,8 +125,11 @@ function rcube_webmail()
   // register a button with popup menu, to set its state according to the state of all commands in the menu
   this.register_menu_button = function(button, menu_id)
   {
-    if (!this.menu_buttons[menu_id]) {
-      this.menu_buttons[menu_id] = [[], []];
+    if (this.menu_buttons[menu_id]) {
+      this.menu_buttons[menu_id][0].push(button);
+    }
+    else {
+      var commands = [];
       $('#' + menu_id).find('a').each(function() {
         var command, link = $(this), onclick = link.attr('onclick');
 
@@ -135,12 +138,12 @@ function rcube_webmail()
         else
           command = function() { return link.is('.active'); };
 
-        ref.menu_buttons[menu_id][1].push(command);
+        commands.push(command);
       });
-    }
 
-    if (ref.menu_buttons[menu_id][1].length)
-      this.menu_buttons[menu_id][0].push(button);
+      if (commands.length)
+        this.menu_buttons[menu_id] = [[button], commands];
+    }
 
     this.set_menu_buttons();
   };

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -127,8 +127,6 @@ function rcube_webmail()
   {
     if (!this.menu_buttons[menu_id]) {
       this.menu_buttons[menu_id] = [[], []];
-      var commands = [];
-
       $('#' + menu_id).find('a').each(function() {
         var command, link = $(this), onclick = link.attr('onclick');
 


### PR DESCRIPTION
after ab6b651 I am looking at extending the contextmenu plugin to work in the same way. checking through the entire menu_buttons array each time seems wasteful. this small change stores the information by menu id for quick access to check if a specific menu has any active commands.