### PR TITLE
add expand/collapse all treelist methods

### DIFF
--- a/program/js/app.js
+++ b/program/js/app.js
@@ -1776,6 +1776,9 @@ function rcube_webmail()
 
   this.folder_collapsed = function(node)
   {
+    if (this.folder_collapsed_timer)
+      clearTimeout(this.folder_collapsed_timer);
+
     var prefname = this.env.task == 'addressbook' ? 'collapsed_abooks' : 'collapsed_folders',
       old = this.env[prefname];
 
@@ -1794,7 +1797,7 @@ function rcube_webmail()
 
     if (!this.drag_active) {
       if (old !== this.env[prefname])
-        this.command('save-pref', { name: prefname, value: this.env[prefname] });
+        this.folder_collapsed_timer = setTimeout(function(){ ref.command('save-pref', { name: prefname, value: ref.env[prefname] }); }, 10)
 
       if (this.env.unread_counts)
         this.set_unread_count_display(node.id, false);

--- a/program/js/treelist.js
+++ b/program/js/treelist.js
@@ -81,6 +81,8 @@ function rcube_treelist_widget(node, p)
   this.container = container;
   this.expand = expand;
   this.collapse = collapse;
+  this.expand_all = expand_all;
+  this.collapse_all = collapse_all;
   this.select = select;
   this.render = render;
   this.reset = reset;
@@ -210,10 +212,8 @@ function rcube_treelist_widget(node, p)
     });
   }
 
-  /////// private methods
-
   /**
-   * Collaps a the node with the given ID
+   * Collapse a the node with the given ID
    */
   function collapse(id, recursive, set)
   {
@@ -251,6 +251,27 @@ function rcube_treelist_widget(node, p)
     if (node = indexbyid[id]) {
       collapse(id, recursive, !node.collapsed);
     }
+  }
+
+  /**
+   * Collapse all expanded nodes
+   */
+  function collapse_all(set)
+  {
+    var collapsed = typeof set == 'undefined' || set;
+    $.each(indexbyid, function(id, data) {
+      if (data.children.length > 0 && data.collapsed != collapsed) {
+        collapse(id, false, collapsed);
+      }
+    });
+  }
+
+  /**
+   * Expand all collapsed nodes
+   */
+  function expand_all()
+  {
+    collapse_all(false);
   }
 
   /**

--- a/program/js/treelist.js
+++ b/program/js/treelist.js
@@ -256,12 +256,11 @@ function rcube_treelist_widget(node, p)
   /**
    * Collapse all expanded nodes
    */
-  function collapse_all(set)
+  function collapse_all()
   {
-    var collapsed = typeof set == 'undefined' || set;
     $.each(indexbyid, function(id, data) {
-      if (data.children.length > 0 && data.collapsed != collapsed) {
-        collapse(id, false, collapsed);
+      if (data.children.length > 0 && !data.collapsed) {
+        collapse(id);
       }
     });
   }
@@ -271,7 +270,11 @@ function rcube_treelist_widget(node, p)
    */
   function expand_all()
   {
-    collapse_all(false);
+    $.each(indexbyid, function(id, data) {
+      if (data.children.length > 0 && data.collapsed) {
+        collapse(id, false, false);
+      }
+    });
   }
 
   /**


### PR DESCRIPTION
add methods to the rcube_treelist_widget JS class to support expanding/collapsing all nodes in single action

note: I removed the "private methods" as it makes no sense to me, not all the method are private and similar comments are not used in other JS classes