### PR TITLE
Simplify jQuery DOM ready at the footer

### DIFF
--- a/program/include/rcmail_output_html.php
+++ b/program/include/rcmail_output_html.php
@@ -1852,7 +1852,7 @@ EOF;
 
         // put docready commands into page footer
         if (!empty($this->scripts['docready'])) {
-            $this->add_script('$(document).ready(function(){ ' . $this->scripts['docready'] . "\n});", 'foot');
+            $this->add_script('$(function(){ ' . $this->scripts['docready'] . "\n});", 'foot');
         }
 
         // replace specialchars in content


### PR DESCRIPTION
# Problem

At the end of every page of RC, there is a segment code like

```html
<script type="text/javascript">
$(document).ready(function(){
rcmail.init();
// ... maybe more codes here
});
</script>
```

It can be simplified.


# Proposal

According to jQuery's official doc:

jQuery offers several ways to attach a function that will run when the DOM is ready. All of the following syntaxes are equivalent:

- $( handler )
- $( document ).ready( handler )
- $( "document" ).ready( handler )
- $( "img" ).ready( handler )
- $().ready( handler )

As of jQuery 3.0, only the first syntax is recommended; the other syntaxes still work but are deprecated. This is because the selection has no bearing on the behavior of the .ready() method, which is inefficient and can lead to incorrect assumptions about the method's behavior. For example, the third syntax works with "document" which selects nothing. The fourth syntax waits for the document to be ready but implies (incorrectly) that it waits for images to become ready.

The `.ready()` method is typically used with an anonymous function:

```js
$( document ).ready(function() {
  // Handler for .ready() called.
});
```

Which is equivalent to the **recommended** way of calling:

```js
$(function() {
  // Handler for .ready() called.
});
```


# Reference

- https://api.jquery.com/ready/#entry-longdesc
