### PR TITLE
Fix: Composer missing icons when 'htmleditor' is in config['dont_override']

### DIFF
--- a/skins/elastic/templates/compose.html
+++ b/skins/elastic/templates/compose.html
@@ -60,14 +60,12 @@
 				</div>
 			</div>
 			<roundcube:endif />
-			<roundcube:if condition="!in_array('htmleditor', (array)config:dont_override)" />
-				<div class="form-group row hidden">
-					<label for="editor-selector" class="col-form-label col-6"><roundcube:label name="editortype" /></label>
-					<div class="col-6">
-						<roundcube:object name="editorSelector" id="editor-selector" editorid="composebody" noform="true" tabindex="2" />
-					</div>
+			<div class="form-group row hidden">
+				<label for="editor-selector" class="col-form-label col-6"><roundcube:label name="editortype" /></label>
+				<div class="col-6">
+					<roundcube:object name="editorSelector" id="editor-selector" editorid="composebody" noform="true" tabindex="2" />
 				</div>
-			<roundcube:endif />
+			</div>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
`html_editor_init()` in `skins/elastic/ui.js` requires a `<select name="editorSelector">` element after the `<textarea>`. But this select element is not rendered by the template if `'htmleditor'` is in `config['dont_override']`.

This leads to `html_editor_init()` not adding the `'html-editor'` class, making the html/plaintext icons invisible.

This pull request fixes this by always rendering the editorSelector. I don't know the reason for not rendering it, so maybe this will break something.