### PR TITLE
7251 Add option to keep sessions when browser restarts

### DIFF
--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -488,7 +488,18 @@ $config['skin_include_php'] = false;
 $config['display_product_info'] = 1;
 
 // Session lifetime in minutes
+// While the browser is active, the session's life is constantly extended. But
+// when the browser is inactive, the session expires after this amount of
+// minutes.
 $config['session_lifetime'] = 10;
+
+// Maximum session lifetime in minutes
+// Maximum allowed time for a user to stay logged in even while the browser is
+// active. A value of 0 means that the session will be valid until the browser
+// is closed. A greater value means that logins persist browser restarts. But
+// the session will end this amount of minutes after the user initially logged
+// in.
+$config['session_lifetime_max'] = 0;
 
 // Session domain: .example.org
 $config['session_domain'] = '';

--- a/program/lib/Roundcube/rcube.php
+++ b/program/lib/Roundcube/rcube.php
@@ -443,6 +443,7 @@ class rcube
         $sess_path     = $this->config->get('session_path');
         $sess_samesite = $this->config->get('session_samesite');
         $lifetime      = $this->config->get('session_lifetime', 0) * 60;
+        $lifetime_max  = $this->config->get('session_lifetime_max', 0) * 60;
         $is_secure     = $this->config->get('use_https') || rcube_utils::https_check();
 
         // set session domain
@@ -463,8 +464,7 @@ class rcube
             ini_set('session.gc_maxlifetime', $lifetime * 2);
         }
 
-        // set session cookie lifetime so it never expires (#5961)
-        ini_set('session.cookie_lifetime', 0);
+        ini_set('session.cookie_lifetime', $lifetime_max);
         ini_set('session.cookie_secure', $is_secure);
         ini_set('session.name', $sess_name ?: 'roundcube_sessid');
         ini_set('session.use_cookies', 1);

--- a/program/lib/Roundcube/rcube_session.php
+++ b/program/lib/Roundcube/rcube_session.php
@@ -693,8 +693,9 @@ abstract class rcube_session
      */
     public function set_auth_cookie()
     {
+        $expiry_timestamp = $this->now + ($this->lifetime / 2) * 3;
         $this->cookie = $this->_mkcookie($this->now);
-        rcube_utils::setcookie($this->cookiename, $this->cookie, 0);
+        rcube_utils::setcookie($this->cookiename, $this->cookie, $expiry_timestamp);
         $_COOKIE[$this->cookiename] = $this->cookie;
     }
 


### PR DESCRIPTION
This is a proposal to solve #7251 with backwards compatibility. The new configuration variable `session_lifetime_max` sets an expiry date on the session cookie. It will survive browser restarts. But since PHP is not renewing session cookies, it also limits the maximum time a user can be logged in. After that amount of time the user gets kicked out. This is different to the default configuration which will let the session cookie live until the browser is closed, which could be never.

### Draft

I see a possible issues here:

It could be very inconvenient to get kicked out while you are logged in, potentially writing an email. In order to prevent that, we would need to renew the session cookie. Is that something worthwhile?

Reviewing this situation, I'm not sure if the additional authentication cookie is necessary. Its purpose is better security but I'm wondering if we could renew the session cookie in a similar fashion.

The timeslot logic is a bit complex and doesn't add any security. An attacker could steal an old cookie and guess the new timestamp after observing the session lifetime. I'm not sure I have enough time for a re-implementation though.