### PR TITLE
hide advanced settings sections in Elastic

### DIFF
--- a/skins/elastic/styles/widgets/forms.less
+++ b/skins/elastic/styles/widgets/forms.less
@@ -377,6 +377,26 @@ input.smart-upload {
     }
 }
 
+fieldset.advanced {
+    > legend {
+        width: auto;
+        cursor: pointer;
+
+        &:after {
+            &:extend(.font-icon-class);
+            float: right;
+            margin: 0 0 0 .25rem;
+            line-height: inherit;
+            font-size: inherit;
+            content: @fa-var-angle-up;
+        }
+
+        &.closed:after {
+            content: @fa-var-angle-down;
+        }
+    }
+}
+
 @media screen and (max-width: @screen-width-bs-phone) {
     .formcontent .text-only {
         .form-group:not(tr) {

--- a/skins/elastic/ui.js
+++ b/skins/elastic/ui.js
@@ -909,6 +909,16 @@ function rcube_elastic_ui()
             });
         });
 
+        // Advanced options form
+        $('fieldset.advanced', context).each(function() {
+            var table = $(this).children('.propform').first();
+            table.wrap($('<div>').addClass('collapse'));
+            $(this).children('legend').first().addClass('closed').on('click', function() {
+                table.parent().collapse('toggle');
+                $(this).toggleClass('closed');
+            });
+        });
+
         // Other forms, e.g. Insert response
         $('.propform > .prop.block:not(.row)', context).each(function() {
             $(this).addClass('form-group row').each(function() {


### PR DESCRIPTION
similar to what is in the Larry skin the idea is to hide the Advanced Options sections on settings screens by default, only showing them if the user clicks. 