### PR TITLE
Change the query type ANY to MX/A/CNAME/AAAA for dns_check (#6581)

### DIFF
--- a/program/lib/Roundcube/rcube_utils.php
+++ b/program/lib/Roundcube/rcube_utils.php
@@ -127,13 +127,23 @@ class rcube_utils
                 return true;
             }
 
+            // find A record(s)
+            if (!function_exists('checkdnsrr') || checkdnsrr($domain_part, 'A')) {
+                return true;
+            }
+
             // find MX record(s)
             if (!function_exists('getmxrr') || getmxrr($domain_part, $mx_records)) {
                 return true;
             }
 
-            // find any DNS record
-            if (!function_exists('checkdnsrr') || checkdnsrr($domain_part, 'ANY')) {
+            // find CNAME record(s)
+            if (!function_exists('checkdnsrr(host)') || checkdnsrr($domain_part, 'CNAME')) {
+                return true;
+            }
+
+            // find AAAA record(s)
+            if (!function_exists('checkdnsrr') || checkdnsrr($domain_part, 'AAAA')) {
                 return true;
             }
         }


### PR DESCRIPTION
As query type ANY is not used by all dns servers, the domain validation
function checks for an A, MX, CNAME, and AAAA record (in that order).