### PR TITLE
Parse abook entries more reliably

### DIFF
--- a/plugins/squirrelmail_usercopy/squirrelmail_usercopy.php
+++ b/plugins/squirrelmail_usercopy/squirrelmail_usercopy.php
@@ -159,9 +159,11 @@ class squirrelmail_usercopy extends rcube_plugin
 
         /**** File based backend ****/
         if ($rcmail->config->get('squirrelmail_driver') == 'file' && ($srcdir = $rcmail->config->get('squirrelmail_data_dir'))) {
+
             if (($hash_level = $rcmail->config->get('squirrelmail_data_dir_hash_level')) > 0) {
                 $srcdir = slashify($srcdir).chunk_split(substr(base_convert(crc32($uname), 10, 16), 0, $hash_level), 1, '/');
             }
+
             $file_charset = $rcmail->config->get('squirrelmail_file_charset');
 
             $prefsfile = slashify($srcdir) . $uname . '.pref';
@@ -194,12 +196,15 @@ class squirrelmail_usercopy extends rcube_plugin
 
                 // parse address book file
                 if (filesize($abookfile)) {
-                    foreach (file($abookfile) as $line) {
-                        $line = $this->convert_charset(rtrim($line), $file_charset);
-                        list($rec['name'], $rec['firstname'], $rec['surname'], $rec['email']) = explode('|', $line);
-                        if ($rec['name'] && $rec['email']) {
-                            $this->abook[] = $rec;
+                    $rec = array();
+                    if(($abook_fh = fopen($abookfile, 'r')) !== FALSE){
+                        while(($line = fgetcsv($abook_fh, 2048, '|')) !== FALSE){
+                            list($rec['name'], $rec['firstname'], $rec['surname'], $rec['email']) = $line;
+                            if ($rec['name'] && $rec['email']) {
+                                $this->abook[] = $rec;
+                            }
                         }
+                        fclose($abook_fh);
                     }
                 }
             }

--- a/plugins/squirrelmail_usercopy/squirrelmail_usercopy.php
+++ b/plugins/squirrelmail_usercopy/squirrelmail_usercopy.php
@@ -165,7 +165,6 @@ class squirrelmail_usercopy extends rcube_plugin
             }
 
             $file_charset = $rcmail->config->get('squirrelmail_file_charset');
-
             $prefsfile = slashify($srcdir) . $uname . '.pref';
             $abookfile = slashify($srcdir) . $uname . '.abook';
             $sigfile   = slashify($srcdir) . $uname . '.sig';
@@ -197,13 +196,20 @@ class squirrelmail_usercopy extends rcube_plugin
                 // parse address book file
                 if (filesize($abookfile)) {
                     $rec = array();
-                    if(($abook_fh = fopen($abookfile, 'r')) !== FALSE){
-                        while(($line = fgetcsv($abook_fh, 2048, '|')) !== FALSE){
+                    if (($abook_fh = fopen($abookfile, 'r')) !== FALSE) {
+
+                        while (($line = fgetcsv($abook_fh, 2048, '|')) !== FALSE) {
+
                             list($rec['name'], $rec['firstname'], $rec['surname'], $rec['email']) = $line;
+
                             if ($rec['name'] && $rec['email']) {
-                                $this->abook[] = $rec;
+                                $this->abook[] = array_map(function ($entry) use ($file_charset) {
+                                    return $this->convert_charset($entry, $file_charset);
+                                }, $rec);
                             }
+
                         }
+
                         fclose($abook_fh);
                     }
                 }
@@ -257,7 +263,7 @@ class squirrelmail_usercopy extends rcube_plugin
     private function convert_charset($str, $charset = null)
     {
         if (!$charset) {
-            return utf8_encode($sig);
+            return utf8_encode($str);
         }
 
         return rcube_charset::convert($str, $charset, RCUBE_CHARSET);

--- a/plugins/squirrelmail_usercopy/squirrelmail_usercopy.php
+++ b/plugins/squirrelmail_usercopy/squirrelmail_usercopy.php
@@ -195,22 +195,23 @@ class squirrelmail_usercopy extends rcube_plugin
 
                 // parse address book file
                 if (filesize($abookfile)) {
-                    $rec = array();
-                    if (($abook_fh = fopen($abookfile, 'r')) !== FALSE) {
 
-                        while (($line = fgetcsv($abook_fh, 2048, '|')) !== FALSE) {
+                    foreach (file($abookfile) as $line) {
 
-                            list($rec['name'], $rec['firstname'], $rec['surname'], $rec['email']) = $line;
+                        $line = $this->convert_charset(rtrim($line), $file_charset);
+                        $line = str_getcsv($line, "|");
 
-                            if ($rec['name'] && $rec['email']) {
-                                $this->abook[] = array_map(function ($entry) use ($file_charset) {
-                                    return $this->convert_charset($entry, $file_charset);
-                                }, $rec);
-                            }
+                        $rec = array(
+                            'name'      => $line[0],
+                            'firstname' => $line[1],
+                            'surname'   => $line[2],
+                            'email'     => $line[3],
+                            'notes'     => $line[4],
+                        );
 
+                        if ($rec['name'] && $rec['email']) {
+                            $this->abook[] = $rec;
                         }
-
-                        fclose($abook_fh);
                     }
                 }
             }

--- a/plugins/squirrelmail_usercopy/squirrelmail_usercopy.php
+++ b/plugins/squirrelmail_usercopy/squirrelmail_usercopy.php
@@ -163,7 +163,6 @@ class squirrelmail_usercopy extends rcube_plugin
                 $srcdir = slashify($srcdir).chunk_split(substr(base_convert(crc32($uname), 10, 16), 0, $hash_level), 1, '/');
             }
             $file_charset = $rcmail->config->get('squirrelmail_file_charset');
-
             $prefsfile = slashify($srcdir) . $uname . '.pref';
             $abookfile = slashify($srcdir) . $uname . '.abook';
             $sigfile   = slashify($srcdir) . $uname . '.sig';
@@ -194,9 +193,12 @@ class squirrelmail_usercopy extends rcube_plugin
 
                 // parse address book file
                 if (filesize($abookfile)) {
+
                     foreach (file($abookfile) as $line) {
+
                         $line = $this->convert_charset(rtrim($line), $file_charset);
                         $line = str_getcsv($line, "|");
+
                         $rec = array(
                             'name'      => $line[0],
                             'firstname' => $line[1],
@@ -204,6 +206,7 @@ class squirrelmail_usercopy extends rcube_plugin
                             'email'     => $line[3],
                             'notes'     => $line[4],
                         );
+
                         if ($rec['name'] && $rec['email']) {
                             $this->abook[] = $rec;
                         }

--- a/plugins/squirrelmail_usercopy/squirrelmail_usercopy.php
+++ b/plugins/squirrelmail_usercopy/squirrelmail_usercopy.php
@@ -196,7 +196,14 @@ class squirrelmail_usercopy extends rcube_plugin
                 if (filesize($abookfile)) {
                     foreach (file($abookfile) as $line) {
                         $line = $this->convert_charset(rtrim($line), $file_charset);
-                        list($rec['name'], $rec['firstname'], $rec['surname'], $rec['email']) = explode('|', $line);
+                        $line = str_getcsv($line, "|");
+                        $rec = array(
+                            'name'      => $line[0],
+                            'firstname' => $line[1],
+                            'surname'   => $line[2],
+                            'email'     => $line[3],
+                            'notes'     => $line[4],
+                        );
                         if ($rec['name'] && $rec['email']) {
                             $this->abook[] = $rec;
                         }
@@ -252,7 +259,7 @@ class squirrelmail_usercopy extends rcube_plugin
     private function convert_charset($str, $charset = null)
     {
         if (!$charset) {
-            return utf8_encode($sig);
+            return utf8_encode($str);
         }
 
         return rcube_charset::convert($str, $charset, RCUBE_CHARSET);


### PR DESCRIPTION
Update the squirrelmail_user_copy plugin to use the same method of parsing abook entries as squirrelmail uses. 

If a user has entered something that has been quoted such as double quotes or pipes, this will
parse the address book entry better than exploding on the pipe alone