### PR TITLE
plugins: password: make Python 3 compatible

### DIFF
--- a/plugins/password/helpers/chpass-wrapper.py
+++ b/plugins/password/helpers/chpass-wrapper.py
@@ -11,12 +11,12 @@ BLACKLIST = (
 
 try:
     username, password = sys.stdin.readline().split(':', 1)
-except ValueError, e:
+except ValueError:
     sys.exit('Malformed input')
 
 try:
     user = pwd.getpwnam(username)
-except KeyError, e:
+except KeyError:
     sys.exit('No such user: %s' % username)
 
 if user.pw_uid < 1000:


### PR DESCRIPTION
Remove the ", e" as the exception is never printed and this makes it
Python 3 compatible as well

Closes: #7118