### PR TITLE
Elastic: support list type layout

### DIFF
--- a/program/include/rcmail_output_html.php
+++ b/program/include/rcmail_output_html.php
@@ -371,6 +371,18 @@ EOF;
             }
         }
 
+        $layouts = $this->config->get('skin_layouts');
+        if (!empty($meta['supported-layouts'])) {
+            $layouts = $meta['supported-layouts'];
+            $this->config->set('skin_layouts', $meta['supported-layouts'], true);
+        }
+
+        // make sure current layout config is supported by current skin
+        // if not then fallback to first defined layout
+        if (!in_array($this->config->get('layout', 'widescreen'), $layouts)) {
+            $this->config->set('layout', $layouts[0], true);
+        }
+
         // Use array_merge() here to allow for global default and extended skins
         $this->meta_tags = array_merge($this->meta_tags, (array) $meta['meta']);
         $this->link_tags = array_merge($this->link_tags, (array) $meta['links']);

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -2364,7 +2364,7 @@ function rcube_webmail()
       row.cols.push(col);
     }
 
-    if (this.env.layout == 'widescreen')
+    if (flags.layout == 'widescreen')
       row = this.widescreen_message_row(row, uid, message);
 
     list.insert_row(row, attop);

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -2721,6 +2721,10 @@ function rcube_webmail()
       this.env.mailbox = mbox;
     }
 
+    url._list_layout = this.env.layout;
+    if (this.env.list_layout)
+      url._list_layout = this.env.list_layout;
+
     // load message list remotely
     if (this.gui_objects.messagelist) {
       this.list_mailbox_remote(mbox, page, url);

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -8354,14 +8354,11 @@ function rcube_webmail()
           if (repl[c].className) cell.className = repl[c].className;
           tr.appendChild(cell);
         }
-        thead.appendChild(tr);
-      }
 
-      for (n=0, len=this.env.listcols.length; n<len; n++) {
-        col = this.env.listcols[n];
-        if ((cell = thead.rows[0].cells[n]) && (col == 'from' || col == 'to' || col == 'fromto')) {
-          $(cell).attr('rel', col).find('span,a').text(this.get_label(col == 'fromto' ? smart_col : col));
-        }
+        if (list.checkbox_selection)
+          list.insert_checkbox(tr, 'thead');
+
+        thead.appendChild(tr);
       }
     }
 

--- a/program/js/list.js
+++ b/program/js/list.js
@@ -89,7 +89,6 @@ function rcube_list_widget(list, p)
 
 rcube_list_widget.prototype = {
 
-
 /**
  * get all message rows from HTML table and init each row
  */
@@ -259,6 +258,11 @@ init_header: function()
   }
 },
 
