### PR TITLE
Fixed incorrect typeof comparison

### DIFF
--- a/program/js/app.js
+++ b/program/js/app.js
@@ -9968,7 +9968,7 @@ function rcube_webmail()
 
     for (i=0; i<len; i++) {
       plugin = plugins[i];
-      if (typeof plugin === 'String') {
+      if (typeof plugin === 'string') {
         if (regex.test(plugin))
           return 1;
       }


### PR DESCRIPTION
`typeof` in js returns "string" not "String"

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof