### PR TITLE
add support for SameSite cookie attribute

### DIFF
--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -476,6 +476,11 @@ $config['session_auth_name'] = null;
 // Session path. Defaults to PHP session.cookie_path setting.
 $config['session_path'] = null;
 
+// Session samesite. Defaults to PHP session.cookie_samesite setting.
+// Requires PHP >= 7.3.0, see https://wiki.php.net/rfc/same-site-cookie for more info
+// Possible values: null (default), 'Lax', or 'Strict'
+$config['session_samesite'] = null;
+
 // Backend to use for session storage. Can either be 'db' (default), 'redis', 'memcache', or 'php'
 //
 // If set to 'memcache', a list of servers need to be specified in 'memcache_hosts'

--- a/program/lib/Roundcube/rcube.php
+++ b/program/lib/Roundcube/rcube.php
@@ -458,12 +458,13 @@ class rcube
             return;
         }
 
-        $storage     = $this->config->get('session_storage', 'db');
-        $sess_name   = $this->config->get('session_name');
-        $sess_domain = $this->config->get('session_domain');
-        $sess_path   = $this->config->get('session_path');
-        $lifetime    = $this->config->get('session_lifetime', 0) * 60;
-        $is_secure   = $this->config->get('use_https') || rcube_utils::https_check();
+        $storage       = $this->config->get('session_storage', 'db');
+        $sess_name     = $this->config->get('session_name');
+        $sess_domain   = $this->config->get('session_domain');
+        $sess_path     = $this->config->get('session_path');
+        $sess_samesite = $this->config->get('session_samesite');
+        $lifetime      = $this->config->get('session_lifetime', 0) * 60;
+        $is_secure     = $this->config->get('use_https') || rcube_utils::https_check();
 
         // set session domain
         if ($sess_domain) {
@@ -472,6 +473,11 @@ class rcube
         // set session path
         if ($sess_path) {
             ini_set('session.cookie_path', $sess_path);
+        }
+        // set session samesite attribute
+        // requires PHP >= 7.3.0, see https://wiki.php.net/rfc/same-site-cookie for more info
+        if (version_compare(PHP_VERSION, '7.3.0', '>=') && $sess_samesite) {
+            ini_set('session.cookie_samesite', $sess_samesite);
         }
         // set session garbage collecting time according to session_lifetime
         if ($lifetime) {

--- a/program/lib/Roundcube/rcube_utils.php
+++ b/program/lib/Roundcube/rcube_utils.php
@@ -49,10 +49,21 @@ class rcube_utils
             return;
         }
 
-        $cookie = session_get_cookie_params();
-        $secure = $cookie['secure'] || self::https_check();
+        $attrib             = session_get_cookie_params();
+        $attrib['expires']  = $exp;
+        $attrib['secure']   = $attrib['secure'] || self::https_check();
+        $attrib['httponly'] = $http_only;
 
-        setcookie($name, $value, $exp, $cookie['path'], $cookie['domain'], $secure, $http_only);
+        // session_get_cookie_params() return includes 'lifetime' but setcookie() does not use it, instead it uses 'expires'
+        unset($attrib['lifetime']);
+
+        if (version_compare(PHP_VERSION, '7.3.0', '>=')) {
+            // An alternative signature for setcookie supporting an options array added in PHP 7.3.0
+            setcookie($name, $value, $attrib);
+        }
+        else {
+            setcookie($name, $value, $attrib['expires'], $attrib['path'], $attrib['domain'], $attrib['secure'], $attrib['httponly']);
+        }
     }
 
     /**


### PR DESCRIPTION
PHP 7.3.0 adds support for the SameSite cookie attribute, see https://wiki.php.net/rfc/same-site-cookie..

To use it the setcookie method must be called in a new way which is not backwards compatible so I added a PHP version check.