### PR TITLE
[managesieve] fix: custom header & variable values are lost on submission

### DIFF
--- a/plugins/managesieve/lib/Roundcube/rcube_sieve_engine.php
+++ b/plugins/managesieve/lib/Roundcube/rcube_sieve_engine.php
@@ -916,7 +916,7 @@ class rcube_sieve_engine
                         }
                     }
                     else {
-                        $cust_header = $headers = $this->strip_value(array_shift($cust_headers));
+                        $cust_header = $headers = $this->strip_value(array_shift($cust_headers[$idx]));
                         $mod         = $this->strip_value($mods[$idx]);
                         $mod_type    = $this->strip_value($mod_types[$idx]);
                         $index       = $this->strip_value($indexes[$idx]);
@@ -926,7 +926,7 @@ class rcube_sieve_engine
                         $mime_part   = $mime_parts[$idx];
 
                         if ($header == 'string') {
-                            $cust_var = $headers = $this->strip_value(array_shift($cust_vars));
+                            $cust_var = $headers = $this->strip_value(array_shift($cust_vars[$idx]));
                         }
 
                         if (preg_match('/^not/', $operator))


### PR DESCRIPTION
When adding a custom header or variable rule in any position except the first one, the value entered as the header or variable name is lost after submitting the form, which in turn causes a validation error stating that the input is required.

Steps to reproduce:
1. Create a filter
2. Add any rule
3. Add a custom header or custom variable rule
4. Enter any header or variable name, and complete the rest
5. Submit the form

Expected result:
The filter is saved correctly

Actual result:
Validation error stating that the header or variable name is required