### PR TITLE
add field mapping step to csv contact import

### DIFF
--- a/program/js/app.js
+++ b/program/js/app.js
@@ -1430,6 +1430,11 @@ function rcube_webmail()
         var dialog = $('<iframe>').attr('src', this.url('import', {_framed: 1, _target: this.env.source})),
           import_func = function(e) {
             var win = dialog[0].contentWindow,
+              form = null;
+
+            if (win.rcmail.gui_objects.importformmap)
+              form = win.rcmail.gui_objects.importformmap;
+            else
               form = win.rcmail.gui_objects.importform;
 
             if (form) {

--- a/program/lib/Roundcube/html.php
+++ b/program/lib/Roundcube/html.php
@@ -745,7 +745,7 @@ class html_table extends html
     protected $allowed = array('id','class','style','width','summary',
         'cellpadding','cellspacing','border');
 
-    private $header   = array();
+    private $header   = null;
     private $rows     = array();
     private $rowindex = 0;
     private $colindex = 0;
@@ -807,9 +807,14 @@ class html_table extends html
         }
 
         $cell = new stdClass;
-        $cell->attrib   = $attr;
-        $cell->content  = $cont;
-        $this->header[] = $cell;
+        $cell->attrib  = $attr;
+        $cell->content = $cont;
+
+        if (empty($this->header)) {
+            $this->header = new stdClass;
+        }
+
+        $this->header->cells[] = $cell;
     }
 
     /**
@@ -821,7 +826,7 @@ class html_table extends html
     public function remove_column($class)
     {
         // Remove the header
-        foreach ($this->header as $index => $header){
+        foreach ($this->header->cells as $index => $header){
             if ($header->attrib['class'] == $class){
                 unset($this->header[$index]);
                 break;
@@ -851,6 +856,24 @@ class html_table extends html
         $this->rows[$this->rowindex] = new stdClass;
         $this->rows[$this->rowindex]->attrib = $attr;
         $this->rows[$this->rowindex]->cells  = array();
+    }
+
+    /**
+     * Set header attributes
+     *
+     * @param array $attr  Row attributes
+     */
+    public function set_header_attribs($attr = array())
+    {
+        if (is_string($attr)) {
+            $attr = array('class' => $attr);
+        }
+
+        if (empty($this->header)) {
+            $this->header = new stdClass;
+        }
+
+        $this->header->attrib = $attr;
     }
 
     /**
@@ -915,10 +938,10 @@ class html_table extends html
         // include <thead>
         if (!empty($this->header)) {
             $rowcontent = '';
-            foreach ($this->header as $c => $col) {
+            foreach ($this->header->cells as $c => $col) {
                 $rowcontent .= self::tag($head_tagname, $col->attrib, $col->content);
             }
-            $thead = $this->tagname == 'table' ? self::tag('thead', null, self::tag('tr', null, $rowcontent, parent::$common_attrib)) :
+            $thead = $this->tagname == 'table' ? self::tag('thead', null, self::tag('tr', $this->header->attrib ?: null, $rowcontent, parent::$common_attrib)) :
                 self::tag($row_tagname, array('class' => 'thead'), $rowcontent, parent::$common_attrib);
         }
 

--- a/program/lib/Roundcube/rcube_csv2vcard.php
+++ b/program/lib/Roundcube/rcube_csv2vcard.php
@@ -312,9 +312,10 @@ class rcube_csv2vcard
     protected $gmail_label_map = array(
         'E-mail' => array(
             'Value' => array(
-                'home' => 'email:home',
-                'work' => 'email:work',
-                '*'    => 'email:other',
+                'home'  => 'email:home',
+                'work'  => 'email:work',
+                'other' => 'email:other',
+                ''      => 'email:other',
             ),
         ),
         'Phone' => array(
@@ -380,7 +381,6 @@ class rcube_csv2vcard
     protected $local_label_map = array();
     protected $vcards          = array();
     protected $map             = array();
-    protected $gmail_map       = array();
 
 
     /**
@@ -408,9 +408,12 @@ class rcube_csv2vcard
     /**
      * Import contacts from CSV file
      *
-     * @param string $csv Content of the CSV file
+     * @param  string  $csv     Content of the CSV file
+     * @param  boolean $dry_run Generate automatic field mapping
+     *
+     * @return array   Field mapping info (dry run only)
      */
