### PR TITLE
Bugfix in password/pwned driver result parsing

### DIFF
--- a/plugins/password/drivers/pwned.php
+++ b/plugins/password/drivers/pwned.php
@@ -203,7 +203,7 @@ class rcube_pwned_password
         foreach (preg_split('/[\r\n]+/', $list) as $line) {
             $line = strtolower($line);
 
-            if (preg_match('/^([0-9a-f]{35}):(\d)+$/', $line, $matches)) {
+            if (preg_match('/^([0-9a-f]{35}):(\d+)$/', $line, $matches)) {
                 if ($matches[2] > 0 && $matches[1] === $candidate) {
                     // more than 0 occurrences, and suffix matches
                     // -> password is compromised


### PR DESCRIPTION
This is a fix for a subtle bug in the pwned driver of the password plugin.

The original regex mistakenly only captured the first digit of the count, instead of all digits, and then compared that captured number to be greater than 0.

For all practical purposes, this should not make a difference, because there is no sensible use case where the API would return any number greater than 0 prefixed with a 0 (e.g. '04' instead of '4', which would be the only way to trigger the bug).

Still, this is a bug, even if only theoretically exploitable, and that's the reason for this bugfix PR.

PS: I'm really sorry for not having noticed this earlier on. I double- and triple-checked my code before submitting it. But I only realized this particular issue now, after looking at the code yet another time.
