### PR TITLE
fix deleting original message in some markasjunk drivers

### DIFF
--- a/plugins/markasjunk/drivers/edit_headers.php
+++ b/plugins/markasjunk/drivers/edit_headers.php
@@ -56,7 +56,7 @@ class markasjunk_edit_headers
             $saved = $rcube->storage->save_message($dst_mbox, $raw_message);
 
             if ($saved !== false) {
-                $rcube->output->command('rcmail_markasjunk_move', null, $uid);
+                $rcube->output->command('rcmail_markasjunk_move', null, array($uid));
                 array_push($new_uids, $saved);
             }
         }

--- a/plugins/markasjunk/drivers/sa_detach.php
+++ b/plugins/markasjunk/drivers/sa_detach.php
@@ -47,7 +47,7 @@ class markasjunk_sa_detach
                         $orig_message_raw = $message->get_part_body($part->mime_id);
 
                         if ($saved = $storage->save_message($dst_mbox, $orig_message_raw)) {
-                            $rcube->output->command('rcmail_markasjunk_move', null, $uid);
+                            $rcube->output->command('rcmail_markasjunk_move', null, array($uid));
                             array_push($new_uids, $saved);
                         }
                     }


### PR DESCRIPTION
fix small bug in a couple of markasjunk drivers where original message was not deleted because the UID was not passed to the JS correctly. Its something from before markasjunk2 was merged.