### PR TITLE
rewrite skin_logo config

### DIFF
--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -393,13 +393,35 @@ $config['support_url'] = '';
 // replace Roundcube logo with this image
 // specify an URL relative to the document root of this Roundcube installation
 // an array can be used to specify different logos for specific template files
-// '*' for default logo
-// ':favicon' for favicon
-// ':print' for logo on all print templates (e.g. messageprint, contactprint)
-// ':small' for small screen logo in Elastic
-// different logos can be specified for different skins by prefixing the skin name to the array key
-// config applied in order: <skin>:<template>, <skin>:*, <template>, *
-// for example array("*" => "/images/roundcube_logo.png", "messageprint" => "/images/roundcube_logo_print.png", "elastic:*" => "/images/logo.png")
+// the array key specifies the template(s) the logo should be applied to while the
+// value should be the relative URL of the image.
+//
+// the array key is made up of (up to) 3 parts:
+// the skin name (optional)
+// the template name (or * for all templates)
+// the logo type (optional) the type attribute is used for logos used on multiple templates
+//   the available types include '[favicon]' for favicon, '[print]' for logo on all print
+//   templates (e.g. messageprint, contactprint) and '[small]' for small screen logo in supported skins
+//
+// config applied in order: <skin>:<template>, <skin>:<template>, <skin>:*, <template>, *
+/*
+ * example config for skin_logo
+ *
+   array(
+     // show the image /images/logo_login_small.png for the Login screen in the Elastic skin on small screens
+     "elastic:login[small]" => "/images/logo_login_small.png",
+     // show the image /images/logo_login.png for the Login screen in the Elastic skin
+     "elastic:login" => "/images/logo_login.png",
+     // show the image /images/logo_small.png in the Elastic skin
+     "elastic[small]" => "/images/logo_small.png",
+     // show the image /images/larry.png in the Larry skin
+     "larry:*" => "/images/larry.png",
+     // show the image /images/logo_login.png on the login template in all skins
+     "login" => "/images/logo_login.png",
+     // show the image /images/logo_print.png for all print type logos in all skins
+     "[print]" => "/images/logo_print.png",
+   );
+*/
 $config['skin_logo'] = null;
 
 // automatically create a new Roundcube user when log-in the first time.

--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -413,7 +413,7 @@ $config['support_url'] = '';
      // show the image /images/logo_login.png for the Login screen in the Elastic skin
      "elastic:login" => "/images/logo_login.png",
      // show the image /images/logo_small.png in the Elastic skin
-     "elastic[small]" => "/images/logo_small.png",
+     "elastic:*[small]" => "/images/logo_small.png",
      // show the image /images/larry.png in the Larry skin
      "larry:*" => "/images/larry.png",
      // show the image /images/logo_login.png on the login template in all skins

