### PR TITLE
attachment filesize includes units

### DIFF
--- a/program/steps/mail/show.inc
+++ b/program/steps/mail/show.inc
@@ -221,7 +221,7 @@ function rcmail_message_attachments($attrib)
                     'class'       => 'filename',
                 );
 
-                if ($filesize == 0) {
+                if ($filesize == '0 B') {
                     $li_class .= ' no-menu';
                     $link_attrs['onclick'] = sprintf('%s.alert_dialog(%s.get_label(\'emptyattachment\')); return false',
                             rcmail_output::JS_OBJECT_NAME, rcmail_output::JS_OBJECT_NAME);


### PR DESCRIPTION
small fix for 377239fa8e066e290b50f094c6024d0f4f6d4a79.

the line `if ($filesize == 0) {` expects `$filesize` it be an `int` but its a `string`. `$RCMAIL->message_part_size($attach_prop);` uses `rcmail::show_bytes()` which always adds at least a unit, in the case of 0 that's going to be a B.