### PR TITLE
Fix bug where HTML messages with a xml:namespace tag were not rendered.

### DIFF
--- a/program/lib/Roundcube/rcube_washtml.php
+++ b/program/lib/Roundcube/rcube_washtml.php
@@ -605,6 +605,8 @@ class rcube_washtml
             '/^(\0\0\xFE\xFF|\xFF\xFE\0\0|\xFE\xFF|\xFF\xFE|\xEF\xBB\xBF)/',
             // washtml/DOMDocument cannot handle xml namespaces
             '/<html\s[^>]+>/i',
+            // washtml/DOMDocument cannot handle xml namespaces
+            '/<\?xml:namespace\s[^>]+>/i',
         );
 
         $html_replace = array(
@@ -613,6 +615,7 @@ class rcube_washtml
             '',
             '',
             '<html>',
+            '',
         );
 
         $html = preg_replace($html_search, $html_replace, $html);

--- a/tests/Framework/Washtml.php
+++ b/tests/Framework/Washtml.php
@@ -430,4 +430,18 @@ class Framework_Washtml extends PHPUnit_Framework_TestCase
         $this->assertContains('for="testmy-other-id"', $washed);
         $this->assertContains('class="testmy-class1 testmy-class2"', $washed);
     }
+
+    /**
+     * Test removing xml:namespace tag
+     */
+    function test_xml_namespace()
+    {
+        $html = '<p><?xml:namespace prefix = "xsl" /></p>';
+
+        $washer = new rcube_washtml;
+        $washed = $this->cleanupResult($washer->wash($html));
+
+        $this->assertNotContains('&lt;?xml:namespace"', $washed);
+        $this->assertSame($washed, '<p></p>');
+    }
 }


### PR DESCRIPTION
HTML messages with  `<P><?xml:namespace prefix = "xsl" />...message...</P>`
were not being displayed in roundcube because `DOMDocument` did not handle the `<?xml:namespace` tag.
Although i don't understand why would an email client / API use that kind of code (in this case, it is CDO for Windows), the fact is that some of my users are receiving official emails from a bank like this.