### PR TITLE
MySQL charset change

### DIFF
--- a/program/lib/Roundcube/db/mysql.php
+++ b/program/lib/Roundcube/db/mysql.php
@@ -47,17 +47,6 @@ class rcube_db_mysql extends rcube_db
     }
 
     /**
-     * Driver-specific configuration of database connection
-     *
-     * @param array $dsn DSN for DB connections
-     * @param PDO   $dbh Connection handler
-     */
-    protected function conn_configure($dsn, $dbh)
-    {
-        $dbh->query("SET NAMES 'utf8'");
-    }
-
-    /**
      * Abstract SQL statement for value concatenation
      *
      * @return string SQL statement to be used in query
@@ -101,7 +90,12 @@ class rcube_db_mysql extends rcube_db
             $params[] = 'unix_socket=' . $dsn['socket'];
         }
 
-        $params[] = 'charset=utf8';
+        if ($dsn['charset']) {
+            $params[] = 'charset=' . $dsn['charset'];
+        }
+        else {
+            $params[] = 'charset=utf8';
+        }
 
         if (!empty($params)) {
             $result .= implode(';', $params);


### PR DESCRIPTION
There is no reason to use "SET NAMES", when charset connection parameter is used.
This way charset can be easily configured in db_dsnw or forced on server side.
Motivation for this is use of utf8mb4 charset.