### PR TITLE
add php 7.3/nightly to travis and allow failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,11 @@ matrix:
     - php: 7.1
       env: CODE_COVERAGE=1
     - php: 7.2
+    - php: 7.3
+    - php: nightly
+  allow_failures:
+    - php: 7.3
+    - php: nightly
 
 cache:
   directories:


### PR DESCRIPTION
php 7.3 is not released yet, so allow failure

But we can see if something fails with new php environment.