### PR TITLE
fix typo in regex in keyservers function

### DIFF
--- a/program/lib/Roundcube/rcube_config.php
+++ b/program/lib/Roundcube/rcube_config.php
@@ -594,7 +594,7 @@ class rcube_config
         $list = (array) $this->prop['keyservers'];
 
         foreach ($list as $idx => $host) {
-            if (!preg_match('|^[a-z]://|', $host)) {
+            if (!preg_match('|^[a-z]+://|', $host)) {
                 $host = "https://$host";
             }
 


### PR DESCRIPTION
`|^[a-z]://|` matches only single-character protocol shortnames, to correctly exclude e.g. `hkps://` the expression should be `|^[a-z]+://|` instead.