### PR TITLE
fix border radius in popovers on small screens

### DIFF
--- a/skins/elastic/styles/widgets/dialogs.less
+++ b/skins/elastic/styles/widgets/dialogs.less
@@ -55,13 +55,15 @@
         display: none;
     }
 
-    .listing {
-        li:first-child {
-            border-radius: .25rem .25rem 0 0;
-        }
+    @media screen and (min-width: (@screen-width-small + 1px)) {
+        .listing {
+            li:first-child {
+                border-radius: .25rem .25rem 0 0;
+            }
 
-        li:last-child {
-            border-radius: 0 0 .25rem .25rem;
+            li:last-child {
+                border-radius: 0 0 .25rem .25rem;
+            }
         }
     }
 }


### PR DESCRIPTION
on small and phone screens there is a border radius on the first/last menu items in popovermenus. I think this is to fit in with the rounded corners on the popovers in large screens but on small screens they are square. the problem does not appear on the mail screen because the first menu item is hidden. this screenshot is from the compose screen:
![Untitled-1](https://user-images.githubusercontent.com/88682/64231765-64c6de80-cee8-11e9-8fd2-0d8518649604.png)
