### PR TITLE
Option to make message too big errors more human friendly

### DIFF
--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -703,6 +703,10 @@ $config['sendmail_delay'] = 0;
 // Size in bytes (possible unit suffix: K, M, G)
 $config['max_message_size'] = '100M';
 
+// Show message size by the attachable size in errors. i.e. the above limit
+// divided by 1.33 to account for base64 encoding.
+$config['show_message_size_by_attachment'] = false;
+
 // Maximum number of recipients per message (including To, Cc, Bcc).
 // Default: 0 (no limit)
 $config['max_recipients'] = 0;

--- a/program/actions/mail/attachment_upload.php
+++ b/program/actions/mail/attachment_upload.php
@@ -275,7 +275,12 @@ class rcmail_action_mail_attachment_upload extends rcmail_action_mail_index
         $size  += $filesize * $multip;
 
         if ($size > $limit) {
-            $limit = self::show_bytes($limit);
+            if ($rcmail->config->get('show_message_size_by_attachment')) {
+                // Account for base64 encoding
+                $limit = self::show_bytes($limit/1.33);
+            } else {
+                $limit = self::show_bytes($limit);
+            }
             return $rcmail->gettext(['name' => 'msgsizeerror', 'vars' => ['size' => $limit]]);
         }
     }

--- a/program/actions/mail/compose.php
+++ b/program/actions/mail/compose.php
@@ -1253,7 +1253,12 @@ class rcmail_action_mail_compose extends rcmail_action_mail_index
         }
 
         if ($size_errors) {
-            $limit = self::show_bytes($size_limit);
+            if ($rcmail->config->get('show_message_size_by_attachment')) {
+                // Account for base64 encoding
+                $limit = self::show_bytes($limit/1.33);
+            } else {
+                $limit = self::show_bytes($limit);
+            }
             $error = $rcmail->gettext([
                     'name' => 'msgsizeerrorfwd',
                     'vars' => ['num' => $size_errors, 'size' => $limit]


### PR DESCRIPTION
When a user attempts to add an attachment which puts the message over the max message size limit, the error shown states the limit as the "real" maximum size. This is confusing for most people, as their attachments will always add up to far less than that maximum size.

This change adds an option, which is disabled by default, to make the maximum message size in these errors show up as the maximum "practical" size, calculated the same as we calculate the maximum attachment size - dividing by 1.33 to accomodate base64 overhead.