### PR TITLE
Fix visibility of rcube_ldap_exop_password::$debug

### DIFF
--- a/plugins/password/drivers/ldap_exop.php
+++ b/plugins/password/drivers/ldap_exop.php
@@ -31,7 +31,7 @@ require_once __DIR__ . '/ldap_simple.php';
 
 class rcube_ldap_exop_password extends rcube_ldap_simple_password
 {
-    private $debug = false;
+    protected $debug = false;
 
     function save($curpass, $passwd)
     {


### PR DESCRIPTION
`$debug` is `protected` in its parent class `rcube_ldap_simple_password`.

```
PHP Fatal error:  Access level to rcube_ldap_exop_password::$debug must be protected (as in class rcube_ldap_simple_password) or weaker in /var/www/roundcubemail/plugins/password/drivers/ldap_exop.php on line 0
PHP Warning:  Zend OPcache could not compile file /var/www/roundcubemail/plugins/password/drivers/ldap_exop.php in /var/www/roundcubemail/vendor/preload.php on line 47
```