### PR TITLE
Elastic: remove hover effect on dropbuttons when primary action is di…

### DIFF
--- a/program/js/app.js
+++ b/program/js/app.js
@@ -162,7 +162,7 @@ function rcube_webmail()
             return disabled = false;
           }
         });
-        $(this[0]).addClass(disabled ? 'disabled' : 'active').removeClass(disabled ? 'active' : 'disabled');
+        $(this[0]).add($(this[0]).parent('.dropbutton')).addClass(disabled ? 'disabled' : 'active').removeClass(disabled ? 'active' : 'disabled');
       });
     }, 50);
   };

--- a/skins/elastic/styles/widgets/toolbar.less
+++ b/skins/elastic/styles/widgets/toolbar.less
@@ -695,7 +695,7 @@ html.ie11 .toolbar .dropbutton a.dropdown:before {
             height: @layout-header-height;
             display: inline-block;
 
-            &:hover {
+            &:not(.disabled):hover {
                 background-color: @color-toolbar-button-background-hover;
             }
 


### PR DESCRIPTION
…sabled

In Elastic when a menu item is disabled there is no hover effect. this is true for everything except menu items which have dropbutton like reply-all or forward. This adds a disabled class to the dropbutton to remove the hover effect from these buttons when the button is disabled.