### PR TITLE
Fix variables defined in variable.less cannot be overwritten

### DIFF
--- a/skins/elastic/styles/variables.less
+++ b/skins/elastic/styles/variables.less
@@ -11,7 +11,6 @@
 
 @import (reference) "fontawesome";
 @import (reference) "colors";
-@import (reference) "_variables";
 
 @screen-width-large:    1200px;
 @screen-width-medium:   1024px;
@@ -52,3 +51,5 @@
 // Additional icons
 @icon-resize-corner:    data-uri("image/svg+xml;charset=utf-8", "../images/corner-handle.svg"); // size: 512x512
 @icon-file-drop:        data-uri("image/svg+xml;charset=utf-8", "../images/download.svg");
+
+@import (reference) "_variables";


### PR DESCRIPTION
Variables defined in `variables.less` cannot be overwritten by `_variables.less`.

For example, re-defining `@page-font-size` in `_variables.less` is not working.