### PR TITLE
Correct upgrade database process

### DIFF
--- a/SQL/mysql/2013052500.sql
+++ b/SQL/mysql/2013052500.sql
@@ -1,3 +1,5 @@
+DROP TABLE `cache_shared`;
+
 CREATE TABLE `cache_shared` (
  `cache_key` varchar(255) /*!40101 CHARACTER SET ascii COLLATE ascii_general_ci */ NOT NULL,
  `created` datetime NOT NULL DEFAULT '1000-01-01 00:00:00',


### PR DESCRIPTION
During my upgrade (from 1.1.2 to 1.3.8) the following error appears:

```
Updating database schema (2013052500)... [FAILED]
Error 500: Error in DDL upgrade 2013052500: [1050] Table 'cache_shared' already exists
```
I propose you to drop the table before to recreate it.