### PR TITLE
Set 'IDNA_NONTRANSITIONAL_TO_ASCII' idn-option

### DIFF
--- a/program/lib/Roundcube/rcube_utils.php
+++ b/program/lib/Roundcube/rcube_utils.php
@@ -949,7 +949,7 @@ class rcube_utils
         // Note that in PHP 7.2/7.3 calling idn_to_* functions with default arguments
         // throws a warning, so we have to set the variant explicitely (#6075)
         $variant = defined('INTL_IDNA_VARIANT_UTS46') ? INTL_IDNA_VARIANT_UTS46 : null;
-        $options = 0;
+        $options = defined('IDNA_NONTRANSITIONAL_TO_ASCII') ? IDNA_NONTRANSITIONAL_TO_ASCII : 0;
 
         // Because php-intl extension lowercases domains and return false
         // on invalid input (#6224), we skip conversion when not needed

--- a/program/lib/Roundcube/rcube_utils.php
+++ b/program/lib/Roundcube/rcube_utils.php
@@ -949,7 +949,7 @@ class rcube_utils
         // Note that in PHP 7.2/7.3 calling idn_to_* functions with default arguments
         // throws a warning, so we have to set the variant explicitely (#6075)
         $variant = defined('INTL_IDNA_VARIANT_UTS46') ? INTL_IDNA_VARIANT_UTS46 : null;
-        $options = defined('IDNA_NONTRANSITIONAL_TO_ASCII') ? IDNA_NONTRANSITIONAL_TO_ASCII : 0;
+        $options = 0;
 
         // Because php-intl extension lowercases domains and return false
         // on invalid input (#6224), we skip conversion when not needed
@@ -957,10 +957,12 @@ class rcube_utils
 
         if ($is_utf) {
             if (preg_match('/[^\x20-\x7E]/', $domain)) {
+                $options = defined('IDNA_NONTRANSITIONAL_TO_ASCII') ? IDNA_NONTRANSITIONAL_TO_ASCII : 0;
                 $domain = idn_to_ascii($domain, $options, $variant);
             }
         }
         else if (preg_match('/(^|\.)xn--/i', $domain)) {
+            $options = defined('IDNA_NONTRANSITIONAL_TO_UNICODE') ? IDNA_NONTRANSITIONAL_TO_UNICODE : 0;
             $domain = idn_to_utf8($domain, $options, $variant);
         }
 


### PR DESCRIPTION
This change adds the `IDNA_NONTRANSITIONAL_TO_ASCII` option, if defined, to the idn_to_ascii call.

Why do we need this change?
Without this option the `ß` character is still being translated to `ss`, according to the deprecated IDNA 2003 variant, instead of the IDNA2008 translation.

For example when adding a new identity for the domain `fußball.de` the current master generates and saves `fussball.de` instead of `xn--fuball-cta.de`.