### PR TITLE
HTML5 Upload Progress (#6177)

### DIFF
--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -796,11 +796,6 @@ $config['max_pagesize'] = 200;
 // Minimal value of user's 'refresh_interval' setting (in seconds)
 $config['min_refresh_interval'] = 60;
 
-// Enables files upload indicator. Requires APC installed and enabled apc.rfc1867 option.
-// By default refresh time is set to 1 second. You can set this value to true
-// or any integer value indicating number of seconds.
-$config['upload_progress'] = false;
-
 // Specifies for how many seconds the Undo button will be available
 // after object delete action. Currently used with supporting address book sources.
 // Setting it to 0, disables the feature.

--- a/program/js/editor.js
+++ b/program/js/editor.js
@@ -729,7 +729,7 @@ function rcube_text_editor(config, id)
     });
 
     // enable drag-n-drop area
-    if ((window.XMLHttpRequest && XMLHttpRequest.prototype && XMLHttpRequest.prototype.sendAsBinary) || window.FormData) {
+    if (window.FormData) {
       if (!rcmail.env.filedrop) {
         rcmail.env.filedrop = {};
       }

--- a/program/steps/mail/attachments.inc
+++ b/program/steps/mail/attachments.inc
@@ -19,11 +19,6 @@
  +-----------------------------------------------------------------------+
 */
 
-// Upload progress update
-if (!empty($_GET['_progress'])) {
-    $RCMAIL->upload_progress();
-}
-
 $COMPOSE_ID = rcube_utils::get_input_value('_id', rcube_utils::INPUT_GPC);
 $COMPOSE    = null;
 

--- a/program/steps/settings/upload.inc
+++ b/program/steps/settings/upload.inc
@@ -19,11 +19,6 @@
  +-----------------------------------------------------------------------+
 */
 
-// Upload progress update
-if (!empty($_GET['_progress'])) {
-    $RCMAIL->upload_progress();
-}
-
 $from = rcube_utils::get_input_value('_from', rcube_utils::INPUT_GET);
 $type = preg_replace('/(add|edit)-/', '', $from);
 


### PR DESCRIPTION
Replaced all old upload progress code in favour of ajax upload progress.
Instead of posting a hidden iframe, we now use AJAX (as we did for drag-n-drop).
Removed code for old browsers. Now we support IE >= 10, Firefox > 4.
Upload progress may not work in some more, but support is quite good.