-    public function import($csv)
+    public function import($csv, $dry_run = false, $skip_head = true)
     {
         // convert to UTF-8
         $head      = substr($csv, 0, 4096);
@@ -418,56 +421,78 @@ class rcube_csv2vcard
         $csv       = rcube_charset::convert($csv, $charset);
         $csv       = preg_replace(array('/^[\xFE\xFF]{2}/', '/^\xEF\xBB\xBF/', '/^\x00+/'), '', $csv); // also remove BOM
         $head      = '';
-        $prev_line = false;
 
-        $this->map       = array();
-        $this->gmail_map = array();
+        // Split CSV file into lines
+        $lines = rcube_utils::explode_quoted_string('[\r\n]+', $csv);
 
-        // Parse file
-        foreach (preg_split("/[\r\n]+/", $csv) as $line) {
-            if (!empty($prev_line)) {
-                $line = '"' . $line;
-            }
+        // Parse first 2 lines of file to identify fields
+        // 2 lines because for gmail CSV we need to get the value from the "Type" fields to identify which is which
+        if (empty($this->map)) {
+            $this->parse_header(array_slice($lines, 0, 2));
+        }
 
+        // Parse the fields
+        foreach ($lines as $n => $line) {
             $elements = $this->parse_line($line);
+
+            if ($dry_run) {
+                return array('source' => $elements, 'destination' => $this->map);
+            }
 
             if (empty($elements)) {
                 continue;
             }
 
-            // Parse header
-            if (empty($this->map)) {
-                $this->parse_header($elements);
-                if (empty($this->map)) {
-                    break;
-                }
-            }
-            // Parse data row
-            else {
-                // handle multiline elements (e.g. Gmail)
-                if (!empty($prev_line)) {
-                    $first = array_shift($elements);
-
-                    if ($first[0] == '"') {
-                        $prev_line[count($prev_line)-1] = '"' . $prev_line[count($prev_line)-1] . "\n" . substr($first, 1);
-                    }
-                    else {
-                        $prev_line[count($prev_line)-1] .= "\n" . $first;
-                    }
-
-                    $elements = array_merge($prev_line, $elements);
-                }
-
-                $last_element = $elements[count($elements)-1];
-                if (isset($last_element[0]) && $last_element[0] == '"') {
-                    $elements[count($elements)-1] = substr($last_element, 1);
-                    $prev_line = $elements;
-                    continue;
-                }
+            // first line is the headers so do not import unless explicitly set
+            if (!$skip_head || $n > 0) {
                 $this->csv_to_vcard($elements);
-                $prev_line = false;
             }
         }
+    }
+
+    /**
+     * Set field mapping info
+     *
+     * @param array Field mapping
+     */
+    public function set_map($elements)
+    {
+        // sanitize input
+        $elements = array_filter($elements, function($val) {
+                return in_array($val, $this->csv2vcard_map);
+            });
+
+        $this->map = $elements;
+    }
+
+    /**
+     * Set field mapping info
+     *
+     * @return array Array of vcard fields and localized names
+     */
+    public function get_fields()
+    {
+        // get all vcard fields
+        $fields = array_unique($this->csv2vcard_map);
+        $local_field_names = $this->local_label_map ?: $this->label_map;
+        $local_field_names = array_flip($local_field_names);
+
+        // translate with the local map
+        $map = array();
+        foreach ($fields as $csv => $vcard) {
+            if ($vcard == '_auto_') {
+                continue;
+            }
+
+            $map[$vcard] = $local_field_names[$csv];
+        }
+
+        // small fix to prevent "Groups" displaying as "Categories"
+        $map['groups'] = $local_field_names['groups'];
+
+        asort($map);
+
+        return $map;
     }
 
     /**
@@ -491,24 +516,10 @@ class rcube_csv2vcard
     {
         $line = trim($line);
         if (empty($line)) {
-            return null;
+            return array();
         }
 
-        $fields = rcube_utils::explode_quoted_string(',', $line);
-
-        // remove quotes if needed
-        if (!empty($fields)) {
-            foreach ($fields as $idx => $value) {
-                if (($len = strlen($value)) > 1 && $value[0] == '"' && $value[$len-1] == '"') {
-                    // remove surrounding quotes
-                    $value = substr($value, 1, -1);
-                    // replace doubled quotes inside the string with single quote
-                    $value = str_replace('""', '"', $value);
-
-                    $fields[$idx] = $value;
-                }
-            }
-        }
+        $fields = str_getcsv($line);
 
         return $fields;
     }
@@ -518,8 +529,15 @@ class rcube_csv2vcard
      *
      * @param array $elements Array of field names from a first line in CSV file
      */
-    protected function parse_header($elements)
+    protected function parse_header($lines)
     {
+        $elements = $this->parse_line($lines[0]);
+
+        if (count($lines) == 2) {
+            // first line of contents needed to properly identify fields in gmail CSV
+            $contents = $this->parse_line($lines[1]);
+        }
+
         $map1 = array();
         $map2 = array();
         $size = count($elements);
@@ -562,19 +580,22 @@ class rcube_csv2vcard
 
         $this->map = count($map1) >= count($map2) ? $map1 : $map2;
 
-        // support special Gmail format
-        foreach ($this->gmail_label_map as $key => $items) {
-            $num = 1;
-            while (($_key = "$key $num - Type") && ($found = array_search($_key, $elements)) !== false) {
-                $this->gmail_map["$key:$num"] = array('_key' => $key, '_idx' => $found);
-                foreach (array_keys($items) as $item_key) {
-                    $_key = "$key $num - $item_key";
-                    if (($found = array_search($_key, $elements)) !== false) {
-                        $this->gmail_map["$key:$num"][$item_key] = $found;
-                    }
-                }
+        if (!empty($contents)) {
+            foreach ($this->gmail_label_map as $key => $items) {
+                $num = 1;
+                while (($_key = "$key $num - Type") && ($found = array_search($_key, $elements)) !== false) {
+                    $type = $contents[$found];
+                    $type = preg_replace('/[^a-z]/', '', strtolower($type));
 
-                $num++;
+                    foreach ($items as $item_key => $vcard_fields) {
+                        $_key = "$key $num - $item_key";
+                        if (($found = array_search($_key, $elements)) !== false) {
+                            $this->map[$found] = $vcard_fields[$type];
+                        }
+                    }
+
+                    $num++;
+                }
             }
         }
     }
@@ -588,6 +609,9 @@ class rcube_csv2vcard
     {
         $contact = array();
         foreach ($this->map as $idx => $name) {
+            if ($name == '_auto_')
+                continue;
+
             $value = $data[$idx];
             if ($value !== null && $value !== '') {
                 if (!empty($contact[$name])) {
@@ -596,35 +620,6 @@ class rcube_csv2vcard
                 }
                 else {
                    $contact[$name] = $value;
-                }
-            }
-        }
-
-        // Gmail format support
-        foreach ($this->gmail_map as $idx => $item) {
-            $type = preg_replace('/[^a-z]/', '', strtolower($data[$item['_idx']]));
-            $key  = $item['_key'];
-
-            unset($item['_idx']);
-            unset($item['_key']);
-
-            foreach ($item as $item_key => $item_idx) {
-                $value = $data[$item_idx];
-                if ($value !== null && $value !== '') {
-                    foreach (array($type, '*') as $_type) {
-                        if (!empty($this->gmail_label_map[$key][$item_key][$_type])) {
-                            $data_idx = $this->gmail_label_map[$key][$item_key][$_type];
-                            $value    = explode(' ::: ', $value);
-
-                            if (!empty($contact[$data_idx])) {
-                                $contact[$data_idx]   = array_merge((array) $contact[$data_idx], $value);
-                            }
-                            else {
-                                $contact[$data_idx] = $value;
-                            }
-                            break;
-                        }
-                    }
                 }
             }
         }
@@ -643,12 +638,10 @@ class rcube_csv2vcard
             $contact['groups'] = str_replace(',', '', $contact['groups']);
             $contact['groups'] = str_replace(';', ',', $contact['groups']);
 
-            if (!empty($this->gmail_map)) {
-                // remove "* " added by GMail
-                $contact['groups'] = str_replace('* ', '', $contact['groups']);
-                // replace strange delimiter
-                $contact['groups'] = str_replace(' ::: ', ',', $contact['groups']);
-            }
+            // remove "* " added by GMail
+            $contact['groups'] = str_replace('* ', '', $contact['groups']);
+            // replace strange delimiter added by GMail
+            $contact['groups'] = str_replace(' ::: ', ',', $contact['groups']);
         }
 
         // Empty dates, e.g. "0/0/00", "0000-00-00 00:00:00"

--- a/program/localization/en_US/labels.inc
+++ b/program/localization/en_US/labels.inc
@@ -494,6 +494,9 @@ $labels['importgroups'] = 'Import group assignments';
 $labels['importgroupsall'] = 'All (create groups if necessary)';
 $labels['importgroupsexisting'] = 'Only for existing groups';
 $labels['importdesc'] = 'You can upload contacts from an existing address book.<br/>We currently support importing addresses from the <a href="https://en.wikipedia.org/wiki/VCard">vCard</a> or CSV (comma-separated) data format.';
+$labels['importmapdesc'] = 'Confirm the field mapping information below is correct before proceeding with CSV (comma-separated) data import.';
+$labels['fieldnotmapped'] = 'Field not mapped (do not import)';
+$labels['skipheader'] = 'Do not import first line (headers)';
 $labels['done'] = 'Done';
 
 // settings
@@ -677,6 +680,7 @@ $labels['installedplugins'] = 'Installed plugins';
 $labels['plugin'] = 'Plugin';
 $labels['version'] = 'Version';
 $labels['source'] = 'Source';
+$labels['destination'] = 'Destination';
 $labels['license'] = 'License';
 $labels['support'] = 'Get support';
 $labels['savedsearches'] = 'Saved searches';

--- a/program/localization/en_US/messages.inc
+++ b/program/localization/en_US/messages.inc
@@ -125,6 +125,7 @@ $messages['converting'] = 'Removing formatting...';
 $messages['messageopenerror'] = 'Could not load message from server.';
 $messages['filelinkerror'] = 'Attaching the file failed.';
 $messages['fileuploaderror'] = 'File upload failed.';
+$messages['csvfilemismatch'] = 'Upload of multiple CSV files with different fields is not supported.';
 $messages['filesizeerror'] = 'The uploaded file exceeds the maximum size of $size.';
 $messages['filecounterror'] = 'You can upload maximum $count files at once.';
 $messages['msgsizeerror'] = 'Failed to attach a file. Maximum size of a message ($size) exceeded.';

--- a/program/steps/addressbook/import.inc
+++ b/program/steps/addressbook/import.inc
@@ -20,14 +20,23 @@
 
 /** The import process **/
 
+const UPLOAD_ERR_CSV_FIELDS = 101;
+
 $importstep = 'rcmail_import_form';
 
-if (is_array($_FILES['_file'])) {
+if (is_array($_FILES['_file']) || is_array($_POST['_map'])) {
     $replace      = (bool)rcube_utils::get_input_value('_replace', rcube_utils::INPUT_GPC);
     $target       = rcube_utils::get_input_value('_target', rcube_utils::INPUT_GPC);
     $with_groups  = intval(rcube_utils::get_input_value('_groups', rcube_utils::INPUT_GPC));
 
+    // reload params for CSV field mapping screen
+    if (is_array($_POST['_map']) && $params = $_SESSION['contactcsvimport']['params']) {
+        list('replace' => $replace, 'target' => $target, 'with_groups' => $with_groups) = $params;
+    }
+
     $vcards       = array();
+    $csvs         = array();
+    $map          = array();
     $upload_error = null;
 
     $CONTACTS = $RCMAIL->get_address_book($target, true);
@@ -40,54 +49,102 @@ if (is_array($_FILES['_file'])) {
         $OUTPUT->show_message('addresswriterror', 'error');
     }
     else {
-        foreach ((array)$_FILES['_file']['tmp_name'] as $i => $filepath) {
-            // Process uploaded file if there is no error
-            $err = $_FILES['_file']['error'][$i];
-
-            if ($err) {
-                $upload_error = $err;
-            }
-            else {
-                $file_content = file_get_contents($filepath);
-
-                // let rcube_vcard do the hard work :-)
-                $vcard_o = new rcube_vcard();
-                $vcard_o->extend_fieldmap($CONTACTS->vcard_map);
-                $v_list = $vcard_o->import($file_content);
-
-                if (!empty($v_list)) {
-                    $vcards = array_merge($vcards, $v_list);
-                    continue;
-                }
-
-                // no vCards found, try CSV
-                $csv = new rcube_csv2vcard($_SESSION['language']);
-                $csv->import($file_content);
-                $v_list = $csv->export();
-
-                if (!empty($v_list)) {
-                    $vcards = array_merge($vcards, $v_list);
-                }
-            }
-        }
-    }
-
-    // no vcards detected
-    if (!count($vcards)) {
-        if ($upload_error == UPLOAD_ERR_INI_SIZE || $err == UPLOAD_ERR_FORM_SIZE) {
-            $size = $RCMAIL->show_bytes(rcube_utils::max_upload_size());
-            $OUTPUT->show_message('filesizeerror', 'error', array('size' => $size));
-        }
-        else if ($upload_error) {
-            $OUTPUT->show_message('fileuploaderror', 'error');
+        $filepaths = array();
+        if (is_array($_POST['_map'])) {
+            $filepaths = $_SESSION['contactcsvimport']['files'];
         }
         else {
-            $OUTPUT->show_message('importformaterror', 'error');
+            foreach ((array)$_FILES['_file']['tmp_name'] as $i => $filepath) {
+                // Process uploaded file if there is no error
+                $err = $_FILES['_file']['error'][$i];
+
+                if ($err) {
+                    $upload_error = $err;
+                }
+                else {
+                    $filepaths[] = $filepath;
+                }
+            }
         }
 
+        foreach ($filepaths as $filepath) {
+            $file_content = file_get_contents($filepath);
+
+            // let rcube_vcard do the hard work :-)
+            $vcard_o = new rcube_vcard();
+            $vcard_o->extend_fieldmap($CONTACTS->vcard_map);
+            $v_list = $vcard_o->import($file_content);
+
+            if (!empty($v_list)) {
+                $vcards = array_merge($vcards, $v_list);
+                continue;
+            }
+
+            // no vCards found, try CSV
+            $csv = new rcube_csv2vcard($_SESSION['language']);
+
+            if (is_array($_POST['_map'])) {
+                $skip_head = isset($_POST['_skip_header']);
+                $map       = rcube_utils::get_input_value('_map', rcube_utils::INPUT_GPC);
+                $map       = array_filter($map);
+
+                $csv->set_map($map);
+                $csv->import($file_content, false, $skip_head);
+
+                unlink($filepath);
+            }
+            else {
+                // save uploaded file for the real import in the next step
+                $temp_csv = rcube_utils::temp_filename('csvimpt');
+                if (move_uploaded_file($filepath, $temp_csv) && file_exists($temp_csv)) {
+                    $fields = $csv->get_fields();
+                    $last_map = $map;
+                    $map = $csv->import($file_content, true);
+
+                    // when multiple CSV files are uploaded check they all have the same structure
+                    if ($last_map && $last_map !== $map) {
+                        $csvs = array();
+                        $upload_error = UPLOAD_ERR_CSV_FIELDS;
+                        break;
+                    }
+
+                    $csvs[] = $temp_csv;
+                }
+                else {
+                    $upload_error = UPLOAD_ERR_CANT_WRITE;
+                }
+
+                continue;
+            }
+
+            $v_list = $csv->export();
+
+            if (!empty($v_list)) {
+                $vcards = array_merge($vcards, $v_list);
+            }
+        }
+    }
+
+    if (count($csvs) > 0) {
+        // csv import, show field mapping options
+        $importstep = 'rcmail_import_map';
+
+        $_SESSION['contactcsvimport']['files'] = $csvs;
+        $_SESSION['contactcsvimport']['params'] = array(
+                'replace'     => $replace,
+                'target'      => $target,
+                'with_groups' => $with_groups,
+                'fields'      => $fields
+            );
+
+        // Stored separately due to nested array limitations in session
+        $_SESSION['contactcsvimport']['map'] = $map;
+
+        // Re-enable the import button
         $OUTPUT->command('parent.import_state_set', 'error');
     }
-    else {
+    elseif (count($vcards) > 0) {
+        // import vcards
         $IMPORT_STATS = new stdClass;
         $IMPORT_STATS->names = array();
         $IMPORT_STATS->skipped_names = array();
@@ -172,8 +229,27 @@ if (is_array($_FILES['_file'])) {
         }
 
         $importstep = 'rcmail_import_confirm';
+        $_SESSION['contactcsvimport'] = null;
 
         $OUTPUT->command('parent.import_state_set', $IMPORT_STATS->inserted ? 'reload' : 'ok');
+    }
+    else {
+        // no data to import
+        if ($upload_error == UPLOAD_ERR_INI_SIZE || $err == UPLOAD_ERR_FORM_SIZE) {
+            $size = $RCMAIL->show_bytes(rcube_utils::max_upload_size());
+            $OUTPUT->show_message('filesizeerror', 'error', array('size' => $size));
+        }
+        else if ($upload_error == UPLOAD_ERR_CSV_FIELDS) {
+            $OUTPUT->show_message('csvfilemismatch', 'error');
+        }
+        else if ($upload_error) {
+            $OUTPUT->show_message('fileuploaderror', 'error');
+        }
+        else {
+            $OUTPUT->show_message('importformaterror', 'error');
+        }
+
+        $OUTPUT->command('parent.import_state_set', 'error');
     }
 }
 
@@ -268,6 +344,65 @@ function rcmail_import_form($attrib)
             'action'  => $RCMAIL->url('import'),
             'method'  => 'post',
             'enctype' => 'multipart/form-data') + $attrib,
+            $form);
+
+    // remove any info left over info from previous import attempts
+    $_SESSION['contactcsvimport'] = null;
+
+    return $out;
+}
+
+/**
+ * Render the field mapping page for the CSV import process
+ */
+function rcmail_import_map($attrib)
+{
+    global $RCMAIL, $OUTPUT;
+
+    $params = $_SESSION['contactcsvimport']['params'];
+
+    // hide groups field from list when group import disabled
+    if ($params['with_groups'] == 0) {
+        unset($params['fields']['groups']);
+    }
+
+    $fieldlist = new html_select(array('name' => '_map[]'));
+    $fieldlist->add($RCMAIL->gettext('fieldnotmapped'), '');
+    foreach ($params['fields'] as $id => $name) {
+        $fieldlist->add($name, $id);
+    }
+
+    $field_table = new html_table(array('cols' => 2) + $attrib);
+
+    if ($classes = $attrib['table-header-class']) {
+        $field_table->set_header_attribs($classes);
+    }
+
+    $field_table->add_header($attrib['table-col-source-class'] ?: null, $RCMAIL->gettext('source'));
+    $field_table->add_header($attrib['table-col-destination-class'] ?: null, $RCMAIL->gettext('destination'));
+
+    $map = $_SESSION['contactcsvimport']['map'];
+    foreach ($map['source'] as $i => $name) {
+        $field_table->add('title', html::label('rcmimportmap' . $i, rcube::Q($name)));
+        $field_table->add(null, $fieldlist->show(array_key_exists($i, $map['destination']) ? $map['destination'][$i] : '', array('id' => 'rcmimportmap' . $i)));
+    }
+
+    $form = '';
+    $form .= html::tag('input', array('type' => 'hidden', 'name' => '_unlock', 'value' => ''));
+
+    // show option to import data from first line of the file
+    $check_header = new html_checkbox(array('name' => '_skip_header', 'value' => 1, 'id' => 'rcmskipheader'));
+    $form .= html::p(null, html::label('rcmskipheader', $check_header->show(1) . $RCMAIL->gettext('skipheader')));
+
+    $form .= $field_table->show();
+
+    $attrib += array('id' => "rcmImportFormMap");
+    $OUTPUT->add_gui_object('importformmap', $attrib['id']);
+
+    $out = html::p(null, rcube::Q($RCMAIL->gettext('importmapdesc'), 'show'))
+        . $OUTPUT->form_tag(array(
+            'action'  => $RCMAIL->url('import'),
+            'method'  => 'post') + $attrib,
             $form);
 
     return $out;

--- a/skins/elastic/templates/contactimport.html
+++ b/skins/elastic/templates/contactimport.html
@@ -3,7 +3,7 @@
 <h1 class="voice"><roundcube:label name="addressbook" /> : <roundcube:label name="importcontacts" /></h1>
 
 <div class="formcontent">
-	<roundcube:object name="importstep" class="propform" />
+	<roundcube:object name="importstep" class="propform" table-header-class="form-group row d-none d-sm-flex" table-col-source-class="col-sm-4" table-col-destination-class="col-sm-8" />
 </div>
 
 <roundcube:include file="includes/footer.html" />


### PR DESCRIPTION
importing csv files into the address book can be a little tricky and there are few tickets from confused users asking about column names and things like that so I thought may be a good solution is add an intermediate step into the CSV file import process (does not effect vCards) which shows what Roundcube guessed for the field mapping and give the user the opportunity to change that mapping.

![Untitled-1](https://user-images.githubusercontent.com/88682/68992267-18413d00-0861-11ea-9ded-136f6cef74d7.png)

I'm not sure about my addition to Elastic ui.js I think there must be a better way to get the styling of the table header right, any hints?
