### PR TITLE
allow skins to define which layout options they support

### DIFF
--- a/program/lib/Roundcube/rcube_config.php
+++ b/program/lib/Roundcube/rcube_config.php
@@ -257,6 +257,9 @@ class rcube_config
             ini_set('error_log', $error_log);
         }
 
+        // set default screen layouts
+        $this->prop['supported_layouts'] = array('widescreen', 'desktop', 'list');
+
         // remove deprecated properties
         unset($this->prop['dst_active']);
     }
@@ -399,6 +402,11 @@ class rcube_config
             }
             if ($result && is_string($result)) {
                 $result = explode(',', $result);
+            }
+        }
+        else if ($name == 'layout') {
+            if (!in_array($result, $this->prop['supported_layouts'])) {
+                $result = $this->prop['supported_layouts'][0];
             }
         }
 

--- a/program/steps/settings/func.inc
+++ b/program/steps/settings/func.inc
@@ -404,7 +404,7 @@ function rcmail_user_prefs($current = null)
                 'advanced'    => array('name' => rcube::Q($RCMAIL->gettext('advancedoptions'))),
             );
 
-            if (!isset($no_override['layout'])) {
+            if (!isset($no_override['layout']) && count($config['supported_layouts']) > 1) {
                 if (!$current) {
                     continue 2;
                 }
@@ -412,9 +412,16 @@ function rcmail_user_prefs($current = null)
                 $field_id = 'rcmfd_layout';
                 $select   = new html_select(array('name' => '_layout', 'id' => $field_id));
 
-                $select->add($RCMAIL->gettext('layoutwidescreendesc'), 'widescreen');
-                $select->add($RCMAIL->gettext('layoutdesktopdesc'), 'desktop');
-                $select->add($RCMAIL->gettext('layoutlistdesc'), 'list');
+                $layouts = array(
+                    'widescreen' => 'layoutwidescreendesc',
+                    'desktop'    => 'layoutdesktopdesc',
+                    'list'       => 'layoutlistdesc'
+                );
+
+                $available_layouts = array_intersect_key($layouts, array_flip($config['supported_layouts']));
+                foreach ($available_layouts as $val => $label) {
+                    $select->add($RCMAIL->gettext($label), $val);
+                }
 
                 $blocks['main']['options']['layout'] = array(
                     'title'   => html::label($field_id, rcube::Q($RCMAIL->gettext('layout'))),

--- a/skins/elastic/meta.json
+++ b/skins/elastic/meta.json
@@ -4,7 +4,7 @@
 	"license": "Creative Commons Attribution-ShareAlike",
 	"license-url": "http://creativecommons.org/licenses/by-sa/3.0/",
 	"config": {
-		"layout": "widescreen",
+		"supported_layouts": ["widescreen"],
 		"jquery_ui_colors_theme": "bootstrap",
 		"embed_css_location": "/styles/embed.css",
 		"editor_css_location": "/styles/embed.css",


### PR DESCRIPTION
Elastic currently sets the `layout` config option to `dont_override`. This is a proposal for an alternative approach which allows a skin to define which of the core layout modes a skin supports. If only 1 mode is supported then the option is hidden on the settings screen.

This allows, for example, for a new skin to extend Elastic and add new layout options.

(excerpt from #7195)