### PR TITLE
Add infrastructure to apply CSS styles to specific action dialogs/screens

### DIFF
--- a/skins/elastic/templates/includes/layout.html
+++ b/skins/elastic/templates/includes/layout.html
@@ -30,7 +30,7 @@
 		<roundcube:link rel="stylesheet" href="/styles/print.css" condition="env:action == 'print'" />
 	<roundcube:endif />
 </head>
-<body class="task-<roundcube:exp expression="env:error_task ?: env:task ?: 'error'">">
+<body class="task-<roundcube:exp expression="env:error_task ?: env:task ?: 'error'"> action-<roundcube:exp expression="asciiwords(env:action, true, '-') ?: 'none'">">
 	<roundcube:if condition="!env:framed || env:extwin" />
 		<div id="<roundcube:exp expression="env:action == 'print' ? 'print-' : ''">layout">
 	<roundcube:endif />


### PR DESCRIPTION
As discussed in #6730

Adds the ability to apply CSS styles to specific action dialogs/screens.

Examples:
* action-headers - The headers popup
* action-plugin-managesieve-action - The managesieve filter creation screen
