### PR TITLE
create new meta and links template objects, replace favicon

### DIFF
--- a/skins/classic/includes/links.html
+++ b/skins/classic/includes/links.html
@@ -1,5 +1,5 @@
 <link rel="index" href="$__comm_path" />
-<roundcube:object name="favicon" doctype="html4" />
+<roundcube:object name="meta" />
 <link rel="stylesheet" type="text/css" href="/common.css" />
 <roundcube:if condition="in_array(env:task, array('mail', 'addressbook', 'settings'))" />
 <link rel="stylesheet" type="text/css" href="/<roundcube:var name="env:task" />.css" />
@@ -7,3 +7,4 @@
 <roundcube:if condition="browser:safari" />
 <link rel="stylesheet" type="text/css" href="/safari.css" />
 <roundcube:endif />
+<roundcube:object name="links" />

--- a/skins/elastic/meta.json
+++ b/skins/elastic/meta.json
@@ -9,5 +9,10 @@
 		"embed_css_location": "/styles/embed.css",
 		"editor_css_location": "/styles/embed.css",
 		"media_browser_css_location": "none"
+	},
+	"meta": {
+		"viewport": "width=device-width, initial-scale=1.0, shrink-to-fit=no, maximum-scale=1.0",
+		"theme-color": "#f4f4f4",
+		"msapplication-navbutton-color": "#f4f4f4"
 	}
 }

--- a/skins/elastic/templates/includes/layout.html
+++ b/skins/elastic/templates/includes/layout.html
@@ -15,8 +15,7 @@
 <roundcube:endif />
 <head>
 	<title><roundcube:object name="pagetitle" /></title>
-	<meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no, maximum-scale=1.0" id="viewport">
-	<roundcube:object name="favicon" />
+	<roundcube:object name="meta" />
 	<link rel="stylesheet" href="/deps/bootstrap.min.css">
 	<roundcube:if condition="config:devel_mode" />
 		<link rel="stylesheet/less" href="/styles/styles.less">
@@ -26,6 +25,7 @@
 		<link rel="stylesheet" href="/styles/styles.css">
 		<roundcube:link rel="stylesheet" href="/styles/print.css" condition="env:action == 'print'" />
 	<roundcube:endif />
+	<roundcube:object name="links" />
 </head>
 <body class="task-<roundcube:exp expression="env:error_task ?: env:task ?: 'error'">">
 	<roundcube:if condition="!env:framed || env:extwin" />

--- a/skins/larry/includes/links.html
+++ b/skins/larry/includes/links.html
@@ -1,9 +1,10 @@
 <meta name="viewport" content="" id="viewport" />
-<roundcube:object name="favicon" />
+<roundcube:object name="meta" />
 <link rel="stylesheet" type="text/css" href="/styles.css" />
 <roundcube:if condition="in_array(env:task, array('mail','addressbook','settings'))" />
 <link rel="stylesheet" type="text/css" href="/<roundcube:var name="env:task" />.css" />
 <roundcube:endif />
+<roundcube:object name="links" />
 <script type="text/javascript" src="/ui.js"></script>
 <roundcube:add_label name="errortitle" />
 <roundcube:add_label name="toggleadvancedoptions" />


### PR DESCRIPTION
see https://github.com/roundcube/roundcubemail/pull/6604#issuecomment-459254411

The idea is to replace the (rather specific) 'favicon' (added in 1.4-beta) template object with 2 new objects 'meta' and 'links'. I chose to use objects because when extending a skin then a custom CSS file could now be added via meta.json rather than having to create your own includes/links.html type template. eg:
```
{
  "name": "MySkin",
  "extends": "elastic",
  "meta": {
    "msapplication-TileColor": "#da532c",
    "heme-color": "#ffffff",
    "viewport": "width=device-width, initial-scale=1.0, shrink-to-fit=no, maximum-scale=1.0"
  },
  "links": {
    "apple-touch-icon": {"sizes": "180x180", "href": "/apple-touch-icon.png"},
    "icon": [
      {"type": "image/png", "sizes": "32x32", "href": "/favicon-32x32.png"},
      {"type": "image/png", "sizes": "16x16", "href": "/favicon-16x16.png"}
    ],
    "manifest": "/site.webmanifest",
    "mask-icon": {"href": "/safari-pinned-tab.svg", "color": "#5bbad5"},
    "stylesheet": [
      "/branding.css",
      "/layout.css"
    ]
  }
}
```

I did not move `<meta name="viewport" content="" id="viewport" />` from skins/larry/includes/links.html into meta.json because it is required by the skin (referenced in ui.js).

`<link rel="index" href="$__comm_path" />` in skins/classic/includes/links.html could be moved to meta.json but I've left it as is for now.