--- a/program/include/rcmail_output_html.php
+++ b/program/include/rcmail_output_html.php
@@ -1353,7 +1353,7 @@ EOF;
                 else if ($object == 'logo') {
                     $attrib += array('alt' => $this->xml_command(array('', 'object', 'name="productname"')));
 
-                    if (!empty($attrib['type']) && ($template_logo = $this->get_template_logo(':' . $attrib['type'], true)) !== null) {
+                    if (!empty($attrib['type']) && ($template_logo = $this->get_template_logo(null, $attrib['type'], true)) !== null) {
                         $attrib['src'] = $template_logo;
                     }
                     else if (($template_logo = $this->get_template_logo()) !== null) {
@@ -1363,7 +1363,7 @@ EOF;
                     // process alternative logos (eg for Elastic small screen)
                     foreach ($attrib as $key => $value) {
                         if (preg_match('/data-src-(.*)/', $key, $matches)) {
-                            if (($template_logo = $this->get_template_logo(':' . $matches[1], true)) !== null) {
+                            if (($template_logo = $this->get_template_logo(null, $matches[1], true)) !== null) {
                                 $attrib[$key] = $template_logo;
                             }
 
@@ -1447,7 +1447,7 @@ EOF;
 
                             // special handling for favicon
                             if ($object == 'links' && $name == 'shortcut icon' && empty($args[$param])) {
-                                if ($href = $this->get_template_logo(':favicon', true)) {
+                                if ($href = $this->get_template_logo(null, 'favicon', true)) {
                                     $args[$param] = $href;
                                 }
                                 else if ($href = $this->config->get('favicon', '/images/favicon.ico')) {
@@ -2449,11 +2449,13 @@ EOF;
      *
      * @param string  $name     Name of the logo to check for
      *                          default is current template
+     * @param string  $type     Type of the logo to check for (e.g. 'print' or 'small')
+     *                          default is null (no special type)
      * @param boolean $strict   True if logo should only be returned for specific template
      *
      * @return string image URL
      */
-    protected function get_template_logo($name = null, $strict = false)
+    protected function get_template_logo($name = null, $type = null, $strict = false)
     {
         $template_logo = null;
 
@@ -2463,13 +2465,26 @@ EOF;
         }
 
         $template_names = array(
+            $this->skin_name . ':' . $name . '[' . $type . ']',
             $this->skin_name . ':' . $name,
+            $this->skin_name . ':*[' . $type . ']',
             $this->skin_name . ':*',
+            $this->skin_name . '[' . $type . ']',
+            '*:' . $name . '[' . $type . ']',
+            '*:' . $name,
+            $name . '[' . $type . ']',
             $name,
+            '*[' . $type . ']',
             '*',
+            '[' . $type . ']',
         );
 
-        // If strict matching then remove wildcard options
+        // If no type is specified then remove those options from the list
+        if (empty($type)) {
+            $template_names = preg_grep("/\\[\]$/", $template_names, PREG_GREP_INVERT);
+        }
+
+        // If strict matching then remove wild card options
         if ($strict) {
             $template_names = preg_grep("/\*$/", $template_names, PREG_GREP_INVERT);
         }

--- a/program/include/rcmail_output_html.php
+++ b/program/include/rcmail_output_html.php
@@ -1353,7 +1353,7 @@ EOF;
                 else if ($object == 'logo') {
                     $attrib += array('alt' => $this->xml_command(array('', 'object', 'name="productname"')));
 
-                    if (!empty($attrib['type']) && ($template_logo = $this->get_template_logo(null, $attrib['type'], true)) !== null) {
+                    if (!empty($attrib['type']) && ($template_logo = $this->get_template_logo($attrib['type'])) !== null) {
                         $attrib['src'] = $template_logo;
                     }
                     else if (($template_logo = $this->get_template_logo()) !== null) {
@@ -1363,7 +1363,7 @@ EOF;
                     // process alternative logos (eg for Elastic small screen)
                     foreach ($attrib as $key => $value) {
                         if (preg_match('/data-src-(.*)/', $key, $matches)) {
-                            if (($template_logo = $this->get_template_logo(null, $matches[1], true)) !== null) {
+                            if (($template_logo = $this->get_template_logo($matches[1])) !== null) {
                                 $attrib[$key] = $template_logo;
                             }
 
@@ -1447,7 +1447,7 @@ EOF;
 
                             // special handling for favicon
                             if ($object == 'links' && $name == 'shortcut icon' && empty($args[$param])) {
-                                if ($href = $this->get_template_logo(null, 'favicon', true)) {
+                                if ($href = $this->get_template_logo('favicon')) {
                                     $args[$param] = $href;
                                 }
                                 else if ($href = $this->config->get('favicon', '/images/favicon.ico')) {
@@ -2447,50 +2447,43 @@ EOF;
     /**
      * Get logo URL for current template based on skin_logo config option
      *
-     * @param string  $name     Name of the logo to check for
-     *                          default is current template
      * @param string  $type     Type of the logo to check for (e.g. 'print' or 'small')
      *                          default is null (no special type)
-     * @param boolean $strict   True if logo should only be returned for specific template
      *
      * @return string image URL
      */
-    protected function get_template_logo($name = null, $type = null, $strict = false)
+    protected function get_template_logo($type = null)
     {
         $template_logo = null;
 
-        // Use current template if none provided
-        if (!$name) {
-            $name = $this->template_name;
-        }
-
-        $template_names = array(
-            $this->skin_name . ':' . $name . '[' . $type . ']',
-            $this->skin_name . ':' . $name,
-            $this->skin_name . ':*[' . $type . ']',
-            $this->skin_name . ':*',
-            $this->skin_name . '[' . $type . ']',
-            '*:' . $name . '[' . $type . ']',
-            '*:' . $name,
-            $name . '[' . $type . ']',
-            $name,
-            '*[' . $type . ']',
-            '*',
-            '[' . $type . ']',
-        );
-
-        // If no type is specified then remove those options from the list
-        if (empty($type)) {
-            $template_names = preg_grep("/\\[\]$/", $template_names, PREG_GREP_INVERT);
-        }
-
-        // If strict matching then remove wild card options
-        if ($strict) {
-            $template_names = preg_grep("/\*$/", $template_names, PREG_GREP_INVERT);
-        }
-
         if ($logo = $this->config->get('skin_logo')) {
             if (is_array($logo)) {
+                $template_names = array(
+                    $this->skin_name . ':' . $this->template_name . '[' . $type . ']',
+                    $this->skin_name . ':' . $this->template_name,
+                    $this->skin_name . ':*[' . $type . ']',
+                    $this->skin_name . ':[' . $type . ']',
+                    $this->skin_name . ':*',
+                    '*:' . $this->template_name . '[' . $type . ']',
+                    '*:' . $this->template_name,
+                    '*:*[' . $type . ']',
+                    '*:[' . $type . ']',
+                    $this->template_name . '[' . $type . ']',
+                    $this->template_name,
+                    '*[' . $type . ']',
+                    '[' . $type . ']',
+                    '*',
+                );
+
+                if (!empty($type)) {
+                    // Use strict matching, remove wild card options
+                    $template_names = preg_grep("/\*$/", $template_names, PREG_GREP_INVERT);
+                }
+                else {
+                    // No type set so remove those options from the list
+                    $template_names = preg_grep("/\\[\]$/", $template_names, PREG_GREP_INVERT);
+                }
+
                 foreach ($template_names as $key) {
                     if (isset($logo[$key])) {
                         $template_logo = $logo[$key];

--- a/tests/Rcmail/OutputHtml.php
+++ b/tests/Rcmail/OutputHtml.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Test class to test rcmail_output_html class
+ *
+ * @package Tests
+ */
+class Rcmail_OutputHtml extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Test get_template_logo()
+     */
+    function test_logo()
+    {
+        $rcmail            = rcube::get_instance();
+        $output            = new rcmail_output_html();
+        $reflection        = new ReflectionClass('rcmail_output_html');
+        $set_skin          = $reflection->getProperty('skin_name');
+        $set_template      = $reflection->getProperty('template_name');
+        $get_template_logo = $reflection->getMethod('get_template_logo');
+
+        $set_skin->setAccessible(true);
+        $set_template->setAccessible(true);
+        $get_template_logo->setAccessible(true);
+
+        $set_skin->setValue($output, 'elastic');
+
+        $rcmail->config->set('skin_logo', 'img00');
+
+        $set_template->setValue($output, 'login');
+        $result = $get_template_logo->invokeArgs($output, array());
+        $this->assertSame('img00', $result);
+
+        $set_template->setValue($output, 'mail');
+        $result = $get_template_logo->invokeArgs($output, array('small'));
+        $this->assertSame('img00', $result);
+
+        $rcmail->config->set('skin_logo', array(
+             "elastic:login[small]" => "img01",
+             "elastic:login"        => "img02",
+             "elastic:*[small]"     => "img03",
+             "larry:*"              => "img04",
+             "*:login[small]"       => "img05",
+             "*:login"              => "img06",
+             "*[print]"             => "img07",
+             "*"                    => "img08",
+           ));
+
+        $set_template->setValue($output, 'login');
+        $result = $get_template_logo->invokeArgs($output, array('small'));
+        $this->assertSame('img01', $result);
+
+        $set_template->setValue($output, 'login');
+        $result = $get_template_logo->invokeArgs($output, array());
+        $this->assertSame('img02', $result);
+
+        $set_template->setValue($output, 'mail');
+        $result = $get_template_logo->invokeArgs($output, array('small'));
+        $this->assertSame('img03', $result);
+
+        $set_template->setValue($output, 'mail');
+        $result = $get_template_logo->invokeArgs($output, array());
+        $this->assertSame('img08', $result);
+
+        $set_template->setValue($output, 'mail');
+        $result = $get_template_logo->invokeArgs($output, array('small'));
+        $this->assertSame('img03', $result);
+
+        $set_template->setValue($output, '_test_');
+        $result = $get_template_logo->invokeArgs($output, array());
+        $this->assertSame('img08', $result);
+
+        $set_skin->setValue($output, 'larry');
+
+        $set_template->setValue($output, 'login');
+        $result = $get_template_logo->invokeArgs($output, array('small'));
+        $this->assertSame('img05', $result);
+
+        $set_template->setValue($output, 'login');
+        $result = $get_template_logo->invokeArgs($output, array());
+        $this->assertSame('img04', $result);
+
+        $set_template->setValue($output, '_test_');
+        $result = $get_template_logo->invokeArgs($output, array());
+        $this->assertSame('img04', $result);
+
+        $set_skin->setValue($output, '_test_');
+
+        $set_template->setValue($output, 'login');
+        $result = $get_template_logo->invokeArgs($output, array('small'));
+        $this->assertSame('img05', $result);
+
+        $set_template->setValue($output, 'login');
+        $result = $get_template_logo->invokeArgs($output, array());
+        $this->assertSame('img06', $result);
+
+        $set_template->setValue($output, '_test_');
+        $result = $get_template_logo->invokeArgs($output, array('print'));
+        $this->assertSame('img07', $result);
+
+        $set_template->setValue($output, '_test_');
+        $result = $get_template_logo->invokeArgs($output, array());
+        $this->assertSame('img08', $result);
+
+        $rcmail->config->set('skin_logo', array(
+             "elastic:login[small]" => "img09",
+             "elastic:login"        => "img10",
+             "larry:*"              => "img11",
+             "elastic[small]"       => "img12",
+             "login[small]"         => "img13",
+             "login"                => "img14",
+             "[print]"              => "img15",
+             "*"                    => "img16",
+           ));
+
+        $set_skin->setValue($output, 'elastic');
+
+        $set_template->setValue($output, 'login');
+        $result = $get_template_logo->invokeArgs($output, array('small'));
+        $this->assertSame('img09', $result);
+
+        $set_template->setValue($output, 'mail');
+        $result = $get_template_logo->invokeArgs($output, array('small'));
+        $this->assertSame(null, $result);
+
+        $set_skin->setValue($output, '_test_');
+
+        $set_template->setValue($output, 'login');
+        $result = $get_template_logo->invokeArgs($output, array('small'));
+        $this->assertSame('img13', $result);
+
+        $set_template->setValue($output, 'login');
+        $result = $get_template_logo->invokeArgs($output, array());
+        $this->assertSame('img14', $result);
+
+        $set_template->setValue($output, '_test_');
+        $result = $get_template_logo->invokeArgs($output, array('print'));
+        $this->assertSame('img15', $result);
+
+        $set_template->setValue($output, '_test_');
+        $result = $get_template_logo->invokeArgs($output, array('_test_'));
+        $this->assertSame(null, $result);
+
+        $set_template->setValue($output, '_test_');
+        $result = $get_template_logo->invokeArgs($output, array());
+        $this->assertSame('img16', $result);
+    }
+}

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -51,6 +51,7 @@
             <file>Framework/VCard.php</file>
             <file>Framework/Washtml.php</file>
             <file>MailFunc.php</file>
+            <file>Rcmail/OutputHtml.php</file>
             <file>Rcmail/Rcmail.php</file>
         </testsuite>
         <testsuite name="Plugins Tests">


### PR DESCRIPTION
for #6981 

various improvements to the skin_logo config option. the following keys are now supported:

```
skin:template[type]
skin:template
skin:*[type]
skin:*
skin[type]
*:template[type]
*:template
template[type]
template
*[type]
*
[type]
```

also I've improved the documentation in `defaults.inc.php`