### PR TITLE
a few tweaks to elastic popup menus

### DIFF
--- a/skins/elastic/styles/widgets/menu.less
+++ b/skins/elastic/styles/widgets/menu.less
@@ -24,6 +24,10 @@
             &:extend(.font-icon-class);
         }
 
+        &:not(.no-icon):before {
+            content: "\00a0"; // blank place holder
+        }
+
         &:hover,
         &:focus {
             outline: 0;
@@ -262,11 +266,51 @@
                     margin-right: .5rem !important;
                     float: left !important;
                     width: 1.18em !important;
+                    min-width: 1.18em;
                 }
 
                 &:not(.disabled):hover {
                     color: @color-menu-hover;
                     background-color: @color-menu-hover-background;
+                }
+
+                &:after {
+                    &:extend(.font-icon-class);
+                    float: right;
+                    color: @color-black-shade-text;
+                    font-size: .9em;
+                }
+
+                &:only-child {
+                    display: flex;
+
+                    > span {
+                        flex-grow: 1;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                    }
+                }
+
+                &[aria-haspopup] {
+                    position: realtive;
+
+                    &:after {
+                        min-width: 1.18em;
+                        content: @fa-var-chevron-right;
+
+                        html.layout-small & {
+                            margin: 0 .2em;
+                        }
+                    }
+
+                    &.dropdown:after {
+                        color: @color-list;
+                        margin: 0 .5em !important;
+                    }
+
+                    &:hover:after {
+                        color: @color-menu-hover;
+                    }
                 }
             }
 
@@ -302,32 +346,6 @@
                 span.inner {
                     display: none;
                 }
-            }
-        }
-
-        a[aria-haspopup] {
-            position: realtive;
-
-            &:after {
-                &:extend(.font-icon-class);
-                content: @fa-var-chevron-right;
-                float: right;
-                margin: 0;
-                color: @color-black-shade-text;
-                font-size: .9em;
-
-                html.layout-small & {
-                    margin: 0 .2em;
-                }
-            }
-
-            &.dropdown:after {
-                margin: 0 .5em !important;
-                color: @color-list;
-            }
-
-            &:hover:after {
-                color: @color-menu-hover;
             }
         }
     }

--- a/skins/elastic/styles/widgets/menu.less
+++ b/skins/elastic/styles/widgets/menu.less
@@ -348,6 +348,12 @@
                 }
             }
         }
+
+        &.no-icon a:before {
+            width: 0 !important;
+            min-width: 0 !important;
+            content: "" !important;
+        }
     }
 }
 


### PR DESCRIPTION
There are a couple of edge cases with the popup menus that I have tried to improve on with this PR. This is based on some CSS from the Contextmenu plugin.

1) If you have a new menu item which does not have an icon then it does not align correctly. For this I have added a blank placeholder icon
2) Wrapping of long menu items with popups. Currently the popup chevron disappears and the height of the item is increased. For this I reworking the existing CSS a little to prevent the line wrapping
3) I added min-widths to the before/after to prevent browsers from squashing them when there is long text and messing up the alignment

One extra thing I did which I think is more personal choice than anything else, there is a blank placeholder on the right (for the chevron) as well as the left now. I think it looks nicer than having the text go right up to the right hand edge but I'm happy to remove it if having the maximum possible space for text is more important

I attach a before and after image for reference.

![menu](https://user-images.githubusercontent.com/88682/64059917-2ca85e80-cbbd-11e9-8a8d-b9a586379021.png)
