### PR TITLE
move all message list entry generation to client side

### DIFF
--- a/program/js/app.js
+++ b/program/js/app.js
@@ -2171,7 +2171,7 @@ function rcube_webmail()
   };
 
   // create a table row in the message list
-  this.add_message_row = function(uid, cols, flags, attop)
+  this.add_message_row = function(uid, cols, flags, attop, layout = this.env.layout)
   {
     if (!this.gui_objects.messagelist || !this.message_list)
       return false;
@@ -2219,7 +2219,14 @@ function rcube_webmail()
         + (flags.deleted ? ' deleted' : '')
         + (flags.flagged ? ' flagged' : '')
         + (message.selected ? ' selected' : ''),
-      row = { cols:[], style:{}, id:'rcmrow'+msg_id, uid:uid };
+      row = { cols:[], style:{}, id:'rcmrow'+msg_id, uid:uid },
+      listcols = layout == 'widescreen' ? this.env.listcols_widescreen : this.env.listcols;
+
+    // widescreen layout does not have a separate status column
+    if (layout == 'widescreen')
+      this.env.status_col = null;
+    else if ((n = $.inArray('status', this.env.listcols)) >= 0)
+      this.env.status_col = n;
 
     // message status icons
     css_class = 'msgicon';
@@ -2298,8 +2305,8 @@ function rcube_webmail()
     }
 
     // add each submitted col
