### PR TITLE
trivial fix for memcached hosts like unix:///path/to/socket.file

### DIFF
--- a/program/lib/Roundcube/cache/memcached.php
+++ b/program/lib/Roundcube/cache/memcached.php
@@ -107,7 +107,7 @@ class rcube_cache_memcached extends rcube_cache
                     if (!$port) $port = 11211;
                 }
                 else {
-                    $host = substr($host, 8);
+                    $host = substr($host, 7);
                     $port = 0;
                 }
 


### PR DESCRIPTION
**what was broken?**
off by one when stripping the AF_UNIX prefix

```php
>>> $host = "unix:///path/to/socket.file"
>>> substr($host, 8)
"path/to/socket.file"
>>> substr($host, 7)
"/path/to/socket.file"
```

**why this fix?**
to keep it memcache (sans d) compatible

**do we need documentation updates?**
no, comment for `$config['memcache_hosts']` in config/defaults.inc.php looks good

**regression potential?**
unlikely: anyone attempting to use memcached with unix sockets must have run into the bug