### PR TITLE
Several Mailvelope-related fixes and features

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -70,6 +70,7 @@ RELEASE 1.4.4
 - Security: Fix local file inclusion (and code execution) via crafted 'plugins' option [CVE-2020-12640]
 - Security: Fix CSRF bypass that could be used to log out an authenticated user [CVE-2020-12626] (#7302)
 - Mailvelope: Fix size of iframe for PGP-inlined mail (#7348)
+- Mailvelope: Add config option to use Main Keyring (#7348)
 
 RELEASE 1.4.3
 -------------

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -71,6 +71,7 @@ RELEASE 1.4.4
 - Security: Fix CSRF bypass that could be used to log out an authenticated user [CVE-2020-12626] (#7302)
 - Mailvelope: Fix size of iframe for PGP-inlined mail (#7348)
 - Mailvelope: Add config option to use Main Keyring (#7348)
+- Mailvelope: Add config option to set the size for new keys (#7348)
 
 RELEASE 1.4.3
 -------------

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -72,6 +72,7 @@ RELEASE 1.4.4
 - Mailvelope: Fix size of iframe for PGP-inlined mail (#7348)
 - Mailvelope: Add config option to use Main Keyring (#7348)
 - Mailvelope: Add config option to set the size for new keys (#7348)
+- Mailvelope: Always ask before discarding email currently being composed (#7348)
 
 RELEASE 1.4.3
 -------------

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -69,6 +69,7 @@ RELEASE 1.4.4
 - Security: Fix remote code execution via crafted 'im_convert_path' or 'im_identify_path' settings [CVE-2020-12641]
 - Security: Fix local file inclusion (and code execution) via crafted 'plugins' option [CVE-2020-12640]
 - Security: Fix CSRF bypass that could be used to log out an authenticated user [CVE-2020-12626] (#7302)
+- Mailvelope: Fix size of iframe for PGP-inlined mail (#7348)
 
 RELEASE 1.4.3
 -------------

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -73,6 +73,7 @@ RELEASE 1.4.4
 - Mailvelope: Add config option to use Main Keyring (#7348)
 - Mailvelope: Add config option to set the size for new keys (#7348)
 - Mailvelope: Always ask before discarding email currently being composed (#7348)
+- Mailvelope: Fix unnecessary warning to re-add attachments when restoring a draft (#7348)
 
 RELEASE 1.4.3
 -------------

--- a/config/config.inc.php.sample
+++ b/config/config.inc.php.sample
@@ -86,3 +86,7 @@ $config['plugins'] = array(
 
 // skin name: folder from skins/
 $config['skin'] = 'elastic';
+
+// Use the Main Keyring in Mailvelope? If not, use (creating if required)
+// a per-site keyring. Most sites use the Main Keyring, so set this to true.
+$config['mailvelope_main_keyring'] = true;

--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -854,6 +854,10 @@ $config['compose_responses_static'] = array(
 // Note: Lookup is client-side, so the server must support Cross-Origin Resource Sharing
 $config['keyservers'] = array('keys.openpgp.org');
 
+// Use the Main Keyring in Mailvelope? If not, use (creating if required)
+// a per-site keyring. This is set to false for backwards compatibility.
+$config['mailvelope_main_keyring'] = false;
+
 // ----------------------------------
 // ADDRESSBOOK SETTINGS
 // ----------------------------------

--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -858,6 +858,10 @@ $config['keyservers'] = array('keys.openpgp.org');
 // a per-site keyring. This is set to false for backwards compatibility.
 $config['mailvelope_main_keyring'] = false;
 
+// Mailvelope RSA bit size for newly generated keys, either 2048 or 4096.
+// It maybe desirable to use 2048 for sites with many mobile users.
+$config['mailvelope_keysize'] = 4096;
+
 // ----------------------------------
 // ADDRESSBOOK SETTINGS
 // ----------------------------------

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -4268,7 +4268,7 @@ function rcube_webmail()
   {
     var cid = new Date().getTime();
     var user_id = {email: identity_email, fullName: $(ref.gui_objects.editform).find('.ff_name').val().trim()};
-    var options = {userIds: [user_id], keySize: 4096};
+    var options = {userIds: [user_id], keySize: this.env.mailvelope_keysize};
 
     $('<div>').attr('id', 'mailvelope-keygen-container-' + cid)
       .css({height: '245px', marginBottom: '10px'})

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -760,7 +760,8 @@ function rcube_webmail()
 
     // check input before leaving compose step
     if (this.task == 'mail' && this.env.action == 'compose' && !this.env.server_error && command != 'save-pref'
-      && $.inArray(command, this.env.compose_commands) < 0 && !this.compose_skip_unsavedcheck
+      && ($.inArray(command, this.env.compose_commands) < 0 || command.startsWith('compose-encrypted') && ref.mailvelope_editor)
+      && !this.compose_skip_unsavedcheck
     ) {
       if (!this.env.is_sent && this.cmp_hash != this.compose_field_hash()) {
         this.confirm_dialog(this.get_label('notsentwarning'), 'discard', function() {
@@ -3834,7 +3835,6 @@ function rcube_webmail()
     // remove Mailvelope editor if active
     if (ref.mailvelope_editor) {
       ref.mailvelope_editor = null;
-      ref.compose_skip_unsavedcheck = false;
       ref.set_button('compose-encrypted', 'act');
 
       container.removeClass('mailvelope')
@@ -3872,7 +3872,6 @@ function rcube_webmail()
 
       mailvelope.createEditorContainer('#' + container.attr('id'), ref.mailvelope_keyring, options).then(function(editor) {
         ref.mailvelope_editor = editor;
-        ref.compose_skip_unsavedcheck = true;
         ref.set_button('compose-encrypted', 'sel');
 
         container.addClass('mailvelope');

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -4021,7 +4021,8 @@ function rcube_webmail()
       }
 
       ref.hide_message(msgid);
-      $(selector).addClass('mailvelope').children().not('iframe').hide();
+      $(selector).children().not('iframe').hide();
+      $('#messagebody').addClass('mailvelope');
 
       // on success we can remove encrypted part from the attachments list
       if (ref.env.pgp_mime_part)

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -3711,7 +3711,7 @@ function rcube_webmail()
   // Load Mailvelope functionality (and initialize keyring if needed)
   this.mailvelope_load = function(action)
   {
-    var keyring = this.env.user_id,
+    var keyring = this.env.mailvelope_main_keyring ? undefined : this.env.user_id,
       fn = function(kr) {
         ref.mailvelope_keyring = kr;
         ref.mailvelope_init(action, kr);
@@ -3722,10 +3722,14 @@ function rcube_webmail()
       mailvelope.VERSION_MAJOR = Math.floor(parseFloat(v));
       return mailvelope.getKeyring(keyring);
     }).then(fn, function(err) {
-      // attempt to create a new keyring for this app/user
-      mailvelope.createKeyring(keyring).then(fn, function(err) {
+      if (keyring) {
+        // attempt to create a new keyring for this app/user
+        mailvelope.createKeyring(keyring).then(fn, function(err) {
+          console.error(err);
+        });
+      } else {
         console.error(err);
-      });
+      }
     });
   };
 

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -3881,9 +3881,14 @@ function rcube_webmail()
         ref.enable_command('spellcheck', 'insert-sig', 'toggle-editor', 'insert-response', 'save-response', false);
         ref.triggerEvent('compose-encrypted', { active:true });
 
-        // notify user about loosing attachments
         if (ref.env.attachments && !$.isEmptyObject(ref.env.attachments)) {
-          ref.alert_dialog(ref.get_label('encryptnoattachments'));
+          // notify user if losing attachments
+          if (ref.env.compose_mode != 'draft'
+            || Object.keys(ref.env.attachments).length != 1
+            || ref.env.attachments[Object.keys(ref.env.attachments)[0]].name != 'encrypted.asc'
+          ) {
+            ref.alert_dialog(ref.get_label('encryptnoattachments'));
+          }
 
           $.each(ref.env.attachments, function(name, attach) {
             ref.remove_from_attachment_list(name);

--- a/program/steps/mail/compose.inc
+++ b/program/steps/mail/compose.inc
@@ -93,6 +93,7 @@ $OUTPUT->set_env('save_localstorage', (bool)$RCMAIL->config->get('compose_save_l
 $OUTPUT->set_env('is_sent', false);
 $OUTPUT->set_env('mimetypes', rcmail_supported_mimetypes());
 $OUTPUT->set_env('keyservers', $RCMAIL->config->keyservers());
+$OUTPUT->set_env('mailvelope_main_keyring', $RCMAIL->config->get('mailvelope_main_keyring'));
 
 $drafts_mbox     = $RCMAIL->config->get('drafts_mbox');
 $config_show_sig = $RCMAIL->config->get('show_sig', 1);

--- a/program/steps/mail/show.inc
+++ b/program/steps/mail/show.inc
@@ -85,7 +85,7 @@ if ($uid) {
 
     // set configuration
     $RCMAIL->set_env_config(array('delete_junk', 'flag_for_deletion', 'read_when_deleted',
-        'skip_deleted', 'display_next', 'forward_attachment'));
+        'skip_deleted', 'display_next', 'forward_attachment', 'mailvelope_main_keyring'));
 
     // set special folders
     foreach (array('drafts', 'trash', 'junk') as $mbox) {

--- a/program/steps/settings/edit_identity.inc
+++ b/program/steps/settings/edit_identity.inc
@@ -34,6 +34,7 @@ if (($_GET['_iid'] || $_POST['_iid']) && $RCMAIL->action=='edit-identity') {
         return;
     }
     $OUTPUT->set_env('mailvelope_main_keyring', $RCMAIL->config->get('mailvelope_main_keyring'));
+    $OUTPUT->set_env('mailvelope_keysize', $RCMAIL->config->get('mailvelope_keysize'));
 }
 // add-identity
 else {

--- a/program/steps/settings/edit_identity.inc
+++ b/program/steps/settings/edit_identity.inc
@@ -33,6 +33,7 @@ if (($_GET['_iid'] || $_POST['_iid']) && $RCMAIL->action=='edit-identity') {
         $RCMAIL->overwrite_action('identities');
         return;
     }
+    $OUTPUT->set_env('mailvelope_main_keyring', $RCMAIL->config->get('mailvelope_main_keyring'));
 }
 // add-identity
 else {


### PR DESCRIPTION
Each commit is listed below. I'm open to any disagreements/critiques, so please fire away!

 * ~~24d0cf5~~ *Merged.* Let Mailvelope use sender's address to find pubkeys to check signatures

    Also remove the showExternalContent option which was removed from the Mailvelope API January 2019.

 * cec240d Fix size of Mailvelope iframe for PGP-inlined mail

    Emails with PGP attachments appear correctly [like this](https://user-images.githubusercontent.com/2966862/80312069-38324080-87b1-11ea-8ce9-88e263e1931b.png), but emails with the PGP in the message body before this commit looked squished [like this](https://user-images.githubusercontent.com/2966862/80312089-55670f00-87b1-11ea-8944-f0510c642a28.png). Now they both appear correctly. (Only tested in Chromium and Firefox 75, sorry.)

 * ~~c3d4598~~ *Merged.* Add missing `\`s to regexes in `rcube_check_email()`

    An unrelated minor bug fix, I can remove it if you'd prefer.

 * 7f64384 Avoid initializing Mailvelope if we don't need to

    Small efficiency fix, but it also makes the next two commits a bit smaller in scope.

 * cc3779f Add config option `mailvelope_main_keyring` to use Mailvelope Main Keyring

    Defaults to false for backwards compatibility. It's probably only useful for new installs. Related: #7157

 * 2f71928 Add config option `mailvelope_keysize` for size of new Mailvelope keys

    Defaults to 4096 for backwards compatibility.

 * a121960 Always ask before discarding composed Mailvelopes

    The unpatched code appears to be intentionally *not* asking before discarding emails currently being composed. This does the exact opposite, which can be minorly annoying if one saves and then leaves while composing, but is much safer in other cases IMO. If others disagree, perhaps this could be a config option instead? Related: #7017

 * 9d39c0a Don't warn to re-add attachments when restoring a Mailvelope draft

    Currently, if you save a Mailvelope email draft, and then select to edit it from your Drafts folder, the "Already uploaded attachments cannot be encrypted"... warning message is unnecessarily displayed.

    edit: I just (Apr 29) amended this last commit to remove the use of `Object.values()` which isn't supported by IE. `Object.keys()` apparently [is supported](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys#Browser_compatibility).

 * ~~40ecd47~~ *Merged.* Show Encrypt button w/Mailvelope, even if disabled (added Apr 30)