### PR TITLE
Make Apache prefer to brotli over gzip when possible

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -19,6 +19,13 @@ RewriteRule /?(README.*|meta\.json|composer\..*|jsdeps.json)$ - [F]
 SetOutputFilter DEFLATE
 </IfModule>
 
+# prefer to brotli over gzip if brotli is available
+<IfModule mod_brotli.c>
+SetOutputFilter BROTLI_COMPRESS
+# some assets have been compressed, so no need to do it again
+SetEnvIfNoCase Request_URI \.(?:gif|jpe?g|png|web[pm]|woff2?)$ no-brotli
+</IfModule>
+
 <IfModule mod_expires.c>
 ExpiresActive On
 ExpiresDefault "access plus 1 month"


### PR DESCRIPTION
# Problem

I use `brotli` (rather than `gzip`) on my server and I occasionally found that it did not be activated on my RC's site. I soon found that there is a `.htaccess` in RC's root dir which forces Apache to use `gzip`.


# Proposal

`brotli` is a better (than `gzip`) compression algorithm derived by Google. It's available in Apache 2.4.26 and later. Maybe we should prefer `brotli` over `gzip` if it's available?


# References

- https://en.wikipedia.org/wiki/Brotli
- https://httpd.apache.org/docs/2.4/mod/mod_brotli.html