-    for (n in this.env.listcols) {
-      c = this.env.listcols[n];
+    for (n in listcols) {
+      c = listcols[n];
       col = {className: String(c).toLowerCase(), events:{}};
 
       if (this.env.coltypes[c] && this.env.coltypes[c].hidden) {
@@ -2364,7 +2371,7 @@ function rcube_webmail()
       row.cols.push(col);
     }
 
-    if (this.env.layout == 'widescreen')
+    if (layout == 'widescreen')
       row = this.widescreen_message_row(row, uid, message);
 
     list.insert_row(row, attop);
@@ -8330,7 +8337,7 @@ function rcube_webmail()
   {
     var list = this.message_list,
       thead = list ? list.thead : null,
-      repl, cell, col, n, len, tr;
+      repl, cell, col, c, n, len, tr;
 
     this.env.listcols = listcols;
 
@@ -8343,7 +8350,8 @@ function rcube_webmail()
         thead.innerHTML = '';
         tr = document.createElement('tr');
 
-        for (c=0, len=repl.length; c < len; c++) {
+        for (n in this.env.listcols) {
+          c = this.env.listcols[n];
           cell = document.createElement('th');
           cell.innerHTML = repl[c].html || '';
           if (repl[c].id) cell.id = repl[c].id;

--- a/program/steps/mail/func.inc
+++ b/program/steps/mail/func.inc
@@ -448,10 +448,7 @@ function rcmail_js_message_list($a_headers, $insert_top=false, $a_show_cols=null
     $thead = $head_replace ? rcmail_message_list_head($_SESSION['list_attrib'], $allcols) : NULL;
 
     // get name of smart From/To column in folder context
-    if (array_search('fromto', $a_show_cols) !== false) {
-        $smart_col = rcmail_message_list_smart_column_name();
-    }
-
+    $smart_col = rcmail_message_list_smart_column_name();
     $OUTPUT->command('set_message_coltypes', array_values($a_show_cols), $thead, $smart_col);
 
     if ($multifolder && $_SESSION['search_scope'] == 'all') {

--- a/program/steps/mail/func.inc
+++ b/program/steps/mail/func.inc
@@ -358,13 +358,6 @@ function rcmail_message_list($attrib)
 
     $listcols = $a_show_cols;
 
-    // Widescreen layout uses hardcoded list of columns
-    if ($RCMAIL->config->get('layout', 'widescreen') == 'widescreen') {
-        $a_show_cols = array('threads', 'subject', 'fromto', 'date', 'flag', 'attachment');
-        $listcols    = $a_show_cols;
-        array_shift($listcols);
-    }
-
     // set client env
     $OUTPUT->add_gui_object('messagelist', $attrib['id']);
     $OUTPUT->set_env('autoexpand_threads', intval($RCMAIL->config->get('autoexpand_threads')));
@@ -372,14 +365,21 @@ function rcmail_message_list($attrib)
     $OUTPUT->set_env('sort_order', $_SESSION['sort_order']);
     $OUTPUT->set_env('messages', array());
     $OUTPUT->set_env('listcols', $listcols);
+    $OUTPUT->set_env('listcols_widescreen', array('threads', 'subject', 'fromto', 'date', 'flag', 'attachment'));
 
     $OUTPUT->include_script('list.js');
 
     $table = new html_table($attrib);
 
     if (!$attrib['noheader']) {
-        foreach (rcmail_message_list_head($attrib, $a_show_cols) as $cell)
-            $table->add_header(array('class' => $cell['className'], 'id' => $cell['id']), $cell['html']);
+        $allcols = array_merge($listcols, array('threads', 'subject', 'fromto', 'date', 'flag', 'attachment'));
+        $allcols = array_unique($allcols);
+
+        foreach (rcmail_message_list_head($attrib, $allcols) as $col => $cell) {
+            if (in_array($col, $listcols)) {
+                $table->add_header(array('class' => $cell['className'], 'id' => $cell['id']), $cell['html']);
+            }
+        }
     }
 
     return $table->show();
@@ -433,11 +433,6 @@ function rcmail_js_message_list($a_headers, $insert_top=false, $a_show_cols=null
     $a_show_cols = array_unique($a_show_cols);
     $_SESSION['list_attrib']['columns'] = $a_show_cols;
 
-    // Widescreen layout uses hardcoded list of columns
-    if ($RCMAIL->config->get('layout', 'widescreen') == 'widescreen') {
-        $a_show_cols = array('threads', 'subject', 'fromto', 'date', 'flag', 'attachment');
-    }
-
     // Plugins may set header's list_cols/list_flags and other rcube_message_header variables
     // and list columns
     $plugin = $RCMAIL->plugins->exec_hook('messages_list',
@@ -446,15 +441,11 @@ function rcmail_js_message_list($a_headers, $insert_top=false, $a_show_cols=null
     $a_show_cols = $plugin['cols'];
     $a_headers   = $plugin['messages'];
 
-    if ($RCMAIL->config->get('layout', 'widescreen') == 'widescreen') {
-        if (!$RCMAIL->storage->get_threading()) {
-            if (($idx = array_search('threads', $a_show_cols)) !== false) {
-                unset($a_show_cols[$idx]);
-            }
-        }
-    }
+    // make sure minimum required columns are present (needed for widescreen layout)
+    $allcols = array_merge($a_show_cols, array('threads', 'subject', 'fromto', 'date', 'flag', 'attachment'));
+    $allcols = array_unique($allcols);
 
-    $thead = $head_replace ? rcmail_message_list_head($_SESSION['list_attrib'], $a_show_cols) : NULL;
+    $thead = $head_replace ? rcmail_message_list_head($_SESSION['list_attrib'], $allcols) : NULL;
 
     // get name of smart From/To column in folder context
     if (array_search('fromto', $a_show_cols) !== false) {
@@ -475,8 +466,8 @@ function rcmail_js_message_list($a_headers, $insert_top=false, $a_show_cols=null
 
     // remove 'threads', 'attachment', 'flag', 'status' columns, we don't need them here
     foreach (array('threads', 'attachment', 'flag', 'status', 'priority') as $col) {
-        if (($key = array_search($col, $a_show_cols)) !== FALSE) {
-            unset($a_show_cols[$key]);
+        if (($key = array_search($col, $allcols)) !== FALSE) {
+            unset($allcols[$key]);
         }
     }
 
@@ -500,7 +491,7 @@ function rcmail_js_message_list($a_headers, $insert_top=false, $a_show_cols=null
         $a_msg_flags = array();
 
         // format each col; similar as in rcmail_message_list()
-        foreach ($a_show_cols as $col) {
+        foreach ($allcols as $col) {
             $col_name = $col == 'fromto' ? $smart_col : $col;
 
             if (in_array($col_name, array('from', 'to', 'cc', 'replyto'))) {
@@ -655,7 +646,7 @@ function rcmail_message_list_head($attrib, $a_show_cols)
         $class_name = $col.$sort_class;
 
         // put it all together
-        $cells[] = array('className' => $class_name, 'id' => "rcm$col", 'html' => $col_name);
+        $cells[$col] = array('className' => $class_name, 'id' => "rcm$col", 'html' => $col_name);
         $coltypes[$col] = array('className' => $class_name, 'id' => "rcm$col", 'label' => $label, 'sortable' => $sortable);
     }
 


### PR DESCRIPTION
This is a rethink of PR #7236.

Rather than changing which cols are returned by `rcmail_js_message_list()` the idea is to always return the user's configured columns plus the hard coded cols required to create the widescreen layout of the message list and then allow the `add_message_row()` JS function to decide what to display and the layout.

I've also added a new JS even to allow skins/plugins to override the defaults and define how a message list row should be rendered.