### PR TITLE
create possibility to seperate screen and list layout options

### DIFF
--- a/program/js/app.js
+++ b/program/js/app.js
@@ -2364,7 +2364,7 @@ function rcube_webmail()
       row.cols.push(col);
     }
 
-    if (this.env.layout == 'widescreen')
+    if (flags.layout == 'widescreen')
       row = this.widescreen_message_row(row, uid, message);
 
     list.insert_row(row, attop);
@@ -2720,6 +2720,10 @@ function rcube_webmail()
       this.unmark_folder(mbox, 'recent', '', true);
       this.env.mailbox = mbox;
     }
+
+    url._list_layout = this.env.layout;
+    if (this.env.list_layout)
+      url._list_layout = this.env.list_layout;
 
     // load message list remotely
     if (this.gui_objects.messagelist) {

--- a/program/steps/mail/func.inc
+++ b/program/steps/mail/func.inc
@@ -359,7 +359,7 @@ function rcmail_message_list($attrib)
     $listcols = $a_show_cols;
 
     // Widescreen layout uses hardcoded list of columns
-    if ($RCMAIL->config->get('layout', 'widescreen') == 'widescreen') {
+    if ($_SESSION['list_layout'] == 'widescreen') {
         $a_show_cols = array('threads', 'subject', 'fromto', 'date', 'flag', 'attachment');
         $listcols    = $a_show_cols;
         array_shift($listcols);
@@ -410,6 +410,7 @@ function rcmail_js_message_list($a_headers, $insert_top=false, $a_show_cols=null
     $delimiter   = $RCMAIL->storage->get_hierarchy_delimiter();
     $search_set  = $RCMAIL->storage->get_search_set();
     $multifolder = $search_set && $search_set[1]->multi;
+    $layout      = $_SESSION['list_layout'];
 
     // add/remove 'folder' column to the list on multi-folder searches
     if ($multifolder && !in_array('folder', $a_show_cols)) {
@@ -434,7 +435,7 @@ function rcmail_js_message_list($a_headers, $insert_top=false, $a_show_cols=null
     $_SESSION['list_attrib']['columns'] = $a_show_cols;
 
     // Widescreen layout uses hardcoded list of columns
-    if ($RCMAIL->config->get('layout', 'widescreen') == 'widescreen') {
+    if ($layout == 'widescreen') {
         $a_show_cols = array('threads', 'subject', 'fromto', 'date', 'flag', 'attachment');
     }
 
@@ -446,7 +447,7 @@ function rcmail_js_message_list($a_headers, $insert_top=false, $a_show_cols=null
     $a_show_cols = $plugin['cols'];
     $a_headers   = $plugin['messages'];
 
-    if ($RCMAIL->config->get('layout', 'widescreen') == 'widescreen') {
+    if ($layout == 'widescreen') {
         if (!$RCMAIL->storage->get_threading()) {
             if (($idx = array_search('threads', $a_show_cols)) !== false) {
                 unset($a_show_cols[$idx]);
@@ -549,8 +550,9 @@ function rcmail_js_message_list($a_headers, $insert_top=false, $a_show_cols=null
         if ($header->priority)
             $a_msg_flags['prio'] = (int) $header->priority;
 
-        $a_msg_flags['ctype'] = rcube::Q($header->ctype);
-        $a_msg_flags['mbox']  = $header->folder;
+        $a_msg_flags['ctype']  = rcube::Q($header->ctype);
+        $a_msg_flags['mbox']   = $header->folder;
+        $a_msg_flags['layout'] = $layout;
 
         // merge with plugin result (Deprecated, use $header->flags)
         if (!empty($header->list_flags) && is_array($header->list_flags))

--- a/program/steps/mail/list.inc
+++ b/program/steps/mail/list.inc
@@ -54,6 +54,13 @@ if ($layout = rcube_utils::get_input_value('_layout', rcube_utils::INPUT_GET)) {
     $cols = $_SESSION['list_attrib']['columns'];
 }
 
+// register list layout change
+if ($list_layout = rcube_utils::get_input_value('_list_layout', rcube_utils::INPUT_GET)) {
+    $_SESSION['list_layout'] = $list_layout;
+    // force header replace on layout change
+    $cols = $_SESSION['list_attrib']['columns'];
+}
+
 if (!empty($save_arr)) {
     $RCMAIL->user->save_prefs($save_arr);
 }


### PR DESCRIPTION
Extend current UI layout behavior to allow a skin to use a different layout mode for the screen and for the message list. Currently if the screen is in widescreen mode then the list is also in widescreen mode.

(excerpt from #7195)