### PR TITLE
Elastic: Make header title in message view slightly wider

### DIFF
--- a/skins/elastic/styles/widgets/mail.less
+++ b/skins/elastic/styles/widgets/mail.less
@@ -229,7 +229,7 @@
     .header-title {
         .overflow-ellipsis;
         white-space: nowrap;
-        max-width: 7em;
+        max-width: 8em;
         font-weight: bold;
         padding-right: 1rem;
         vertical-align: top;


### PR DESCRIPTION
Make header title in message view slightly wider, so we can fit the string "X-Original-To" without wrapping.

Tested on desktop:
* Firefox 66.0.3 - 1920x1080, 1680x1050, 1280x1024
* Edge 42.17134.1.0 - 1920x1080, 1680x1050, 1280x1024
* Chrome 71.0.3578.98 - 1920x1080, 1680x1050, 1280x1024

Tested on mobile:
* Chrome Mobile 73.0.3683.90 1440x2560