### PR TITLE
Fix ISO-2022-JP-MS encoding convert

### DIFF
--- a/program/include/rcmail_sendmail.php
+++ b/program/include/rcmail_sendmail.php
@@ -671,6 +671,10 @@ class rcmail_sendmail
      */
     public function email_input_format($mailto, $count = false, $check = true)
     {
+        // convert to UTF-8 to preserve \x2c(,) and \x3b(;) used in ISO-2022-JP;
+        $charset = $this->options['charset'];
+        $mailto = rcube_charset::convert($mailto, $charset, RCUBE_CHARSET);
+
         // simplified email regexp, supporting quoted local part
         $email_regexp = '(\S+|("[^"]+"))@\S+';
 
@@ -702,7 +706,21 @@ class rcmail_sendmail
                 if ($name[0] == '"' && $name[strlen($name)-1] == '"') {
                     $name = substr($name, 1, -1);
                 }
-                $name     = stripcslashes($name);
+                // encode "name" field.
+                if (function_exists('mb_encode_mimeheader') && $this->rcmail->config->get('head_encoding_base64')) {
+                    $head_encoding_mode = 'B';
+                    $name = rcube_charset::convert($name, RCUBE_CHARSET, $charset);
+                    $mb_charset = $charset;
+                    if (rcube_charset::$mb_aliases[$charset]) {
+                        $mb_charset = rcube_charset::$mb_aliases[$charset];
+                    }
+                    mb_internal_encoding($mb_charset);
+                    $name = preg_replace('/^"(.*)"$/', '$1', $name);
+                    $name = mb_encode_mimeheader($name, $mb_charset, $head_encoding_mode, "\r\n", 8);
+                    mb_internal_encoding(RCUBE_CHARSET);
+                } else {
+                    $name = stripcslashes($name);
+                }
                 $address  = rcube_utils::idn_to_ascii(trim($address, '<>'));
                 $result[] = format_email_recipient($address, $name);
                 $item     = $address;

--- a/program/lib/Roundcube/rcube_charset.php
+++ b/program/lib/Roundcube/rcube_charset.php
@@ -307,7 +307,7 @@ class rcube_charset
 
         // convert charset using iconv module
         if ($iconv_options !== false && $from != 'UTF7-IMAP' && $to != 'UTF7-IMAP'
-            && $from !== 'ISO-2022-JP'
+            && $from !== 'ISO-2022-JP' && $to !== 'ISO-2022-JP'
         ) {
             // throw an exception if iconv reports an illegal character in input
             // it means that input string has been truncated

--- a/program/lib/Roundcube/rcube_charset.php
+++ b/program/lib/Roundcube/rcube_charset.php
@@ -171,6 +171,12 @@ class rcube_charset
         65001 => 'UTF-8',
     );
 
+    static public $mb_aliases = array(
+        'WINDOWS-1257' => 'ISO-8859-13',
+        'US-ASCII'     => 'ASCII',
+        'ISO-2022-JP'  => 'ISO-2022-JP-MS',
+    );
+
     /**
      * Catch an error and throw an exception.
      *
@@ -331,11 +337,7 @@ class rcube_charset
 
         // convert charset using mbstring module
         if ($mbstring_sc !== false) {
-            $aliases = array(
-                'WINDOWS-1257' => 'ISO-8859-13',
-                'US-ASCII'     => 'ASCII',
-                'ISO-2022-JP'  => 'ISO-2022-JP-MS',
-            );
+            $aliases = self::$mb_aliases;
 
             $mb_from = $aliases[$from] ?: $from;
             $mb_to   = $aliases[$to] ?: $to;

--- a/program/lib/Roundcube/rcube_mime.php
+++ b/program/lib/Roundcube/rcube_mime.php
@@ -591,6 +591,9 @@ class rcube_mime
         // Note: Never try to use iconv instead of mbstring functions here
         //       Iconv's substr/strlen are 100x slower (#1489113)
 
+        if (isset(rcube_charset::$mb_aliases[$charset])) {
+            $charset = rcube_charset::$mb_aliases[$charset];
+        }
         if ($charset && $charset != RCUBE_CHARSET) {
             mb_internal_encoding($charset);
         }

--- a/tests/Framework/Charset.php
+++ b/tests/Framework/Charset.php
@@ -71,6 +71,7 @@ class Framework_Charset extends PHPUnit_Framework_TestCase
             array('&BCAEMARBBEEESwQ7BDoEOA-', 'Рассылки', 'UTF7-IMAP', 'UTF-8'),
             array('Рассылки', '&BCAEMARBBEEESwQ7BDoEOA-', 'UTF-8', 'UTF7-IMAP'),
             array(base64_decode('GyRCLWo7M3l1OSk2SBsoQg=='), '㈱山﨑工業', 'ISO-2022-JP', 'UTF-8'),
+            array('㈱山﨑工業', base64_decode('GyRCLWo7M3l1OSk2SBsoQg=='), 'UTF-8', 'ISO-2022-JP'),
         );
     }
 

--- a/tests/Framework/Charset.php
+++ b/tests/Framework/Charset.php
@@ -84,6 +84,31 @@ class Framework_Charset extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Data for test_convert()
+     */
+    function data_email_input_format()
+    {
+        return array(
+            array('ö', 'ö', 'UTF-8'),
+            array(base64_decode('GyRCLWo7M3l1OSk2SBsoQg=='), '㈱山﨑工業', 'ISO-2022-JP'),
+        );
+    }
+
+    /**
+     * @dataProvider data_email_input_format
+     */
+    function test_email_input_format($input, $output, $charset)
+    {
+        $sendmail = new rcmail_sendmail();
+        $sendmail->options['charset'] = $charset;
+        $sendmail->rcmail->config->set('head_encoding_base64', true);
+        $email = ' <t@domain.jp>';
+        $output = base64_encode(rcube_charset::convert($output, 'UTF-8', $charset));
+        $output = '=?' . $charset . '?B?' . $output . '?=' . $email;
+        $this->assertEquals($output, $sendmail->email_input_format($input . $email));
+    }
+
+    /**
      * Data for test_utf7_to_utf8()
      */
     function data_utf7_to_utf8()

--- a/tests/Framework/Mime.php
+++ b/tests/Framework/Mime.php
@@ -238,6 +238,10 @@ class Framework_Mime extends PHPUnit_Framework_TestCase
                 array("this-is-just-some-blabla-to-make-this-more-than-seventy-five-characters-in-a-row -- this line should be wrapped", 20, "\n"),
                 "this-is-just-some-blabla-to-make-this-more-than-seventy-five-characters-in-a-row\n-- this line should\nbe wrapped",
             ),
+            array(
+                array(rcube_charset::convert("㈱山﨑工業", 'UTF-8', 'ISO-2022-JP'), 1, "\n", true, 'ISO-2022-JP'),
+                rcube_charset::convert("㈱\n山\n﨑\n工\n業", 'UTF-8', 'ISO-2022-JP'),
+            ),
         );
 
         foreach ($samples as $sample) {


### PR DESCRIPTION
ISO-2022-JP-MS characters are removed by iconv on sending mail.
Use mbstring functions on sending.
A message with ISO-2022-JP-MS characters currupts by wordwrap.
Use ISO-2022-JP-MS charset in wordwrap.