### PR TITLE
allow array in smtp_host config

### DIFF
--- a/config/config.inc.php.sample
+++ b/config/config.inc.php.sample
@@ -50,6 +50,8 @@ $config['default_host'] = 'localhost';
 // %d - domain (http hostname $_SERVER['HTTP_HOST'] without the first part)
 // %z - IMAP domain (IMAP hostname without the first part)
 // For example %n = mail.domain.tld, %t = domain.tld
+// To specify differnt SMTP servers for different IMAP hosts provide an array
+// of IMAP host (no prefix or port) and SMTP server e.g. array('imap.example.com' => 'smtp.example.net')
 $config['smtp_server'] = 'localhost';
 
 // SMTP port. Use 25 for cleartext, 465 for Implicit TLS, or 587 for STARTTLS (default)

--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -267,6 +267,8 @@ $config['messages_cache_threshold'] = 50;
 // %d - domain (http hostname $_SERVER['HTTP_HOST'] without the first part)
 // %z - IMAP domain (IMAP hostname without the first part)
 // For example %n = mail.domain.tld, %t = domain.tld
+// To specify differnt SMTP servers for different IMAP hosts provide an array
+// of IMAP host (no prefix or port) and SMTP server e.g. array('imap.example.com' => 'smtp.example.net')
 $config['smtp_server'] = 'localhost';
 
 // SMTP port. Use 25 for cleartext, 465 for Implicit TLS, or 587 for STARTTLS (default)

--- a/installer/test.php
+++ b/installer/test.php
@@ -263,6 +263,15 @@ else {
   echo "<br/>";
 }
 
+$smtp_hosts = $RCI->get_hostlist('smtp_server');
+if (!empty($smtp_hosts)) {
+  $smtp_host_field = new html_select(array('name' => '_smtp_host', 'id' => 'smtp_server'));
+  $smtp_host_field->add($smtp_hosts);
+}
+else {
+  $smtp_host_field = new html_inputfield(array('name' => '_smtp_host', 'id' => 'smtp_server'));
+}
+
 $user = $RCI->getprop('smtp_user', '(none)');
 $pass = $RCI->getprop('smtp_pass', '(none)');
 
@@ -284,7 +293,7 @@ if ($pass == '%p') {
 <tbody>
   <tr>
     <td><label for="smtp_server">Server</label></td>
-    <td><?php echo rcube_utils::parse_host($RCI->getprop('smtp_server', 'localhost')); ?></td>
+    <td><?php echo $smtp_host_field->show($_POST['_smtp_host']); ?></td>
   </tr>
   <tr>
     <td><label for="smtp_port">Port</label></td>
@@ -310,6 +319,9 @@ $to_field   = new html_inputfield(array('name' => '_to', 'id' => 'sendmailto'));
 if (isset($_POST['sendmail'])) {
 
   echo '<p>Trying to send email...<br />';
+
+  $smtp_host = trim($_POST['_smtp_host']);
+  $smtp_port = $RCI->getprop('smtp_port');
 
   $from = rcube_utils::idn_to_ascii(trim($_POST['_from']));
   $to   = rcube_utils::idn_to_ascii(trim($_POST['_to']));
@@ -340,8 +352,7 @@ if (isset($_POST['sendmail'])) {
     $head         = $mail_object->txtHeaders($send_headers);
 
     $SMTP = new rcube_smtp();
-    $SMTP->connect(rcube_utils::parse_host($RCI->getprop('smtp_server')),
-      $RCI->getprop('smtp_port'), $CONFIG['smtp_user'], $CONFIG['smtp_pass']);
+    $SMTP->connect($smtp_host, $smtp_port, $CONFIG['smtp_user'], $CONFIG['smtp_pass']);
 
     $status        = $SMTP->send_mail($headers['From'], $headers['To'], $head, $body);
     $smtp_response = $SMTP->get_response();

--- a/program/include/rcmail_install.php
+++ b/program/include/rcmail_install.php
@@ -599,18 +599,33 @@ class rcmail_install
     }
 
     /**
-     * Return a list with all imap hosts configured
+     * Return a list with all imap/smtp hosts configured
      *
-     * @return array Clean list with imap hosts
+     * @return array Clean list with imap/smtp hosts
      */
-    public function get_hostlist()
+    public function get_hostlist($prop = 'default_host')
     {
-        $default_hosts = (array) $this->getprop('default_host');
-        $out           = array();
+        $hosts     = (array) $this->getprop($prop);
+        $out       = array();
+        $imap_host = '';
 
-        foreach ($default_hosts as $key => $name) {
+        if ($prop == 'smtp_server') {
+            // Set the imap host name for the %h macro
+            $default_hosts = $this->get_hostlist();
+            $imap_host = !empty($default_hosts) ? $default_hosts[0] : '';
+        }
+
+        foreach ($hosts as $key => $name) {
             if (!empty($name)) {
-                $out[] = rcube_utils::parse_host(is_numeric($key) ? $name : $key);
+                if ($prop == 'smtp_server') {
+                    // SMTP host array uses `IMAP host => SMTP host` format
+                    $host = $name;
+                }
+                else {
+                    $host = is_numeric($key) ? $name : $key;
+                }
+
+                $out[] = rcube_utils::parse_host($host, $imap_host);
             }
         }
 

--- a/program/lib/Roundcube/rcube_smtp.php
+++ b/program/lib/Roundcube/rcube_smtp.php
@@ -57,9 +57,23 @@ class rcube_smtp
         // reset error/response var
         $this->error = $this->response = null;
 
+        if (!$host) {
+            $host = $rcube->config->get('smtp_server');
+            if (is_array($host)) {
+                if (array_key_exists($_SESSION['storage_host'], $host)) {
+                    $host = $host[$_SESSION['storage_host']];
+                }
+                else {
+                    $this->response[] = "Connection failed: No SMTP server found for IMAP host " . $_SESSION['storage_host'];
+                    $this->error = array('label' => 'smtpconnerror', 'vars' => array('code' => '500'));
+                    return false;
+                }
+            }
+        }
+
         // let plugins alter smtp connection config
         $CONFIG = $rcube->plugins->exec_hook('smtp_connect', array(
-            'smtp_server'    => $host ?: $rcube->config->get('smtp_server'),
+            'smtp_server'    => $host,
             'smtp_port'      => $port ?: $rcube->config->get('smtp_port', 587),
             'smtp_user'      => $user !== null ? $user : $rcube->config->get('smtp_user', '%u'),
             'smtp_pass'      => $pass !== null ? $pass : $rcube->config->get('smtp_pass', '%p'),


### PR DESCRIPTION
it is possible to configure an array of imap hosts but not smtp hosts so if not all your providers use the same naming conventions for their servers you can configure the imap but the smtp.

inspired by https://www.roundcubeforum.net/index.php/topic,28819.msg73532.html#msg73532

if this is accepted I'll update the config information in the wiki to include the array option, similar to what is there for the default_host option - i did not update the comments in `defaults.inc.php` because there is nothing there about the array option for the imap so I think the wiki is enough.

I've also fixed a bug in the installer which meant that the `%h` macro of `smtp_server` was never expanded and always returned blank.