### PR TITLE
Update SMTP TLS/STARTTLS explanation in config.php

### DIFF
--- a/config/config.inc.php.sample
+++ b/config/config.inc.php.sample
@@ -40,8 +40,8 @@ $config['db_dsnw'] = 'mysql://roundcube:pass@localhost/roundcubemail';
 $config['default_host'] = 'localhost';
 
 // SMTP server host (for sending mails).
-// Enter hostname with prefix tls:// to use STARTTLS, or use
-// prefix ssl:// to use the deprecated SSL over SMTP (aka SMTPS)
+// Enter hostname with prefix ssl:// to use Implicit TLS, or use
+// prefix tls:// to use STARTTLS.
 // Supported replacement variables:
 // %h - user's IMAP hostname
 // %n - hostname ($_SERVER['SERVER_NAME'])
@@ -51,8 +51,7 @@ $config['default_host'] = 'localhost';
 // For example %n = mail.domain.tld, %t = domain.tld
 $config['smtp_server'] = 'localhost';
 
-// SMTP port (default is 25; use 587 for STARTTLS or 465 for the
-// deprecated SSL over SMTP (aka SMTPS))
+// SMTP port. Use 25 for cleartext, 465 for Implicit TLS, or 587 for STARTTLS (default)
 $config['smtp_port'] = 587;
 
 // SMTP username (if required) if you use %u as the username Roundcube

--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -257,8 +257,8 @@ $config['messages_cache_threshold'] = 50;
 // ----------------------------------
 
 // SMTP server host (for sending mails).
-// Enter hostname with prefix tls:// to use STARTTLS, or use
-// prefix ssl:// to use the deprecated SSL over SMTP (aka SMTPS)
+// Enter hostname with prefix ssl:// to use Implicit TLS, or use
+// prefix tls:// to use STARTTLS.
 // Supported replacement variables:
 // %h - user's IMAP hostname
 // %n - hostname ($_SERVER['SERVER_NAME'])
@@ -268,7 +268,7 @@ $config['messages_cache_threshold'] = 50;
 // For example %n = mail.domain.tld, %t = domain.tld
 $config['smtp_server'] = 'localhost';
 
-// SMTP port (default is 587)
+// SMTP port. Use 25 for cleartext, 465 for Implicit TLS, or 587 for STARTTLS (default)
 $config['smtp_port'] = 587;
 
 // SMTP username (if required) if you use %u as the username Roundcube


### PR DESCRIPTION
Previously, Implicit TLS (port 465), was not standardized and considered deprecated.

However, [RFC 8314](https://tools.ietf.org/html/rfc8314) (January 2018) re-standardizes it and recommends to use it:

From section 3.3:
> It is desirable to migrate core protocols used by MUA software to Implicit TLS over time, for    consistency as well as for the additional reasons discussed in Appendix A.
> (...)
> As a result, clients and servers SHOULD implement both STARTTLS on port 587 and Implicit TLS on port 465 for this transition period.