### PR TITLE
Fix PHP 7.4 deprecation: implode() wrong parameter order

### DIFF
--- a/bin/installto.sh
+++ b/bin/installto.sh
@@ -130,7 +130,7 @@ if (strtolower($input) == 'y') {
     }
 
     if (!empty($adds)) {
-        echo implode($adds, "\n") . "\n\n";
+        echo implode("\n", $adds) . "\n\n";
     }
 
     echo "Running update script at target...\n";

--- a/plugins/enigma/lib/enigma_ui.php
+++ b/plugins/enigma/lib/enigma_ui.php
@@ -752,7 +752,7 @@ class enigma_ui
         }
 
         $table->add('title', html::label('key-name', rcube::Q($this->enigma->gettext('newkeyident'))));
-        $table->add(null, html::tag('ul', 'proplist', implode($identities, "\n")));
+        $table->add(null, html::tag('ul', 'proplist', implode("\n", $identities)));
 
         // Key size
         $select = new html_select(array('name' => 'size', 'id' => 'key-size'));

--- a/program/lib/Roundcube/rcube_contacts.php
+++ b/program/lib/Roundcube/rcube_contacts.php
@@ -357,7 +357,7 @@ class rcube_contacts extends rcube_addressbook
         if (!empty($post_search) || !empty($required)) {
             $ids = array(0);
             // build key name regexp
-            $regexp = '/^(' . implode(array_keys($post_search), '|') . ')(?:.*)$/';
+            $regexp = '/^(' . implode('|', array_keys($post_search)) . ')(?:.*)$/';
             // use initial WHERE clause, to limit records number if possible
             if (!empty($where))
                 $this->set_search_set($where);

--- a/program/lib/Roundcube/rcube_db.php
+++ b/program/lib/Roundcube/rcube_db.php
@@ -914,7 +914,7 @@ class rcube_db
             $name[] = $start . $elem . $end;
         }
 
-        return implode($name, '.');
+        return implode('.', $name);
     }
 
     /**

--- a/program/steps/addressbook/search.inc
+++ b/program/steps/addressbook/search.inc
@@ -207,8 +207,8 @@ function rcmail_contact_search()
 
     // search request ID
     $search_request = md5('addr'
-        .(is_array($fields) ? implode($fields, ',') : $fields)
-        .(is_array($search) ? implode($search, ',') : $search));
+        .(is_array($fields) ? implode(',', $fields) : $fields)
+        .(is_array($search) ? implode(',', $search) : $search));
 
     // save search settings in session
     $_SESSION['search'][$search_request] = $search_set;

--- a/program/steps/mail/sendmail.inc
+++ b/program/steps/mail/sendmail.inc
@@ -82,7 +82,7 @@ if ($isHtml) {
     }
 
     // append doctype and html/body wrappers
-    $bstyle       = !empty($bstyle) ? (" style='" . implode($bstyle, '; ') . "'") : '';
+    $bstyle       = !empty($bstyle) ? (" style='" . implode('; ', $bstyle) . "'") : '';
     $message_body = '<html><head>'
         . '<meta http-equiv="Content-Type" content="text/html; charset='
         . ($message_charset ?: RCUBE_CHARSET) . '" /></head>'


### PR DESCRIPTION
It has been [deprecated in PHP 7.4](https://wiki.php.net/rfc/deprecations_php_7_4#implode_parameter_order_mix).

Such as PHP deprecated:  implode(): Passing glue string after array is deprecated. Swap the parameters in `/var/www/roundcubemail/program/lib/Roundcube/rcube_db.php` on line 917

NOTE: This PR should probably also be applied to other branches that are still under maintain since formally speaking this is a wrong usage of `implode()` imo.