### PR TITLE
Add icon for language selection form

### DIFF
--- a/skins/elastic/styles/widgets/forms.less
+++ b/skins/elastic/styles/widgets/forms.less
@@ -609,6 +609,9 @@ html.ms .propform {
     &.host:before {
         content: @fa-var-home;
     }
+    &.language.before {
+        content: @fa-var-globe;
+    }
     &.cancel:before {
         content: @fa-var-times;
     }


### PR DESCRIPTION
Trying to fix the appearance of the login-language selector for the new elastic theme.

This is a small addition which makes the login-language plugin present an icon, like the rest of the login form fields. I have also issued a request for the login form selector to drop the custom styles attribute: https://github.com/hassansin/roundcube-login-language/issues/11. These two (small) enhancements make the login form appear perfectly when the login-language plugin is used.

Here is the corrected result with these changes applied: https://imgur.com/a/5clC67e