### PR TITLE
Elastic: Change "All headers..." dialog to use monospace font

### DIFF
--- a/skins/elastic/styles/widgets/dialogs.less
+++ b/skins/elastic/styles/widgets/dialogs.less
@@ -253,3 +253,10 @@ html.touch .popover {
         display: none;
     }
 }
+
+/** Headers popup dialog **/
+body.action-headers {
+    font-family: Consolas, 'Courier New', Courier, monospace;
+    font-size: 90%;
+    line-height: 1.25;
+}

--- a/skins/elastic/templates/includes/layout.html
+++ b/skins/elastic/templates/includes/layout.html
@@ -30,7 +30,7 @@
 		<roundcube:link rel="stylesheet" href="/styles/print.css" condition="env:action == 'print'" />
 	<roundcube:endif />
 </head>
-<body class="task-<roundcube:exp expression="env:error_task ?: env:task ?: 'error'">">
+<body class="task-<roundcube:exp expression="env:error_task ?: env:task ?: 'error'"> action-<roundcube:exp expression="env:action ?: 'none'">">
 	<roundcube:if condition="!env:framed || env:extwin" />
 		<div id="<roundcube:exp expression="env:action == 'print' ? 'print-' : ''">layout">
 	<roundcube:endif />


### PR DESCRIPTION
The "All headers" popup iframe uses the default font - but many (particularly multi-line) headers expect to be displayed in a monospace font.  Examples of this include the "Received" header, or rspamd's "X-Spamd-Result" header.