### PR TITLE
English grammar correction

### DIFF
--- a/installer/config.php
+++ b/installer/config.php
@@ -104,7 +104,7 @@ $input_support = new html_inputfield(array('name' => '_support_url', 'size' => 5
 echo $input_support->show($RCI->getprop('support_url'));
 
 ?>
-<div>Provide an URL where a user can get support for this Roundcube installation.<br/>PLEASE DO NOT LINK TO THE ROUNDCUBE.NET WEBSITE HERE!</div>
+<div>Provide a URL where a user can get support for this Roundcube installation.<br/>PLEASE DO NOT LINK TO THE ROUNDCUBE.NET WEBSITE HERE!</div>
 <p class="hint">Enter an absolute URL (including http://) to a support page/form or a mailto: link.</p>
 </dd>
 

--- a/program/include/rcmail.php
+++ b/program/include/rcmail.php
@@ -850,7 +850,7 @@ class rcmail extends rcube
      *
      * @param mixed   $p        Either a string with the action or
      *                          url parameters as key-value pairs
-     * @param boolean $absolute Build an URL absolute to document root
+     * @param boolean $absolute Build a URL absolute to document root
      * @param boolean $full     Create fully qualified URL including http(s):// and hostname
      * @param bool    $secure   Return absolute URL in secure location
      *

--- a/program/steps/addressbook/photo.inc
+++ b/program/steps/addressbook/photo.inc
@@ -73,7 +73,7 @@ if ($plugin['url']) {
 
 $data = $plugin['data'];
 
-// detect if photo data is an URL
+// detect if photo data is a URL
 if (strlen($data) < 1024 && filter_var($data, FILTER_VALIDATE_URL)) {
     $RCMAIL->output->redirect($data);
 }


### PR DESCRIPTION
"An" is usually used when the next word starts with a vowel, but the "U" in URL is pronounced like a consonant. Therefore, "a" should be used in front of URL instead.

Changed from "an URL" to "a URL" in three files.