### PR TITLE
Fix creation of pgp-keys for IDN emails

### DIFF
--- a/plugins/enigma/lib/enigma_ui.php
+++ b/plugins/enigma/lib/enigma_ui.php
@@ -747,7 +747,7 @@ class enigma_ui
 
         foreach ($identities as $idx => $ident) {
             $name = empty($ident['name']) ? ($ident['email']) : $ident['ident'];
-            $attr = array('value' => $idx, 'data-name' => $ident['name'], 'data-email' => $ident['email']);
+            $attr = array('value' => $idx, 'data-name' => $ident['name'], 'data-email' => $ident['email_ascii']);
             $identities[$idx] = html::tag('li', null, html::label(null, $checkbox->show($idx, $attr) . rcube::Q($name)));
         }
 


### PR DESCRIPTION
This PR fixes the creation of PGP-Keys.

Currently, the plugins sends the utf-8 version containing special characters to openpgp.js, which it does not accept as a valid ID. With this change, it will be sending the correct ascii-version starting with `xn--` which will result in a successful key creation.

Steps to reproduce:
Try creating a pgp-key for an identitiy with the email-address `example@fußball.de`.

Expected result: Sucessfully create a pgp key
Actual Result: Error in the console stating `Error generating keypair: Invalid user id format`
Result with patch: Sucessful creation of the pgp key
