### PR TITLE
Update to TinyMCE 5.1

### DIFF
--- a/jsdeps.json
+++ b/jsdeps.json
@@ -36,12 +36,12 @@
     },
     {
       "lib": "tinymce",
-      "version": "4.8.2",
+      "version": "5.1.5",
       "url": "https://download.tiny.cloud/tinymce/community/tinymce_$v.zip",
       "dest": "program/js",
-      "sha1": "d7fced05acdeeb78299585ea9909b0de2b3d759d",
+      "sha1": "c9f60ce582aa5c7002fafcf3519969da0c44be45",
       "license": "LGPL",
-      "copyright": "Copyright (c) 1999-2015 Ephox Corp. All rights reserved",
+      "copyright": "Copyright (c) 1999-2019 Ephox Corp. All rights reserved",
       "rm": "program/js/tinymce",
       "map": {
         "js/tinymce": "tinymce"


### PR DESCRIPTION
 - Update TinyMCE from 4.8.2 to 5.1.5 in jsdeps.json
 - Update SHA-1 hash

As far as I can see none of the [breaking changes](https://www.tiny.cloud/docs/migration-from-4x/) in TinyMCE 5 affect RoundCube, but please help testing, especially the media file selector since it uses some custom CSS.