### PR TITLE
always update folder count after purge command

### DIFF
--- a/program/steps/mail/folders.inc
+++ b/program/steps/mail/folders.inc
@@ -59,6 +59,13 @@ else if ($RCMAIL->action == 'purge') {
 
         if ($success) {
             $OUTPUT->show_message('folderpurged', 'confirmation');
+            $OUTPUT->command('set_unread_count', $mbox, 0);
+            rcmail_set_unseen_count($mbox, 0);
+
+            // set trash folder state
+            if ($mbox === $trash_mbox) {
+                $OUTPUT->command('set_trash_count', 0);
+            }
 
             if (!empty($_REQUEST['_reload'])) {
                 $OUTPUT->set_env('messagecount', 0);
@@ -66,14 +73,7 @@ else if ($RCMAIL->action == 'purge') {
                 $OUTPUT->set_env('exists', 0);
                 $OUTPUT->command('message_list.clear');
                 $OUTPUT->command('set_rowcount', rcmail_get_messagecount_text(), $mbox);
-                $OUTPUT->command('set_unread_count', $mbox, 0);
                 $OUTPUT->command('set_quota', $RCMAIL->quota_content(null, $mbox));
-                rcmail_set_unseen_count($mbox, 0);
-
-                // set trash folder state
-                if ($mbox === $trash_mbox) {
-                    $OUTPUT->command('set_trash_count', 0);
-                }
             }
         }
         else {


### PR DESCRIPTION
Please set the folder message counts regardless of if the user is currently in the folder being purged or not. This is related to https://github.com/johndoh/roundcube-contextmenu/issues/120. The behavior of these 2 JS commands does not change depending on the current folder.