### PR TITLE
Fix #6746: update rcube_utils::parse_hosts

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -36,6 +36,7 @@ CHANGELOG Roundcube Webmail
 - Fix so bin/install-jsdeps.sh returns error code on error (#6704)
 - Fix bug where bmp images couldn't be displayed on some systems (#6728)
 - Fix bug in parsing vCard data using PHP 7.3 due to an invalid regexp (#6744)
+- Fix bug in rcube_utils::parse_hosts where %t, %d, %z could return only tld (#6746)
 
 RELEASE 1.4-rc1
 ---------------

--- a/config/config.inc.php.sample
+++ b/config/config.inc.php.sample
@@ -37,6 +37,11 @@ $config['db_dsnw'] = 'mysql://roundcube:pass@localhost/roundcubemail';
 // %d - domain (http hostname $_SERVER['HTTP_HOST'] without the first part)
 // %s - domain name after the '@' from e-mail address provided at login screen
 // For example %n = mail.domain.tld, %t = domain.tld
+// (N.B. %t, %d remove only the first part up to domain-level, i.e., if
+//       an FQDN is provided, they will not return anything shorter than
+//       domain.tld or domain.sd.cc. Single hostnames are returned as-is.
+//       NOTE: Currently only 2-letter 'sd' supported, be aware when using
+//             this setting if your ccSLD is longer.
 $config['default_host'] = 'localhost';
 
 // SMTP server host (for sending mails).
@@ -49,6 +54,11 @@ $config['default_host'] = 'localhost';
 // %d - domain (http hostname $_SERVER['HTTP_HOST'] without the first part)
 // %z - IMAP domain (IMAP hostname without the first part)
 // For example %n = mail.domain.tld, %t = domain.tld
+// (N.B. %t, %d, %z remove only the first part up to domain-level, i.e., if
+//       an FQDN is provided, they will not return anything shorter than
+//       domain.tld or domain.sd.cc. Single hostnames are returned as-is.
+//       NOTE: Currently only 2-letter 'sd' supported, be aware when using
+//             this setting if your ccSLD is longer.
 $config['smtp_server'] = 'localhost';
 
 // SMTP port (default is 25; use 587 for STARTTLS or 465 for the

--- a/config/config.inc.php.sample
+++ b/config/config.inc.php.sample
@@ -41,7 +41,7 @@ $config['db_dsnw'] = 'mysql://roundcube:pass@localhost/roundcubemail';
 //       an FQDN is provided, they will not return anything shorter than
 //       domain.tld or domain.sd.cc. Single hostnames are returned as-is.
 //       NOTE: Currently only 2-letter 'sd' supported, be aware when using
-//             this setting if your ccSLD is longer.
+//             this setting if your ccSLD is longer.)
 $config['default_host'] = 'localhost';
 
 // SMTP server host (for sending mails).
@@ -58,7 +58,7 @@ $config['default_host'] = 'localhost';
 //       an FQDN is provided, they will not return anything shorter than
 //       domain.tld or domain.sd.cc. Single hostnames are returned as-is.
 //       NOTE: Currently only 2-letter 'sd' supported, be aware when using
-//             this setting if your ccSLD is longer.
+//             this setting if your ccSLD is longer.)
 $config['smtp_server'] = 'localhost';
 
 // SMTP port (default is 25; use 587 for STARTTLS or 465 for the

--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -137,6 +137,11 @@ $config['redis_debug'] = false;
 // %d - domain (http hostname $_SERVER['HTTP_HOST'] without the first part)
 // %s - domain name after the '@' from e-mail address provided at login screen
 // For example %n = mail.domain.tld, %t = domain.tld
+// (N.B. %t, %d remove only the first part up to domain-level, i.e., if
+//       an FQDN is provided, they will not return anything shorter than
+//       domain.tld or domain.sd.cc. Single hostnames are returned as-is.
+//       NOTE: Currently only 2-letter 'sd' supported, be aware when using
+//             this setting if your ccSLD is longer.)
 // WARNING: After hostname change update of mail_host column in users table is
 //          required to match old user data records with the new host.
 $config['default_host'] = 'localhost';
@@ -262,6 +267,11 @@ $config['messages_cache_threshold'] = 50;
 // %d - domain (http hostname $_SERVER['HTTP_HOST'] without the first part)
 // %z - IMAP domain (IMAP hostname without the first part)
 // For example %n = mail.domain.tld, %t = domain.tld
+// (N.B. %t, %d, %z remove only the first part up to domain-level, i.e., if
+//       an FQDN is provided, they will not return anything shorter than
+//       domain.tld or domain.sd.cc. Single hostnames are returned as-is.
+//       NOTE: Currently only 2-letter 'sd' supported, be aware when using
+//             this setting if your ccSLD is longer.)
 $config['smtp_server'] = 'localhost';
 
 // SMTP port (default is 587)
@@ -522,6 +532,11 @@ $config['cipher_method'] = 'DES-EDE3-CBC';
 // %d - domain (http hostname $_SERVER['HTTP_HOST'] without the first part)
 // %z - IMAP domain (IMAP hostname without the first part)
 // For example %n = mail.domain.tld, %t = domain.tld
+// (N.B. %t, %d, %z remove only the first part up to domain-level, i.e., if
+//       an FQDN is provided, they will not return anything shorter than
+//       domain.tld or domain.sd.cc. Single hostnames are returned as-is.
+//       NOTE: Currently only 2-letter 'sd' supported, be aware when using
+//             this setting if your ccSLD is longer.)
 $config['username_domain'] = '';
 
 // Force domain configured in username_domain to be used for login.
@@ -536,6 +551,11 @@ $config['username_domain_forced'] = false;
 // %d - domain (http hostname without the first part)
 // %z - IMAP domain (IMAP hostname without the first part)
 // For example %n = mail.domain.tld, %t = domain.tld
+// (N.B. %t, %d, %z remove only the first part up to domain-level, i.e., if
+//       an FQDN is provided, they will not return anything shorter than
+//       domain.tld or domain.sd.cc. Single hostnames are returned as-is.
+//       NOTE: Currently only 2-letter 'sd' supported, be aware when using
+//             this setting if your ccSLD is longer.)
 $config['mail_domain'] = '';
 
 // Password character set, to change the password for user
@@ -848,6 +868,11 @@ $config['ldap_public']['Verisign'] = array(
   // %d - domain (http hostname $_SERVER['HTTP_HOST'] without the first part)
   // %z - IMAP domain (IMAP hostname without the first part)
   // For example %n = mail.domain.tld, %t = domain.tld
+  // (N.B. %t, %d, %z remove only the first part up to domain-level, i.e., if
+  //       an FQDN is provided, they will not return anything shorter than
+  //       domain.tld or domain.sd.cc. Single hostnames are returned as-is.
+  //       NOTE: Currently only 2-letter 'sd' supported, be aware when using
+  //             this setting if your ccSLD is longer.)
   'hosts'         => array('directory.verisign.com'),
   'port'          => 389,
   'use_tls'       => false,

--- a/program/lib/Roundcube/rcube_utils.php
+++ b/program/lib/Roundcube/rcube_utils.php
@@ -574,13 +574,15 @@ class rcube_utils
         // %n - host
         $n = self::server_name();
         // %t - host name without first part, e.g. %n=mail.domain.tld, %t=domain.tld
-        $t = preg_replace('/^[^\.]+\./', '', $n);
-        // %d - domain name without first part
-        $d = preg_replace('/^[^\.]+\./', '', self::server_name('HTTP_HOST'));
+        // If %n=domain.tld then %t=domain.tld as well (remains valid)
+        $t = preg_replace('/^[^.]+\.(?![^.]+$)/', '', $n);
+        // %d - domain name without first part (up to domain.tld)
+        $d = preg_replace('/^[^.]+\.(?![^.]+$)/', '', self::server_name('HTTP_HOST'));
         // %h - IMAP host
         $h = $_SESSION['storage_host'] ?: $host;
         // %z - IMAP domain without first part, e.g. %h=imap.domain.tld, %z=domain.tld
-        $z = preg_replace('/^[^\.]+\./', '', $h);
+        // If %h=domain.tld then %z=domain.tld as well (remains valid)
+        $z = preg_replace('/^[^.]+\.(?![^.]+$)/', '', $h);
         // %s - domain name after the '@' from e-mail address provided at login screen.
         //      Returns FALSE if an invalid email is provided
         if (strpos($name, '%s') !== false) {

--- a/program/lib/Roundcube/rcube_utils.php
+++ b/program/lib/Roundcube/rcube_utils.php
@@ -575,14 +575,16 @@ class rcube_utils
         $n = self::server_name();
         // %t - host name without first part, e.g. %n=mail.domain.tld, %t=domain.tld
         // If %n=domain.tld then %t=domain.tld as well (remains valid)
-        $t = preg_replace('/^[^.]+\.(?![^.]+$)/', '', $n);
-        // %d - domain name without first part (up to domain.tld)
-        $d = preg_replace('/^[^.]+\.(?![^.]+$)/', '', self::server_name('HTTP_HOST'));
+        // Also handles domain.sd.cc, if sd is 2 chars (longer ccSLDs will require a more complex fix)
+        $t = preg_replace('/^[^.]+\.(?!(?:[^.]{3,}|(?:[^.]{2}\.[^.]{2}))$)/', '', $n);
+        // %d - domain name without first part (up to domain.tld or domain.sd.cc)
+        $d = preg_replace('/^[^.]+\.(?!(?:[^.]{3,}|(?:[^.]{2}\.[^.]{2}))$)/', '', self::server_name('HTTP_HOST'));
         // %h - IMAP host
         $h = $_SESSION['storage_host'] ?: $host;
         // %z - IMAP domain without first part, e.g. %h=imap.domain.tld, %z=domain.tld
         // If %h=domain.tld then %z=domain.tld as well (remains valid)
-        $z = preg_replace('/^[^.]+\.(?![^.]+$)/', '', $h);
+        // Also handles domain.sd.cc, if sd is 2 chars (longer ccSLDs will require a more complex fix)
+        $z = preg_replace('/^[^.]+\.(?!(?:[^.]{3,}|(?:[^.]{2}\.[^.]{2}))$)/', '', $h);
         // %s - domain name after the '@' from e-mail address provided at login screen.
         //      Returns FALSE if an invalid email is provided
         if (strpos($name, '%s') !== false) {


### PR DESCRIPTION
Fixes bug #6746 where rcube_utils::parse_hosts domain-level substitutions %t, %d, %z could return only tld when underlying hostname was just domain.tld with no subdomain (e.g., NOT mail.domain.tld). New regexps will only strip subdomain, will not strip domain without subdomain.