### PR TITLE
add dialog-open JS event

### DIFF
--- a/program/js/app.js
+++ b/program/js/app.js
@@ -8162,6 +8162,8 @@ function rcube_webmail()
     // Don't propagate keyboard events to the UI below the dialog (#6055)
     popup.parent().on('keydown keyup', function(e) { e.stopPropagation(); });
 
+    this.triggerEvent('dialog-open', { id:popup.attr('id') });
+
     return popup;
   };
 


### PR DESCRIPTION
Add a `dialog-open` JS event, similar to the `menu-open` event to allow plugins to detect when a dialog is opened.