### PR TITLE
address_book_type plugins fix

### DIFF
--- a/program/include/rcmail.php
+++ b/program/include/rcmail.php
@@ -328,6 +328,9 @@ class rcmail extends rcube
             );
         }
 
+        $plugin = $this->plugins->exec_hook('addressbooks_list', array('sources' => $list));
+        $list   = $plugin['sources'];
+ 
         if (!empty($ldap_config)) {
             foreach ($ldap_config as $id => $prop) {
                 // handle misconfiguration
@@ -345,9 +348,6 @@ class rcmail extends rcube
                 );
             }
         }
-
-        $plugin = $this->plugins->exec_hook('addressbooks_list', array('sources' => $list));
-        $list   = $plugin['sources'];
 
         foreach ($list as $idx => $item) {
             // register source for shutdown function


### PR DESCRIPTION
If both LDAP and plugin address books are used, the LDAP one is forced as default (until changed in preferences), even if `address_book_type` is empty.  This patch makes RC check plugins for available address books first, if `address_book_type` is empty. And the plugins address books are now listed before the LDAP ones.

While this could be ignored with the larry skin, we get  annoying 'advanced search' window appearing every time we switch to the contacts page with the new elastic skin.