### PR TITLE
Password: Better handling for Plesk errors

### DIFF
--- a/plugins/password/drivers/plesk.php
+++ b/plugins/password/drivers/plesk.php
@@ -69,9 +69,11 @@ class rcube_plesk_password
 
         if ($result == "ok") {
             return PASSWORD_SUCCESS;
+        } elseif( is_array( $result ) ) {
+            return $result;
         }
-
-        return $result;
+		
+        return PASSWORD_ERROR;
     }
 }
 

--- a/plugins/password/drivers/plesk.php
+++ b/plugins/password/drivers/plesk.php
@@ -69,10 +69,10 @@ class rcube_plesk_password
 
         if ($result == "ok") {
             return PASSWORD_SUCCESS;
-        } elseif( is_array( $result ) ) {
+        } elseif (is_array($result)) {
             return $result;
         }
-		
+
         return PASSWORD_ERROR;
     }
 }

--- a/plugins/password/drivers/plesk.php
+++ b/plugins/password/drivers/plesk.php
@@ -241,12 +241,12 @@ class plesk_rpc
             $xml = new SimpleXMLElement($res);
             $res = strval($xml->mail->update->set->result->status);
 
-			if ($res != "ok") {
-				$res = array(
-					'code' => strval($xml->mail->update->set->result->errcode),
-					'message' => strval($xml->mail->update->set->result->errtext)
-				);
-			}
+            if ($res != "ok") {
+                $res = array(
+                    'code' => strval($xml->mail->update->set->result->errcode),
+                    'message' => strval($xml->mail->update->set->result->errtext)
+                );
+            }
             return $res;
         }
 

--- a/plugins/password/drivers/plesk.php
+++ b/plugins/password/drivers/plesk.php
@@ -245,7 +245,7 @@ class plesk_rpc
 
             if ($res != "ok") {
                 $res = array(
-                    'code' => strval($xml->mail->update->set->result->errcode),
+                    'code' => PASSWORD_ERROR,
                     'message' => strval($xml->mail->update->set->result->errtext)
                 );
             }

--- a/plugins/password/drivers/plesk.php
+++ b/plugins/password/drivers/plesk.php
@@ -67,11 +67,11 @@ class rcube_plesk_password
         $result = $plesk->change_mailbox_password($username, $newpass);
         //$plesk->destroy();
 
-        if ($result) {
+        if ($result == "ok") {
             return PASSWORD_SUCCESS;
         }
 
-        return PASSWORD_ERROR;
+        return $result;
     }
 }
 
@@ -241,7 +241,13 @@ class plesk_rpc
             $xml = new SimpleXMLElement($res);
             $res = strval($xml->mail->update->set->result->status);
 
-            return $res == "ok";
+			if ($res != "ok") {
+				$res = array(
+					'code' => strval($xml->mail->update->set->result->errcode),
+					'message' => strval($xml->mail->update->set->result->errtext)
+				);
+			}
+            return $res;
         }
 
         return false;


### PR DESCRIPTION
Adding on to #6526. I was having issues with users telling me it wasn't working. Drove me crazy until I realized they weren't adhering to the password strength enforced by Plesk. This patch adjusts the return value (when possible) to include errors thrown by Plesk.