### PR TITLE
Fix PHP 7.4 deprecation: array/string curly braces access

### DIFF
--- a/program/lib/Roundcube/rcube_tnef_decoder.php
+++ b/program/lib/Roundcube/rcube_tnef_decoder.php
@@ -493,21 +493,21 @@ class rcube_tnef_decoder
         $length_preload = strlen($preload);
 
         for ($cnt = 0; $cnt < $length_preload; $cnt++) {
-            $uncomp .= $preload{$cnt};
+            $uncomp .= $preload[$cnt];
             ++$out;
         }
 
         while ($out < ($size + $length_preload)) {
             if (($flag_count++ % 8) == 0) {
-                $flags = ord($data{$in++});
+                $flags = ord($data[$in++]);
             }
             else {
                 $flags = $flags >> 1;
             }
 
             if (($flags & 1) != 0) {
-                $offset = ord($data{$in++});
-                $length = ord($data{$in++});
+                $offset = ord($data[$in++]);
+                $length = ord($data[$in++]);
                 $offset = ($offset << 4) | ($length >> 4);
                 $length = ($length & 0xF) + 2;
                 $offset = ((int)($out / 4096)) * 4096 + $offset;
@@ -524,7 +524,7 @@ class rcube_tnef_decoder
                 }
             }
             else {
-                $uncomp .= $data{$in++};
+                $uncomp .= $data[$in++];
                 ++$out;
             }
         }


### PR DESCRIPTION
Deprecated: Array and string offset access syntax with curly braces is deprecated

Hopefully these are all (or most) of them:
```
[Clover@Clover-NB rc]$ rg -tphp "(\\$|->|::)[A-Za-z0-9_]+\{"
program\lib\Roundcube\rcube_tnef_decoder.php:496:            $uncomp .= $preload{$cnt};
program\lib\Roundcube\rcube_tnef_decoder.php:502:                $flags = ord($data{$in++});
program\lib\Roundcube\rcube_tnef_decoder.php:509:                $offset = ord($data{$in++});
program\lib\Roundcube\rcube_tnef_decoder.php:510:                $length = ord($data{$in++});
program\lib\Roundcube\rcube_tnef_decoder.php:527:                $uncomp .= $data{$in++};
```

https://github.com/php/php-src/blob/0e6e2297fcb27103cc5d550ee8434680ff1e879e/UPGRADING#L356-L357
