### PR TITLE
Fix the initial SQL schemas to support ES-419 language.

### DIFF
--- a/SQL/mssql.initial.sql
+++ b/SQL/mssql.initial.sql
@@ -102,14 +102,14 @@ CREATE TABLE [dbo].[users] (
 	[last_login] [datetime] NULL ,
 	[failed_login] [datetime] NULL ,
 	[failed_login_counter] [int] NULL ,
-	[language] [varchar] (5) COLLATE Latin1_General_CI_AI NULL ,
+	[language] [varchar] (6) COLLATE Latin1_General_CI_AI NULL ,
 	[preferences] [text] COLLATE Latin1_General_CI_AI NULL 
 ) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
 GO
 
 CREATE TABLE [dbo].[dictionary] (
 	[user_id] [int] ,
-	[language] [varchar] (5) COLLATE Latin1_General_CI_AI NOT NULL ,
+	[language] [varchar] (6) COLLATE Latin1_General_CI_AI NOT NULL ,
 	[data] [text] COLLATE Latin1_General_CI_AI NOT NULL 
 ) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
 GO

--- a/SQL/mysql.initial.sql
+++ b/SQL/mysql.initial.sql
@@ -25,7 +25,7 @@ CREATE TABLE `users` (
  `last_login` datetime DEFAULT NULL,
  `failed_login` datetime DEFAULT NULL,
  `failed_login_counter` int(10) UNSIGNED DEFAULT NULL,
- `language` varchar(5),
+ `language` varchar(6),
  `preferences` longtext,
  PRIMARY KEY(`user_id`),
  UNIQUE `username` (`username`, `mail_host`)
@@ -176,7 +176,7 @@ CREATE TABLE `identities` (
 CREATE TABLE `dictionary` (
   `id` int(10) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY, -- redundant, for compat. with Galera Cluster
   `user_id` int(10) UNSIGNED DEFAULT NULL, -- NULL here is for "shared dictionaries"
-  `language` varchar(5) NOT NULL,
+  `language` varchar(6) NOT NULL,
   `data` longtext NOT NULL,
   CONSTRAINT `user_id_fk_dictionary` FOREIGN KEY (`user_id`)
     REFERENCES `users`(`user_id`) ON DELETE CASCADE ON UPDATE CASCADE,

--- a/SQL/oracle.initial.sql
+++ b/SQL/oracle.initial.sql
@@ -9,7 +9,7 @@ CREATE TABLE "users" (
     "last_login" timestamp with time zone DEFAULT NULL,
     "failed_login" timestamp with time zone DEFAULT NULL,
     "failed_login_counter" integer DEFAULT NULL,
-    "language" varchar(5),
+    "language" varchar(6),
     "preferences" long DEFAULT NULL,
     CONSTRAINT "users_username_key" UNIQUE ("username", "mail_host")
 );
@@ -186,7 +186,7 @@ CREATE INDEX "cache_messages_expires_idx" ON "cache_messages" ("expires");
 CREATE TABLE "dictionary" (
     "user_id" integer DEFAULT NULL
         REFERENCES "users" ("user_id") ON DELETE CASCADE,
-    "language" varchar(5) NOT NULL,
+    "language" varchar(6) NOT NULL,
     "data" long DEFAULT NULL,
     CONSTRAINT "dictionary_user_id_lang_key" UNIQUE ("user_id", "language")
 );

--- a/SQL/postgres.initial.sql
+++ b/SQL/postgres.initial.sql
@@ -24,7 +24,7 @@ CREATE TABLE users (
     last_login timestamp with time zone DEFAULT NULL,
     failed_login timestamp with time zone DEFAULT NULL,
     failed_login_counter integer DEFAULT NULL,
-    "language" varchar(5),
+    "language" varchar(6),
     preferences text DEFAULT ''::text NOT NULL,
     CONSTRAINT users_username_key UNIQUE (username, mail_host)
 );
@@ -246,7 +246,7 @@ CREATE INDEX cache_messages_expires_idx ON cache_messages (expires);
 CREATE TABLE dictionary (
     user_id integer DEFAULT NULL
         REFERENCES users (user_id) ON DELETE CASCADE ON UPDATE CASCADE,
-   "language" varchar(5) NOT NULL,
+   "language" varchar(6) NOT NULL,
     data text NOT NULL,
     CONSTRAINT dictionary_user_id_language_key UNIQUE (user_id, "language")
 );

--- a/SQL/sqlite.initial.sql
+++ b/SQL/sqlite.initial.sql
@@ -74,7 +74,7 @@ CREATE TABLE users (
   last_login datetime DEFAULT NULL,
   failed_login datetime DEFAULT NULL,
   failed_login_counter integer DEFAULT NULL,
-  language varchar(5),
+  language varchar(6),
   preferences text NOT NULL default ''
 );
 
@@ -99,7 +99,7 @@ CREATE INDEX ix_session_changed ON session (changed);
 
 CREATE TABLE dictionary (
     user_id integer DEFAULT NULL,
-   "language" varchar(5) NOT NULL,
+   "language" varchar(6) NOT NULL,
     data text NOT NULL
 );
 


### PR DESCRIPTION
I got SQL error whilst trying to set Spanish(Latin America) language in the user preferences. It boils down to the width of the language field that is 5 in all schemas thus isn't big enough to accomodate the code 'es-419'.
The one approach is to remove es-419 at all from here:
```
[drrtuy@intmacsta roundcubemail]$ ag -a 'es_419'
program/localization/index.inc
99:  'es_419' => 'Spanish (Latin America)',
```

Another is to resize language field in all schemas. I picked the second approach b/c I need this language. 
I need to alter the field type to varchar(6) that seems to be relatively lightweight operation in all supported databases also and  thus I have a question on schema migration files naming. How should I name incremental migration files?
