### PR TITLE
Add a skip duplicates option when importing contacts

### DIFF
--- a/program/localization/en_CA/labels.inc
+++ b/program/localization/en_CA/labels.inc
@@ -332,6 +332,7 @@ $labels['import'] = 'Import';
 $labels['importcontacts'] = 'Import contacts';
 $labels['importtarget'] = 'Add contacts to';
 $labels['importreplace'] = 'Replace the entire address book';
+$labels['importskip'] = 'Skip duplicate contacts';
 $labels['importgroups'] = 'Import group assignments';
 $labels['importgroupsall'] = 'All (create groups if necessary)';
 $labels['importgroupsexisting'] = 'Only for existing groups';

--- a/program/localization/en_GB/labels.inc
+++ b/program/localization/en_GB/labels.inc
@@ -428,6 +428,7 @@ $labels['importcontacts'] = 'Import contacts';
 $labels['importfromfile'] = 'Import from file';
 $labels['importtarget'] = 'Add contacts to';
 $labels['importreplace'] = 'Replace the entire address book';
+$labels['importskip'] = 'Skip duplicate contacts';
 $labels['importgroups'] = 'Import group assignments';
 $labels['importgroupsall'] = 'All (create groups if necessary)';
 $labels['importgroupsexisting'] = 'Only for existing groups';

--- a/program/localization/en_US/labels.inc
+++ b/program/localization/en_US/labels.inc
@@ -485,6 +485,7 @@ $labels['importcontacts'] = 'Import contacts';
 $labels['importfromfile'] = 'Import from file';
 $labels['importtarget'] = 'Add contacts to';
 $labels['importreplace'] = 'Replace the entire address book';
+$labels['importskip'] = 'Skip duplicate contacts';
 $labels['importgroups'] = 'Import group assignments';
 $labels['importgroupsall'] = 'All (create groups if necessary)';
 $labels['importgroupsexisting'] = 'Only for existing groups';

--- a/program/localization/nl_NL/labels.inc
+++ b/program/localization/nl_NL/labels.inc
@@ -427,6 +427,7 @@ $labels['importcontacts'] = 'Contactpersonen importeren';
 $labels['importfromfile'] = 'Importeer van bestand';
 $labels['importtarget'] = 'Contacten toevoegen aan';
 $labels['importreplace'] = 'Vervang het complete adresboek';
+$labels['importskip'] = 'Sla duplicaten over';
 $labels['importgroups'] = 'Importeer groepstoewijzingen';
 $labels['importgroupsall'] = 'Allemaal (maak groepen aan indien nodig)';
 $labels['importgroupsexisting'] = 'Alleen voor bestaande groepen';

--- a/program/steps/addressbook/import.inc
+++ b/program/steps/addressbook/import.inc
@@ -26,6 +26,7 @@ $importstep = 'rcmail_import_form';
 
 if (is_array($_FILES['_file'])) {
     $replace      = (bool)rcube_utils::get_input_value('_replace', rcube_utils::INPUT_GPC);
+    $skip         = (bool)rcube_utils::get_input_value('_skip', rcube_utils::INPUT_GPC);
     $target       = rcube_utils::get_input_value('_target', rcube_utils::INPUT_GPC);
     $with_groups  = intval(rcube_utils::get_input_value('_groups', rcube_utils::INPUT_GPC));
 
@@ -126,7 +127,7 @@ if (is_array($_FILES['_file'])) {
             $email = $vcard->email[0];
             $email = rcube_utils::idn_to_utf8($email);
 
-            if (!$replace) {
+            if ($skip) {
                 $existing = null;
                 // compare e-mail address
                 if ($email) {
@@ -258,6 +259,11 @@ function rcmail_import_form($attrib)
     $check_replace = new html_checkbox(array('name' => '_replace', 'value' => 1, 'id' => 'rcmimportreplace'));
     $table->add('title', html::label('rcmimportreplace', $RCMAIL->gettext('importreplace')));
     $table->add(null, $check_replace->show(rcube_utils::get_input_value('_replace', rcube_utils::INPUT_GPC)));
+
+    $check_skip = new html_checkbox(array('name' => '_skip', 'value' => 1, 'id' => 'rcmimportskip'));
+    $table->add('title', html::label('rcmimportskip', $RCMAIL->gettext('importskip')));
+    $current_skip = rcube_utils::get_input_value('_skip', rcube_utils::INPUT_GPC);
+    $table->add(null, $check_skip->show(($current_skip !== null ? $current_skip : 1)));
 
     $form .= $table->show(array('id' => null) + $attrib);
 


### PR DESCRIPTION
This PR adds a new option for users to choose what to do with duplicates when importing new contacts. By default the option (checkbox) is checked and thus will skip duplicates (as is the current behaviour).