### PR TITLE
Fix CSRF attack that can cause an authenticated user to be logged out

### DIFF
--- a/index.php
+++ b/index.php
@@ -101,7 +101,7 @@ $RCMAIL->set_task($startup['task']);
 $RCMAIL->action = $startup['action'];
 
 // try to log in
-if ($RCMAIL->task == 'login' && $RCMAIL->action == 'login') {
+if ($RCMAIL->task == 'login' && $RCMAIL->action == 'login' && !isset($_SESSION['user_id'])) {
     $request_valid = $_SESSION['temp'] && $RCMAIL->check_request();
     $pass_charset  = $RCMAIL->config->get('password_charset', 'UTF-8');
 
@@ -185,7 +185,7 @@ if ($RCMAIL->task == 'login' && $RCMAIL->action == 'login') {
 }
 
 // end session
-else if ($RCMAIL->task == 'logout' && isset($_SESSION['user_id'])) {
+else if ($RCMAIL->task == 'logout' && isset($_SESSION['user_id']) && $_SERVER['REQUEST_METHOD'] == 'GET') {
     $RCMAIL->request_security_check($mode = rcube_utils::INPUT_GET);
 
     $userdata = array(


### PR DESCRIPTION
A login POST request without a valid token deleted the active session. The login
code should not run if the session is already authenticated.

A logout POST request succeeded without a valid token as the token checking code
only considers GET. Logging out should therefore be restricted to GET.

A simple proof of concept:

```
<div>
        <form method="post" action="https://demo.roundcubeplus.com/">
                <input type="hidden" name="_task" value="logout">
                <button type="submit">logout</button>
        </form>
        <form method="post" action="https://demo.roundcubeplus.com/">
                <input type="hidden" name="_task" value="login">
                <input type="hidden" name="_action" value="login">
                <input type="hidden" name="_user" value="example">
                <input type="hidden" name="_pass" value="example">
                <button type="submit">login</button>
        </form>
</div>
```