### PR TITLE
program/js/app.js: Remove forcing _mbox to INBOX on task switch.

### DIFF
--- a/program/js/app.js
+++ b/program/js/app.js
@@ -1582,9 +1582,7 @@ function rcube_webmail()
     if (action)
       url += '&_action=' + action;
 
-    if (task == 'mail')
-      url += '&_mbox=INBOX';
-    else if (task == 'logout') {
+    if (task == 'logout') {
       url = this.secure_url(url);
       this.clear_compose_data();
     }


### PR DESCRIPTION
There is no need to force the _mbox query parameter to "INBOX" when
switching task to "mail", since the actual selection of the current
folder is taken care of by rcmail_init_env() in
program/steps/mail/func.php.  In addition, by letting the latter
manage the current folder, going back to the "mail" task always goes
back to the last opened folder, which is more intuitive.

Signed-off-by: Ignacy Gawędzki <bugs@qult.net>