### PR TITLE
Adjust the #mainscreen bottom margin

### DIFF
--- a/skins/larry/styles.css
+++ b/skins/larry/styles.css
@@ -967,7 +967,7 @@ a.iconlink.upload {
 	top: 88px;
 	left: 10px;
 	right: 10px;
-	bottom: 20px;
+	bottom: 10px;
 }
 
 #mainscreencontent {


### PR DESCRIPTION
This PR decreases the bottom margin from 20px to 10px, so the content area can be rendered slightly higher. The layout still looks good, because now the bottom margin matches the left and right margin.

I am aware that this is an opinionated change, so feel free to close the PR if you do not agree. 😄 