+/**
+ * Set the scrollable parent object for the table's fixed header
+ */
+container: window,
+
 init_fixed_header: function()
 {
   var clone = $(this.list.tHead).clone();
@@ -274,14 +278,14 @@ init_fixed_header: function()
     $(this.list).before(this.fixed_header);
 
     var me = this;
-    $(window).resize(function() { me.resize(); });
-    $(window).scroll(function() {
-      var w = $(window);
-      me.fixed_header.css({
-        marginLeft: -w.scrollLeft() + 'px',
-        marginTop: -w.scrollTop() + 'px'
+    $(window).on('resize', function() { me.resize(); });
+    $(this.container).on('scroll', function() {
+        var w = $(this);
+        me.fixed_header.css({
+          marginLeft: -w.scrollLeft() + 'px',
+          marginTop: -w.scrollTop() + 'px'
+        });
       });
-    });
   }
   else {
     $(this.fixed_header).find('thead').replaceWith(clone);

--- a/program/js/list.js
+++ b/program/js/list.js
@@ -265,6 +265,7 @@ init_fixed_header: function()
 
   if (!this.fixed_header) {
     this.fixed_header = $('<table>')
+      .attr('id', this.list.id + '-fixedcopy')
       .attr('class', this.list.className + ' fixedcopy')
       .attr('role', 'presentation')
       .css({ position:'fixed' })
@@ -454,10 +455,10 @@ update_row: function(id, cols, newid, select)
 /**
  * Add selection checkbox to the list record
  */
-insert_checkbox: function(row)
+insert_checkbox: function(row, tag_name)
 {
   var key, self = this,
-    cell = document.createElement(this.col_tagname()),
+    cell = document.createElement(this.col_tagname(tag_name)),
     chbox = document.createElement('input');
 
   chbox.type = 'checkbox';
@@ -494,14 +495,26 @@ enable_checkbox_selection: function()
   this.checkbox_selection = true;
 
   // Add checkbox to existing records if any
-  var r, len, cell, row_tag = this.row_tagname().toUpperCase(),
-    rows = this.tbody.childNodes;
+  var r, len, cell, rows,
+    row_tag = this.row_tagname().toUpperCase();
 
+  if (this.thead) {
+    rows = this.thead.childNodes;
+    for (r=0, len=rows.length; r<len; r++) {
+      if (rows[r].nodeName == row_tag && (cell = rows[r].firstChild)) {
+        if (cell.className == 'selection')
+          break;
+        this.insert_checkbox(rows[r], 'thead');
+      }
+    }
+  }
+
+  rows = this.tbody.childNodes;
   for (r=0, len=rows.length; r<len; r++) {
     if (rows[r].nodeName == row_tag && (cell = rows[r].firstChild)) {
       if (cell.className == 'selection')
         break;
-      this.insert_checkbox(rows[r]);
+      this.insert_checkbox(rows[r], 'tbody');
     }
   }
 },
@@ -1014,10 +1027,10 @@ row_tagname: function()
   return row_tagnames[this.tagname] || row_tagnames['*'];
 },
 
-col_tagname: function()
+col_tagname: function(tagname)
 {
-  var col_tagnames = { table:'td', '*':'span' };
-  return col_tagnames[this.tagname] || col_tagnames['*'];
+  var col_tagnames = { table:'td', thead:'th', tbody:'td', '*':'span' };
+  return col_tagnames[tagname || this.tagname] || col_tagnames['*'];
 },
 
 get_cell: function(row, index)
@@ -1746,7 +1759,7 @@ column_drag_mouse_move: function(e)
         .appendTo(document.body)
         // ... and column position indicator
        .append($('<div>').attr('id', 'rcmcolumnindicator')
-          .css({ position:'absolute', 'border-right':'2px dotted #555', 
+          .css({ position:'absolute', 'border-right':'2px dotted #555',
           'z-index':2002, height: (this.frame.offsetHeight-2)+'px' }));
 
       this.cols = [];

--- a/program/lib/Roundcube/rcube_config.php
+++ b/program/lib/Roundcube/rcube_config.php
@@ -257,6 +257,9 @@ class rcube_config
             ini_set('error_log', $error_log);
         }
 
+        // set default screen layouts
+        $this->prop['skin_layouts'] = array('widescreen', 'desktop', 'list');
+
         // remove deprecated properties
         unset($this->prop['dst_active']);
     }

--- a/program/localization/en_US/labels.inc
+++ b/program/localization/en_US/labels.inc
@@ -54,6 +54,8 @@ $labels['organization'] = 'Organization';
 $labels['readstatus'] = 'Read status';
 $labels['listoptions'] = 'List options...';
 $labels['listoptionstitle'] = 'List options';
+$labels['columnoptions'] = 'Column options...';
+$labels['columnoptionstitle'] = 'Column options';
 
 $labels['mailboxlist'] = 'Folders';
 $labels['messagesfromto'] = 'Messages $from to $to of $count';
@@ -712,6 +714,7 @@ $labels['arialabelmailboxmenu'] = 'Folder actions menu';
 $labels['arialabellistselectmenu'] = 'List selection menu';
 $labels['arialabelthreadselectmenu'] = 'Threads listing menu';
 $labels['arialabelmessagelistoptions'] = 'Message list display and sorting options';
+$labels['arialabelmessagecoloptions'] = 'Message list columns';
 $labels['arialabelmailimportdialog'] = 'Message import dialog';
 $labels['arialabelmessagenav'] = 'Message navigation';
 $labels['arialabelmessagebody'] = 'Message Body';

--- a/program/steps/mail/func.inc
+++ b/program/steps/mail/func.inc
@@ -359,7 +359,7 @@ function rcmail_message_list($attrib)
     $listcols = $a_show_cols;
 
     // Widescreen layout uses hardcoded list of columns
-    if (rcmail_get_messagelist_layout() == 'widescreen') {
+    if ($_SESSION['list_layout'] == 'widescreen') {
         $a_show_cols = array('threads', 'subject', 'fromto', 'date', 'flag', 'attachment');
         $listcols    = $a_show_cols;
         array_shift($listcols);
@@ -410,7 +410,7 @@ function rcmail_js_message_list($a_headers, $insert_top=false, $a_show_cols=null
     $delimiter   = $RCMAIL->storage->get_hierarchy_delimiter();
     $search_set  = $RCMAIL->storage->get_search_set();
     $multifolder = $search_set && $search_set[1]->multi;
-    $layout      = rcmail_get_messagelist_layout();
+    $layout      = $_SESSION['list_layout'];
 
     // add/remove 'folder' column to the list on multi-folder searches
     if ($multifolder && !in_array('folder', $a_show_cols)) {
@@ -1883,14 +1883,4 @@ function rcmail_supported_mimetypes()
     }
 
     return array_values($mimetypes);
-}
-
-function rcmail_get_messagelist_layout()
-{
-    $rcmail = rcube::get_instance();
-
-    $layout = $rcmail->config->get('layout', 'widescreen');
-    $layout = $rcmail->config->get('layout_messagelist') ?: $layout;
-
-    return $layout;
 }

--- a/program/steps/mail/func.inc
+++ b/program/steps/mail/func.inc
@@ -359,7 +359,7 @@ function rcmail_message_list($attrib)
     $listcols = $a_show_cols;
 
     // Widescreen layout uses hardcoded list of columns
-    if ($RCMAIL->config->get('layout', 'widescreen') == 'widescreen') {
+    if (rcmail_get_messagelist_layout() == 'widescreen') {
         $a_show_cols = array('threads', 'subject', 'fromto', 'date', 'flag', 'attachment');
         $listcols    = $a_show_cols;
         array_shift($listcols);
@@ -410,6 +410,7 @@ function rcmail_js_message_list($a_headers, $insert_top=false, $a_show_cols=null
     $delimiter   = $RCMAIL->storage->get_hierarchy_delimiter();
     $search_set  = $RCMAIL->storage->get_search_set();
     $multifolder = $search_set && $search_set[1]->multi;
+    $layout      = rcmail_get_messagelist_layout();
 
     // add/remove 'folder' column to the list on multi-folder searches
     if ($multifolder && !in_array('folder', $a_show_cols)) {
@@ -434,7 +435,7 @@ function rcmail_js_message_list($a_headers, $insert_top=false, $a_show_cols=null
     $_SESSION['list_attrib']['columns'] = $a_show_cols;
 
     // Widescreen layout uses hardcoded list of columns
-    if ($RCMAIL->config->get('layout', 'widescreen') == 'widescreen') {
+    if ($layout == 'widescreen') {
         $a_show_cols = array('threads', 'subject', 'fromto', 'date', 'flag', 'attachment');
     }
 
@@ -446,7 +447,7 @@ function rcmail_js_message_list($a_headers, $insert_top=false, $a_show_cols=null
     $a_show_cols = $plugin['cols'];
     $a_headers   = $plugin['messages'];
 
-    if ($RCMAIL->config->get('layout', 'widescreen') == 'widescreen') {
+    if ($layout == 'widescreen') {
         if (!$RCMAIL->storage->get_threading()) {
             if (($idx = array_search('threads', $a_show_cols)) !== false) {
                 unset($a_show_cols[$idx]);
@@ -549,8 +550,9 @@ function rcmail_js_message_list($a_headers, $insert_top=false, $a_show_cols=null
         if ($header->priority)
             $a_msg_flags['prio'] = (int) $header->priority;
 
-        $a_msg_flags['ctype'] = rcube::Q($header->ctype);
-        $a_msg_flags['mbox']  = $header->folder;
+        $a_msg_flags['ctype']  = rcube::Q($header->ctype);
+        $a_msg_flags['mbox']   = $header->folder;
+        $a_msg_flags['layout'] = $layout;
 
         // merge with plugin result (Deprecated, use $header->flags)
         if (!empty($header->list_flags) && is_array($header->list_flags))
@@ -1881,4 +1883,14 @@ function rcmail_supported_mimetypes()
     }
 
     return array_values($mimetypes);
+}
+
+function rcmail_get_messagelist_layout()
+{
+    $rcmail = rcube::get_instance();
+
+    $layout = $rcmail->config->get('layout', 'widescreen');
+    $layout = $rcmail->config->get('layout_messagelist') ?: $layout;
+
+    return $layout;
 }

--- a/program/steps/mail/func.inc
+++ b/program/steps/mail/func.inc
@@ -593,7 +593,7 @@ function rcmail_message_list_head($attrib, $a_show_cols)
         $a_sort_cols = array('subject', 'date', 'from', 'to', 'fromto', 'size', 'cc');
 
     if (!empty($attrib['optionsmenuicon'])) {
-        $list_menu = rcmail_options_menu_link();
+        $list_menu = rcmail_options_menu_link($attrib);
     }
 
     $cells = $coltypes = array();
@@ -662,21 +662,22 @@ function rcmail_options_menu_link($attrib = array())
 {
     global $RCMAIL;
 
-    $onclick = 'return ' . rcmail_output::JS_OBJECT_NAME . ".command('menu-open', 'messagelistmenu', this, event)";
+    if ($attrib['optionsmenuicon'] == 'config:list_cols' && in_array('list_cols', (array)$RCMAIL->config->get('dont_override'))) {
+        return;
+    }
+
+    $onclick = 'return ' . rcmail_output::JS_OBJECT_NAME . ".command('menu-open', '" . ($attrib['optionsmenuname'] ?: 'messagelistmenu') ."', this, event)";
     $inner   = $title = $RCMAIL->gettext($attrib['label'] ?: 'listoptions');
 
-    if (is_string($attrib['optionsmenuicon']) && $attrib['optionsmenuicon'] != 'true') {
-        $inner = html::img(array('src' => $RCMAIL->output->asset_url($attrib['optionsmenuicon'], true), 'alt' => $title));
-    }
-    else if ($attrib['innerclass']) {
+    if ($attrib['innerclass']) {
         $inner = html::span($attrib['innerclass'], $inner);
     }
 
     return html::a(array(
             'href'     => '#list-options',
             'onclick'  => $onclick,
-            'class'    => isset($attrib['class']) ? $attrib['class'] : 'listmenu',
-            'id'       => 'listmenulink',
+            'class'    => isset($attrib['linkclass']) ? $attrib['linkclass'] : 'listmenu',
+            'id'       => $attrib['menulinkid'] ?: 'listmenulink',
             'title'    => $title,
             'tabindex' => '0',
     ), $inner);

--- a/program/steps/mail/list.inc
+++ b/program/steps/mail/list.inc
@@ -54,6 +54,13 @@ if ($layout = rcube_utils::get_input_value('_layout', rcube_utils::INPUT_GET)) {
     $cols = $_SESSION['list_attrib']['columns'];
 }
 
+// register list layout change
+if ($list_layout = rcube_utils::get_input_value('_list_layout', rcube_utils::INPUT_GET)) {
+    $_SESSION['list_layout'] = $list_layout;
+    // force header replace on layout change
+    $cols = $_SESSION['list_attrib']['columns'];
+}
+
 if (!empty($save_arr)) {
     $RCMAIL->user->save_prefs($save_arr);
 }

--- a/program/steps/settings/func.inc
+++ b/program/steps/settings/func.inc
@@ -412,9 +412,17 @@ function rcmail_user_prefs($current = null)
                 $field_id = 'rcmfd_layout';
                 $select   = new html_select(array('name' => '_layout', 'id' => $field_id));
 
-                $select->add($RCMAIL->gettext('layoutwidescreendesc'), 'widescreen');
-                $select->add($RCMAIL->gettext('layoutdesktopdesc'), 'desktop');
-                $select->add($RCMAIL->gettext('layoutlistdesc'), 'list');
+                $layouts = array(
+                    'widescreen' => 'layoutwidescreendesc',
+                    'desktop'    => 'layoutdesktopdesc',
+                    'list'       => 'layoutlistdesc'
+                );
+
+                foreach ($layouts as $val => $label) {
+                    if (in_array($val, $config['skin_layouts'])) {
+                        $select->add($RCMAIL->gettext($label), $val);
+                    }
+                }
 
                 $blocks['main']['options']['layout'] = array(
                     'title'   => html::label($field_id, rcube::Q($RCMAIL->gettext('layout'))),

--- a/program/steps/settings/func.inc
+++ b/program/steps/settings/func.inc
@@ -418,10 +418,9 @@ function rcmail_user_prefs($current = null)
                     'list'       => 'layoutlistdesc'
                 );
 
-                foreach ($layouts as $val => $label) {
-                    if (in_array($val, $config['skin_layouts'])) {
-                        $select->add($RCMAIL->gettext($label), $val);
-                    }
+                $available_layouts = array_intersect_key($layouts, array_flip($config['skin_layouts']));
+                foreach ($available_layouts as $val => $label) {
+                    $select->add($RCMAIL->gettext($label), $val);
                 }
 
                 $blocks['main']['options']['layout'] = array(

--- a/skins/elastic/meta.json
+++ b/skins/elastic/meta.json
@@ -5,7 +5,6 @@
 	"license-url": "http://creativecommons.org/licenses/by-sa/3.0/",
 	"supported-layouts": ["widescreen", "list"],
 	"config": {
-		"layout_messagelist": "widescreen",
 		"jquery_ui_colors_theme": "bootstrap",
 		"embed_css_location": "/styles/embed.css",
 		"editor_css_location": "/styles/embed.css",

--- a/skins/elastic/meta.json
+++ b/skins/elastic/meta.json
@@ -3,8 +3,9 @@
 	"author": "Aleksander Machniak",
 	"license": "Creative Commons Attribution-ShareAlike",
 	"license-url": "http://creativecommons.org/licenses/by-sa/3.0/",
+	"supported-layouts": ["widescreen", "list"],
 	"config": {
-		"layout": "widescreen",
+		"layout_messagelist": "widescreen",
 		"jquery_ui_colors_theme": "bootstrap",
 		"embed_css_location": "/styles/embed.css",
 		"editor_css_location": "/styles/embed.css",

--- a/skins/elastic/styles/colors.less
+++ b/skins/elastic/styles/colors.less
@@ -100,7 +100,7 @@
 @color-list-unread-status:          @color-warning;
 
 @color-list-header:                 @color-list;
-@color-list-header-icon:            fadeout(@color-list-secondary, 25%);
+@color-list-header-icon:            @color-list-icon;
 @color-list-header-background:      @color-layout-list-background;
 
 @color-attachmentlist-border:       #f4f4f4;

--- a/skins/elastic/styles/colors.less
+++ b/skins/elastic/styles/colors.less
@@ -81,6 +81,12 @@
 @color-list-secondary:              @color-black-shade-text;
 @color-list-droptarget-background:  #ffffcc;
 @color-list-focus-indicator:        lighten(@color-main, 20%);
+@color-list-priority-1:             #ff5552;
+@color-list-priority-2:             #ffd452;
+@color-list-priority-3:             @color-font;
+@color-list-priority-4:             #41b849;
+@color-list-priority-5:             #37beff;
+@color-list-thread-background:      tint(@color-main, 98%);
 
 @color-list-border:                 @color-black-shade-bg;
 @color-list-badge:                  #fff;
@@ -92,6 +98,10 @@
 @color-list-pagenav:                @color-black-shade-text;
 @color-list-icon:                   fadeout(@color-list-secondary, 25%);
 @color-list-unread-status:          @color-warning;
+
+@color-list-header:                 @color-list;
+@color-list-header-icon:            fadeout(@color-list-secondary, 25%);
+@color-list-header-background:      @color-layout-list-background;
 
 @color-attachmentlist-border:       #f4f4f4;
 @color-attachmentlist-background:   #fcfcfc;

--- a/skins/elastic/styles/colors.less
+++ b/skins/elastic/styles/colors.less
@@ -86,7 +86,7 @@
 @color-list-priority-3:             @color-font;
 @color-list-priority-4:             #41b849;
 @color-list-priority-5:             #37beff;
-@color-list-thread-background:      tint(@color-main, 98%);
+@color-list-thread-background:      tint(@color-main, 95%);
 
 @color-list-border:                 @color-black-shade-bg;
 @color-list-badge:                  #fff;

--- a/skins/elastic/styles/layout.less
+++ b/skins/elastic/styles/layout.less
@@ -148,6 +148,32 @@ body {
     min-width: 300px;
     border-right: 1px solid @color-layout-border;
     background-color: @color-layout-list-background;
+
+    #layout.list & {
+        flex: 9;
+        max-width: none;
+
+        html.layout-normal & {
+            #toolbar-menu {
+                width: 100%;
+            }
+
+            a.toolbar-button {
+                order: 98;
+            }
+        }
+
+        html.layout-large & {
+            & > .header > #toolbar-menu {
+                margin-left: 2.5em;
+            }
+
+            & > .footer {
+                padding-left: 30% !important;
+                padding-right: 30% !important;
+            }
+        }
+    }
 }
 
 #layout-content {
@@ -253,6 +279,10 @@ body {
 
     .sidebar-right & {
         left: -3px;
+    }
+
+    #layout.list > #layout-list & {
+        display: none;
     }
 }
 
@@ -393,6 +423,18 @@ html.layout-normal {
     .hidden-lbs,
     .hidden-big {
         display: none !important;
+    }
+
+    #layout.list {
+        a.back-list-button,
+        a.back-sidebar-button,
+        #layout-list span.header-title {
+            display: none !important;
+        }
+
+        #layout-content {
+            display: none;
+        }
     }
 }
 

--- a/skins/elastic/styles/layout.less
+++ b/skins/elastic/styles/layout.less
@@ -149,7 +149,7 @@ body {
     border-right: 1px solid @color-layout-border;
     background-color: @color-layout-list-background;
 
-    #layout.list & {
+    #layout.layout-list & {
         flex: 9;
         max-width: none;
 
@@ -281,7 +281,7 @@ body {
         left: -3px;
     }
 
-    #layout.list > #layout-list & {
+    #layout.layout-list > #layout-list & {
         display: none;
     }
 }
@@ -425,7 +425,7 @@ html.layout-normal {
         display: none !important;
     }
 
-    #layout.list {
+    #layout.layout-list {
         a.back-list-button,
         a.back-sidebar-button,
         #layout-list span.header-title {

--- a/skins/elastic/styles/widgets/lists.less
+++ b/skins/elastic/styles/widgets/lists.less
@@ -769,6 +769,10 @@ ul.treelist {
             font-size: .4rem;
             width: 1.1rem;
             height: 2rem;
+
+            .layout-list& {
+                margin-top: .2rem;
+            }
         }
 
         &.status:before {

--- a/skins/elastic/styles/widgets/lists.less
+++ b/skins/elastic/styles/widgets/lists.less
@@ -12,6 +12,11 @@
 /*** List and treelist widgets ***/
 
 .listing {
+    > thead {
+        background-color: @color-list-header-background;
+    }
+
+    thead th,
     tbody td,
     li {
         border-bottom: 1px solid @color-list-border;
@@ -20,12 +25,44 @@
         line-height: @listing-line-height;
     }
 
+    thead th,
     tbody td,
     li a {
         padding: 0 .5rem;
         white-space: nowrap;
         vertical-align: middle;
         color: @color-list;
+    }
+
+    thead th {
+        padding: .25rem .5rem;
+        font-weight: bold;
+        color: @color-list-header;
+
+        a {
+            color: @color-list-header;
+
+            &:hover {
+                text-decoration: none;
+            }
+        }
+
+        &.sortedDESC,
+        &.sortedASC, {
+            > a:after {
+                &:extend(.font-icon-class);
+                float: none;
+                display: inline-block;
+                margin-left: .1em;
+                font-size: .9rem;
+                color: @color-list-header-icon;
+                content: @fa-var-long-arrow-alt-up;
+            }
+        }
+
+        &.sortedASC > a:after {
+            content: @fa-var-long-arrow-alt-down;
+        }
     }
 
     tbody td {
@@ -50,6 +87,10 @@
         background-color: @color-list-selected-background;
     }
 
+    th.selection > input {
+        display: none;
+    }
+
     td.selection {
         padding: 0 0 0 .5em;
         width: 2em;
@@ -60,6 +101,7 @@
         }
     }
 
+    &:not(.withselection) th.selection,
     &:not(.withselection) td.selection {
         display: none;
     }
@@ -558,12 +600,24 @@ ul.treelist {
 /*** Messages list widget ***/
 
 .messagelist > thead,
-.messagelist .branch,
-table.fixedcopy {
-    display: none;
+.messagelist .branch {
+    .layout-widescreen& {
+        display: none;
+    }
+
+    th.threads,
+    th.flag,
+    th.attachment,
+    th.status,
+    th.priority {
+        text-indent: -999px;
+        white-space: nowrap;
+        overflow: hidden;
+    }
 }
 
 .messagelist {
+    th,
     td {
         border-left: 0;
         width: 2em;
@@ -572,10 +626,13 @@ table.fixedcopy {
     }
 
     td.subject {
-        width: 100%;
         padding-right: 0;
-        display: flex;
-        flex-wrap: wrap;
+
+        .layout-widescreen& {
+            width: 100%;
+            display: flex;
+            flex-wrap: wrap;
+        }
 
         a {
             text-decoration: none;
@@ -626,6 +683,7 @@ table.fixedcopy {
     }
 
     tr.flagged td,
+    tr.flagged td.subject > a,
     tr.flagged td.subject span.subject a,
     tr.flagged td.subject span.date,
     tr.flagged td.subject span.fromto {
@@ -633,6 +691,7 @@ table.fixedcopy {
     }
 
     tr.deleted td,
+    tr.deleted td.subject > a,
     tr.deleted td.subject span.subject a,
     tr.deleted td.subject span.date,
     tr.deleted td.subject span.fromto {
@@ -659,14 +718,17 @@ table.fixedcopy {
         content: @fa-var-angle-down;
     }
 
-    td.subject span.msgicon.status {
+    td.subject span.msgicon {
         &:before {
             &:extend(.font-icon-class);
             content: @fa-var-circle;
-            cursor: pointer;
             font-size: .4rem;
             width: 1.1rem;
             height: 2rem;
+        }
+
+        &.status:before {
+            cursor: pointer;
         }
 
         &.unread:before {
@@ -701,33 +763,179 @@ table.fixedcopy {
         }
     }
 
-    span.attachment span {
-        &:extend(.font-icon-class);
-        color: @color-list-icon;
+    th.attachment,
+    td.attachment,
+    span.attachment {
+        span {
+            &:before {
+                &:extend(.font-icon-class);
+                color: @color-list-icon;
 
-        &:before {
-            margin: 0;
-            content: @fa-var-paperclip;
+                margin: 0;
+                content: @fa-var-paperclip;
+
+                .layout-list& {
+                    height: auto;
+                    text-indent: 0;
+                }
+            }
+            &.report:before {
+                .font-icon-regular(@fa-var-file-alt);
+            }
+            &.encrypted:before {
+                content: @fa-var-lock;
+            }
+            &.vcard:before {
+                .font-icon-regular(@fa-var-user); // vcard_attachments plugin
+            }
         }
-        &.report:before {
-            .font-icon-regular(@fa-var-file-alt);
-        }
-        &.encrypted:before {
-            content: @fa-var-lock;
-        }
-        &.vcard:before {
-            .font-icon-regular(@fa-var-user); // vcard_attachments plugin
-        }
+    }
+
+    th.attachment span:before {
+        color: @color-list-header;
+    }
+
+    th.threads a:before {
+        &:extend(.font-icon-class);
+        content: @fa-var-columns;
+        height: auto;
+        text-indent: 0;
     }
 
     span.flagged:before {
         &:extend(.font-icon-class);
         content: @fa-var-flag;
+
+        .layout-list& {
+            height: auto;
+            text-indent: 0;
+        }
+    }
+
+    span.status:before {
+        &:extend(.font-icon-class);
+        content: @fa-var-envelope;
+
+        .layout-list& {
+            height: auto;
+            text-indent: 0;
+        }
+    }
+
+    span.priority:before {
+        &:extend(.font-icon-class);
+        content: @fa-var-exclamation;
+
+        .layout-list& {
+            height: auto;
+            text-indent: 0;
+        }
+    }
+
+    .layout-list& {
+        th {
+            &.threads,
+            &.flag,
+            &.attachment
+            &.status,
+            &.priority, {
+                width: 2.5em;
+            }
+
+            &.fromto,
+            &.from,
+            &.to,
+            &.cc,
+            &.replyto {
+                width: 15em;
+            }
+
+            &.date {
+                width: 11em;
+            }
+
+            &.size {
+                width: 4em;
+            }
+
+            &.subject {
+                width: 99%;
+            }
+        }
+
+        span.unflagged:before {
+            &:extend(.font-icon-class);
+            content: @fa-var-flag;
+            height: auto;
+            color: transparent;
+        }
+
+        td.status span {
+            &:extend(.font-icon-class);
+            height: auto;
+            cursor: pointer;
+
+            &:before {
+                .font-icon-regular(@fa-var-envelope-open);
+            }
+
+            &.unread:before {
+                .font-icon-solid(@fa-var-envelope);
+            }
+        }
+
+        td.priority span {
+            &:extend(.font-icon-class);
+            height: auto;
+
+            &.prio1:before {
+                content: @fa-var-exclamation;
+                color: @color-list-priority-1;
+            }
+
+            &.prio2:before {
+                content: @fa-var-long-arrow-alt-up;
+                color: @color-list-priority-2;
+            }
+
+            &.prio3:before {
+                content: @fa-var-arrows-alt-v;
+                color: @color-list-priority-3;
+            }
+
+            &.prio4:before {
+                content: @fa-var-long-arrow-alt-down;
+                color: @color-list-priority-4;
+            }
+
+            &.prio5:before {
+                content: @fa-var-long-arrow-alt-down;
+                color: @color-list-priority-5;
+            }
+        }
+
+        td > span.branch > div {
+            display: inline-block;
+        }
+
+        tr.unread td {
+            font-weight: bold;
+        }
+
+        tr.thread.expanded {
+            background-color: @color-list-thread-background
+        }
     }
 
     tr:hover span.unflagged:before {
         &:extend(.font-icon-class);
         .font-icon-regular(@fa-var-flag);
+        cursor: pointer;
+
+        .layout-list& {
+            height: auto;
+            color: @color-list;
+        }
     }
 }
 

--- a/skins/elastic/styles/widgets/lists.less
+++ b/skins/elastic/styles/widgets/lists.less
@@ -869,7 +869,7 @@ ul.treelist {
 
         &.unread:before {
             .font-icon-solid(@fa-var-envelope);
-            color: @color-list;
+            color: @color-list-unread-status !important;
         }
     }
 
@@ -918,7 +918,7 @@ ul.treelist {
     tr:hover {
         td.status span:before,
         span.unflagged:before {
-            color: @color-list;
+            color: @color-list-icon;
             cursor: pointer;
         }
     }

--- a/skins/elastic/styles/widgets/lists.less
+++ b/skins/elastic/styles/widgets/lists.less
@@ -836,7 +836,7 @@ ul.treelist {
         th {
             &.threads,
             &.flag,
-            &.attachment
+            &.attachment,
             &.status,
             &.priority, {
                 width: 2.5em;

--- a/skins/elastic/styles/widgets/lists.less
+++ b/skins/elastic/styles/widgets/lists.less
@@ -25,7 +25,6 @@
         line-height: @listing-line-height;
     }
 
-    thead th,
     tbody td,
     li a {
         padding: 0 .5rem;
@@ -36,8 +35,12 @@
 
     thead th {
         padding: .25rem .5rem;
+        white-space: nowrap;
+        vertical-align: middle;
         font-weight: bold;
         color: @color-list-header;
+        .overflow-ellipsis;
+        outline: none;
 
         a {
             color: @color-list-header;
@@ -599,20 +602,10 @@ ul.treelist {
 
 /*** Messages list widget ***/
 
-.messagelist > thead,
-.messagelist .branch {
-    .layout-widescreen& {
+.messagelist:not(.layout-list) {
+    > thead,
+    .branch {
         display: none;
-    }
-
-    th.threads,
-    th.flag,
-    th.attachment,
-    th.status,
-    th.priority {
-        text-indent: -999px;
-        white-space: nowrap;
-        overflow: hidden;
     }
 }
 
@@ -625,10 +618,61 @@ ul.treelist {
         font-size: 1rem !important;
     }
 
+    th {
+        &.threads,
+        &.flag,
+        &.attachment,
+        &.status,
+        &.priority {
+            text-indent: -999px;
+            white-space: nowrap;
+            overflow: hidden;
+            width: 2.5em;
+        }
+
+        &.threads a:before {
+            &:extend(.font-icon-class);
+            content: @fa-var-columns;
+            height: auto;
+            text-indent: 0;
+        }
+
+        &.flag,
+        &.attachment {
+            span:before {
+                color: @color-list-header !important;
+            }
+        }
+
+        &.status span:before {
+            .font-icon-solid(@fa-var-envelope);
+        }
+
+        &.fromto,
+        &.from,
+        &.to,
+        &.cc,
+        &.replyto {
+            width: 15em;
+        }
+
+        &.date {
+            width: 11em;
+        }
+
+        &.size {
+            width: 4em;
+        }
+
+        &.subject {
+            width: 99%;
+        }
+    }
+
     td.subject {
         padding-right: 0;
 
-        .layout-widescreen& {
+        :not(.layout-list)& {
             width: 100%;
             display: flex;
             flex-wrap: wrap;
@@ -791,129 +835,95 @@ ul.treelist {
         }
     }
 
-    th.attachment span:before {
-        color: @color-list-header;
-    }
+    th.flag span,
+    td.flag span,
+    span.flag span {
+        &:before {
+            &:extend(.font-icon-class);
+            .font-icon-regular(@fa-var-flag);
+            color: transparent;
 
-    th.threads a:before {
-        &:extend(.font-icon-class);
-        content: @fa-var-columns;
-        height: auto;
-        text-indent: 0;
-    }
+            .layout-list& {
+                height: auto;
+                text-indent: 0;
+            }
+        }
 
-    span.flagged:before {
-        &:extend(.font-icon-class);
-        content: @fa-var-flag;
-
-        .layout-list& {
-            height: auto;
-            text-indent: 0;
+        &.flagged:before {
+            .font-icon-solid(@fa-var-flag);
+            color: @color-list-flagged;
         }
     }
 
-    span.status:before {
-        &:extend(.font-icon-class);
-        content: @fa-var-envelope;
+    td.status span,
+    span.status {
+        &:before {
+            &:extend(.font-icon-class);
+            .font-icon-regular(@fa-var-envelope-open);
 
-        .layout-list& {
-            height: auto;
-            text-indent: 0;
+            .layout-list& {
+                height: auto;
+                text-indent: 0;
+            }
+        }
+
+        &.unread:before {
+            .font-icon-solid(@fa-var-envelope);
+            color: @color-list;
         }
     }
 
-    span.priority:before {
-        &:extend(.font-icon-class);
-        content: @fa-var-exclamation;
+    td.status span {
+        color: transparent;
+    }
 
-        .layout-list& {
-            height: auto;
-            text-indent: 0;
+    td.priority span,
+    span.priority {
+        &:before {
+            &:extend(.font-icon-class);
+            content: @fa-var-exclamation;
+
+            .layout-list& {
+                height: auto;
+                text-indent: 0;
+            }
+        }
+
+        &.prio1:before {
+            content: @fa-var-exclamation;
+            color: @color-list-priority-1;
+        }
+
+        &.prio2:before {
+            content: @fa-var-long-arrow-alt-up;
+            color: @color-list-priority-2;
+        }
+
+        &.prio3:before {
+            content: @fa-var-arrows-alt-v;
+            color: @color-list-priority-3;
+        }
+
+        &.prio4:before {
+            content: @fa-var-long-arrow-alt-down;
+            color: @color-list-priority-4;
+        }
+
+        &.prio5:before {
+            content: @fa-var-long-arrow-alt-down;
+            color: @color-list-priority-5;
+        }
+    }
+
+    tr:hover {
+        td.status span:before,
+        span.unflagged:before {
+            color: @color-list;
+            cursor: pointer;
         }
     }
 
     .layout-list& {
-        th {
-            &.threads,
-            &.flag,
-            &.attachment,
-            &.status,
-            &.priority, {
-                width: 2.5em;
-            }
-
-            &.fromto,
-            &.from,
-            &.to,
-            &.cc,
-            &.replyto {
-                width: 15em;
-            }
-
-            &.date {
-                width: 11em;
-            }
-
-            &.size {
-                width: 4em;
-            }
-
-            &.subject {
-                width: 99%;
-            }
-        }
-
-        span.unflagged:before {
-            &:extend(.font-icon-class);
-            content: @fa-var-flag;
-            height: auto;
-            color: transparent;
-        }
-
-        td.status span {
-            &:extend(.font-icon-class);
-            height: auto;
-            cursor: pointer;
-
-            &:before {
-                .font-icon-regular(@fa-var-envelope-open);
-            }
-
-            &.unread:before {
-                .font-icon-solid(@fa-var-envelope);
-            }
-        }
-
-        td.priority span {
-            &:extend(.font-icon-class);
-            height: auto;
-
-            &.prio1:before {
-                content: @fa-var-exclamation;
-                color: @color-list-priority-1;
-            }
-
-            &.prio2:before {
-                content: @fa-var-long-arrow-alt-up;
-                color: @color-list-priority-2;
-            }
-
-            &.prio3:before {
-                content: @fa-var-arrows-alt-v;
-                color: @color-list-priority-3;
-            }
-
-            &.prio4:before {
-                content: @fa-var-long-arrow-alt-down;
-                color: @color-list-priority-4;
-            }
-
-            &.prio5:before {
-                content: @fa-var-long-arrow-alt-down;
-                color: @color-list-priority-5;
-            }
-        }
-
         td > span.branch > div {
             display: inline-block;
         }
@@ -923,18 +933,7 @@ ul.treelist {
         }
 
         tr.thread.expanded {
-            background-color: @color-list-thread-background
-        }
-    }
-
-    tr:hover span.unflagged:before {
-        &:extend(.font-icon-class);
-        .font-icon-regular(@fa-var-flag);
-        cursor: pointer;
-
-        .layout-list& {
-            height: auto;
-            color: @color-list;
+            background-color: @color-list-thread-background;
         }
     }
 }

--- a/skins/elastic/templates/mail.html
+++ b/skins/elastic/templates/mail.html
@@ -200,6 +200,17 @@
 		</div>
 	</div>
 	<roundcube:endif />
+	<roundcube:if condition="!in_array('layout', (array)config:dont_override)" />
+	<div class="form-group row">
+		<label for="listoptions-layout" class="col-form-label col-sm-4"><roundcube:label name="layout" /></label>
+		<div class="col-sm-8">
+			<select id="listoptions-layout" name="layout">
+				<option value="widescreen"><roundcube:label name="layoutwidescreendesc" /></option>
+				<option value="list"><roundcube:label name="layoutlistdesc" /></option>
+			</select>
+		</div>
+	</div>
+	<roundcube:endif />
 	<roundcube:container name="listoptions" id="listoptionsmenu" />
 	<roundcube:add_label name="listoptionstitle" />
 </div>

--- a/skins/elastic/templates/mail.html
+++ b/skins/elastic/templates/mail.html
@@ -36,7 +36,7 @@
 			<roundcube:if condition="env:threads" />
 				<a href="#threads" class="threads disabled" data-popup="threadselect-menu" title="<roundcube:label name="threads" />"><span class="inner"><roundcube:label name="threads" /></span></a>
 			<roundcube:endif />
-			<roundcube:object name="listmenulink" class="options active" label="options" innerclass="inner" />
+			<roundcube:object name="listmenulink" linkclass="options active" label="options" innerclass="inner" />
 			<roundcube:container name="listcontrols" id="listcontrols" />
 		</div>
 		<roundcube:button command="checkmail" type="link" class="button icon toolbar-button refresh"
@@ -85,9 +85,11 @@
 			<button type="button" class="btn btn-primary icon search" onclick="return rcmail.command('search')"><roundcube:label name="search" /></button>
 		</div>
 	</div>
+
 	<div id="messagelist-content" class="scroller" tabindex="-1">
 		<h2 id="aria-label-messagelist" class="voice"><roundcube:label name="arialabelmessagelist" /></h2>
 		<roundcube:object name="messages" id="messagelist" class="listing messagelist sortheader fixedheader"
+			optionsmenuicon="config:list_cols" optionsmenuname="messagelistcolsmenu" label="columnoptions" menulinkid="colmenulink"
 			aria-labelledby="aria-label-messagelist" data-list="message_list" data-label-msg="listempty"
 		/>
 	</div>
@@ -138,8 +140,7 @@
 	<h3 id="aria-label-listselect-menu" class="voice"><roundcube:label name="arialabellistselectmenu" /></h3>
 	<ul class="menu listing" role="menu" aria-labelledby="aria-label-listselect-menu">
 		<roundcube:button type="link-menuitem" label="selection" class="selection disabled" classAct="selection active"
-			name="list-toggle-button" id="list-toggle-button"
-			onclick="if ($(this).is('.active')) $('#messagelist').toggleClass('withselection');" />
+			name="list-toggle-button" id="list-toggle-button" onclick="UI.toggle_list_selection(this, 'messagelist');" />
 		<roundcube:button command="select-all" type="link-menuitem" label="all" class="select all disabled" classAct="select all active" />
 		<roundcube:button command="select-all" type="link-menuitem" prop="page" label="currpage" class="select page disabled" classAct="select page active" />
 		<roundcube:button command="select-all" type="link-menuitem" prop="unread" label="unread" class="select unread disabled" classAct="select unread active" />
@@ -201,7 +202,7 @@
 	</div>
 	<roundcube:endif />
 	<roundcube:if condition="!in_array('layout', (array)config:dont_override)" />
-	<div class="form-group row">
+	<div class="form-group row hidden-phone hidden-small">
 		<label for="listoptions-layout" class="col-form-label col-sm-4"><roundcube:label name="layout" /></label>
 		<div class="col-sm-8">
 			<select id="listoptions-layout" name="layout">
@@ -213,6 +214,37 @@
 	<roundcube:endif />
 	<roundcube:container name="listoptions" id="listoptionsmenu" />
 	<roundcube:add_label name="listoptionstitle" />
+</div>
+
+<div id="coloptions-menu" class="popupmenu propform" role="dialog" aria-labelledby="aria-label-coloptions">
+	<h3 id="aria-label-coloptions" class="voice"><roundcube:label name="arialabelmessagecoloptions" /></h3>
+    <roundcube:if condition="!in_array('list_cols', (array)config:dont_override)" />
+	<div class="row">
+		<div class="col-sm-6">
+			<ul class="proplist">
+				<li><label class="disabled"><input type="checkbox" name="list_col[]" value="threads" disabled /> <span><roundcube:label name="threads" /></span></label></li>
+				<li><label class="disabled"><input type="checkbox" name="list_col[]" value="subject" disabled /> <span><roundcube:label name="subject" /></span></label></li>
+				<li><label><input type="checkbox" name="list_col[]" value="fromto" /> <span><roundcube:label name="fromto" /></span></label></li>
+				<li><label><input type="checkbox" name="list_col[]" value="from" /> <span><roundcube:label name="from" /></span></label></li>
+				<li><label><input type="checkbox" name="list_col[]" value="to" /> <span><roundcube:label name="to" /></span></label></li>
+				<li><label><input type="checkbox" name="list_col[]" value="replyto" /> <span><roundcube:label name="replyto" /></span></label></li>
+				<li><label><input type="checkbox" name="list_col[]" value="cc" /> <span><roundcube:label name="cc" /></span></label></li>
+			</ul>
+		</div>
+		<div class="col-sm-6">
+			<ul class="proplist">
+				<li><label><input type="checkbox" name="list_col[]" value="date" /> <span><roundcube:label name="date" /></span></label></li>
+				<li><label><input type="checkbox" name="list_col[]" value="size" /> <span><roundcube:label name="size" /></span></label></li>
+				<li><label><input type="checkbox" name="list_col[]" value="status" /> <span><roundcube:label name="readstatus" /></span></label></li>
+				<li><label><input type="checkbox" name="list_col[]" value="attachment" /> <span><roundcube:label name="attachment" /></span></label></li>
+				<li><label><input type="checkbox" name="list_col[]" value="flag" /> <span><roundcube:label name="flag" /></span></label></li>
+				<li><label><input type="checkbox" name="list_col[]" value="priority" /> <span><roundcube:label name="priority" /></span></label></li>
+			</ul>
+		</div>
+		<roundcube:container name="coloptions" id="coloptionsmenu" />
+		<roundcube:add_label name="columnoptionstitle" />
+	</div>
+    <roundcube:endif />
 </div>
 
 <roundcube:include file="includes/footer.html" />

--- a/skins/elastic/templates/mail.html
+++ b/skins/elastic/templates/mail.html
@@ -85,7 +85,6 @@
 			<button type="button" class="btn btn-primary icon search" onclick="return rcmail.command('search')"><roundcube:label name="search" /></button>
 		</div>
 	</div>
-
 	<div id="messagelist-content" class="scroller" tabindex="-1">
 		<h2 id="aria-label-messagelist" class="voice"><roundcube:label name="arialabelmessagelist" /></h2>
 		<roundcube:object name="messages" id="messagelist" class="listing messagelist sortheader fixedheader"

--- a/skins/elastic/ui.js
+++ b/skins/elastic/ui.js
@@ -310,6 +310,9 @@ function rcube_elastic_ui()
                 if ($(this).next('.formbuttons').length) {
                     $(this).parent().addClass('formcontainer');
                 }
+
+                // Set the scrollable parent object for the table's fixed header
+                rcube_list_widget.prototype.container = 'div.formcontent';
             });
         }
 

--- a/skins/elastic/ui.js
+++ b/skins/elastic/ui.js
@@ -1804,7 +1804,7 @@ function rcube_elastic_ui()
 
     /**
      * mail screen layout
-     * switch between widescreen and list views
+     * switch between wide screen and list views
      */
     function mail_layout(p)
     {
@@ -1815,6 +1815,10 @@ function rcube_elastic_ui()
             list_header = layout.list.find('.header'),
             content_header = layout.content.find('.header');
 
+        // set message list layout
+        rcmail.env.list_layout = 'widescreen';
+
+        // set the layout class on layout change and initial page load
         if (p || $('#layout')[0].classList == '')
             $('#layout').removeClass().addClass(cur_layout);
 


### PR DESCRIPTION
First attempt at adding a list type layout mode to the Elastic skin (no preview pane)
![demo](https://user-images.githubusercontent.com/88682/73607072-90d6b080-45a9-11ea-9602-832b912a4f3b.jpg)
I tried a few different layouts for the combined toolbar above the message list. I think I prefer option 2 from the selection below.
![toolbars](https://user-images.githubusercontent.com/88682/73123653-ed264880-3f89-11ea-8725-24b880660de5.jpg)
Most of the changes are confined to the Elastic skin itself but there were a couple of updates needed in the core.

1. allow skins to device which layout modes they support - this PR adds support for the `list` layout mode but not `desktop`. So I needed a way for skins to define which layouts they support. I have added `supported-layouts` to the skin `meta.json` file and an internal config option called `skin_layouts` which controls which options are shown on the settings screen.
2. separation of skin layout and message list layout options -currently the value of `layout` is used both for the skin layout and for the layout of the fields in the message list. That's good for Classic and Larry but not for Elastic ~~so by setting `layout_messagelist` the layout of the message list can be defined separately. If `layout_messagelist` is not defined then `layout` is used.~~ I also made a small tweak in `app.js` to ensure that `add_message_row()` uses the same message row layout that the PHP does when generating the row. Edit 1: I've added a new JS env var called list_layout which can be used to set the list layout separately to the screen layout, if this env var is not present then the `layout` env is still used.

UPDATE: I've added support for "list mode" message list on large screens. 

I know this feature is not a priority for the devs so it would be great if people who opened issues (e.g. #7161, #7193) about hiding the preview pane could help test this PR. All feedback welcome. Thanks.