### PR TITLE
add option to build login form using divs

### DIFF
--- a/program/include/rcmail_output_html.php
+++ b/program/include/rcmail_output_html.php
@@ -2078,26 +2078,47 @@ EOF;
 
         $this->add_gui_object('loginform', $form_name);
 
-        // create HTML table with two cols
-        $table = new html_table(array('cols' => 2));
-
-        $table->add('title', html::label('rcmloginuser', html::quote($this->app->gettext('username'))));
-        $table->add('input', $input_user->show(rcube_utils::get_input_value('_user', rcube_utils::INPUT_GPC)));
-
-        $table->add('title', html::label('rcmloginpwd', html::quote($this->app->gettext('password'))));
-        $table->add('input', $input_pass->show());
+        $fields = array(
+            'user' => array(
+                'title'   => html::label('rcmloginuser', html::quote($this->app->gettext('username'))),
+                'content' => $input_user->show(rcube_utils::get_input_value('_user', rcube_utils::INPUT_GPC))
+            ),
+            'password' => array(
+                'title'   => html::label('rcmloginpwd', html::quote($this->app->gettext('password'))),
+                'content' => $input_pass->show()
+            )
+        );
 
         // add host selection row
         if (is_object($input_host) && !$hide_host) {
-            $table->add('title', html::label('rcmloginhost', html::quote($this->app->gettext('server'))));
-            $table->add('input', $input_host->show(rcube_utils::get_input_value('_host', rcube_utils::INPUT_GPC)));
+            $fields['host'] = array(
+                'title'   => html::label('rcmloginhost', html::quote($this->app->gettext('server'))),
+                'content' => $input_host->show(rcube_utils::get_input_value('_host', rcube_utils::INPUT_GPC))
+            );
         }
 
         $out  = $input_task->show();
         $out .= $input_action->show();
         $out .= $input_tzone->show();
         $out .= $input_url->show();
-        $out .= $table->show();
+
+        if (!empty($attrib['form-layout']) && $attrib['form-layout'] == 'div') {
+            foreach ($fields as $field) {
+                $out .= html::div(null, $field['title'] . $field['content']);
+            }
+        }
+        else {
+            // create HTML table with two cols
+            // for backwards compatibility with skins pre version 1.4
+            $table = new html_table(array('cols' => 2));
+
+            foreach ($fields as $field) {
+                $table->add('title', $field['title']);
+                $table->add('input', $field['content']);
+            }
+
+            $out .= $table->show();
+        }
 
         if ($hide_host) {
             $out .= $input_host->show();

--- a/skins/elastic/templates/login.html
+++ b/skins/elastic/templates/login.html
@@ -5,7 +5,7 @@
 <div class="content selected no-navbar" role="main">
 	<roundcube:object name="logo" src="/images/logo.svg" data-src-small="0" id="logo" alt="Logo" />
 	<roundcube:form id="login-form" name="login-form" method="post" class="propform">
-	<roundcube:object name="loginform" form="login-form" size="40" submit=true />
+	<roundcube:object name="loginform" form="login-form" form-layout="div" size="40" submit=true />
 		<div id="login-footer" role="contentinfo">
 			<roundcube:object name="productname" condition="config:display_product_info &gt; 0" />
 			<roundcube:object name="version" condition="config:display_product_info == 2" />

--- a/skins/elastic/ui.js
+++ b/skins/elastic/ui.js
@@ -995,22 +995,24 @@ function rcube_elastic_ui()
         // Make logon form prettier
         if (rcmail.env.task == 'login' && context == document) {
             $('#rcmloginsubmit').addClass('btn-lg text-uppercase w-100');
-            $('#login-form table tr').each(function() {
-                var input = $('input,select', this),
-                    label = $('label', this),
-                    icon_name = input.data('icon'),
-                    icon = $('<i>').attr('class', 'input-group-text icon ' + input.attr('name').replace('_', ''));
+            $('#login-form > div').each(function() {
+                if ($('input,select', this).length == 1) {
+                    var input = $('input,select', this),
+                        label = $('label', this),
+                        icon_name = input.data('icon'),
+                        icon = $('<i>').attr('class', 'input-group-text icon ' + input.attr('name').replace('_', ''));
 
-                if (icon_name) {
-                    icon.addClass(icon_name);
+                    if (icon_name) {
+                        icon.addClass(icon_name);
+                    }
+
+                    $(this).addClass('form-group');
+                    label.css('display', 'none');
+                    input.addClass(input.is('select') ? 'custom-select' : 'form-control')
+                        .attr('placeholder', label.text())
+                        .before($('<span class="input-group-prepend">').append(icon))
+                        .parent().addClass('input-group input-group-lg');
                 }
-
-                $(this).addClass('form-group row');
-                label.parent().css('display', 'none');
-                input.addClass(input.is('select') ? 'custom-select' : 'form-control')
-                    .attr('placeholder', label.text())
-                    .before($('<span class="input-group-prepend">').append(icon))
-                    .parent().addClass('input-group input-group-lg');
             });
         }
 


### PR DESCRIPTION
For #6565

According to https://github.com/twbs/bootstrap/pull/21569 there are some general issues with IE11, flex-box and tables. but it seems like only the login form is really affected in Elastic.

Rather than trying to hack around the shortcomings of IE11 I thought it might be easier and also most useful for the future to layout the login form using divs rather than a table. For current sinks though a table is still required so this PR allows for both. Keeping table as the default form of layout it adds a param to switch it to divs.
