### PR TITLE
Treelist - Default value for node.collapsed when node.children.length = 0

### DIFF
--- a/program/js/treelist.js
+++ b/program/js/treelist.js
@@ -745,6 +745,9 @@ function rcube_treelist_widget(node, p)
 
         li.attr('aria-expanded', node.collapsed ? 'false' : 'true');
       }
+      else {
+        node.collapsed = true;
+      }
       if (li.hasClass('selected')) {
         li.attr('aria-selected', 'true');
         selection = node.id;


### PR DESCRIPTION
When a node has children but with length = 0 the node.collapsed value is not set so the node is considered as expanded.
This is problematic when we use a dynamic tree loaded by ajax, the node is always considered has expanded but it's isn't.
I think by default node.collapsed needs to be set to true when there is no children because it's what we expect to have