### PR TITLE
remove depreciated jquery.trim function

### DIFF
--- a/plugins/hide_blockquote/hide_blockquote.js
+++ b/plugins/hide_blockquote/hide_blockquote.js
@@ -33,7 +33,7 @@ function hide_blockquote()
     // from merging lines from different quoting level
     $('blockquote').before(document.createTextNode("\n"));
 
-    text = $.trim(q.text());
+    text = q.text().trim();
     res = text.split(/\n/);
 
     if (res.length <= limit) {

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -344,7 +344,7 @@ function rcube_webmail()
                 n.children().remove();
 
                 dt.setData('roundcube-uri', href);
-                dt.setData('roundcube-name', $.trim(n.text()));
+                dt.setData('roundcube-name', n.text().trim());
               }
             });
         }
@@ -3897,7 +3897,7 @@ function rcube_webmail()
     // get recipients
     var recipients = [];
     $.each(['to', 'cc', 'bcc'], function(i,field) {
-      var pos, rcpt, val = $.trim($('[name="_' + field + '"]').val());
+      var pos, rcpt, val = $('[name="_' + field + '"]').val().trim();
       while (val.length && rcube_check_email(val, true)) {
         rcpt = RegExp.$2.replace(/^<+/, '').replace(/>+$/, '');
         recipients.push(rcpt);
@@ -4189,7 +4189,7 @@ function rcube_webmail()
   this.mailvelope_identity_keygen = function()
   {
     var container = $(this.gui_objects.editform).find('.identity-encryption').first();
-    var identity_email = $.trim($(this.gui_objects.editform).find('.ff_email').val());
+    var identity_email = $(this.gui_objects.editform).find('.ff_email').val().trim();
 
     if (!container.length || !identity_email || !this.mailvelope_keyring.createKeyGenContainer)
       return;
@@ -4260,7 +4260,7 @@ function rcube_webmail()
   this.mailvelope_show_keygen_container = function(container, identity_email)
   {
     var cid = new Date().getTime();
-    var user_id = {email: identity_email, fullName: $.trim($(ref.gui_objects.editform).find('.ff_name').val())};
+    var user_id = {email: identity_email, fullName: $(ref.gui_objects.editform).find('.ff_name').val().trim()};
     var options = {userIds: [user_id], keySize: 4096};
 
     $('<div>').attr('id', 'mailvelope-keygen-container-' + cid)
@@ -4871,7 +4871,7 @@ function rcube_webmail()
       input_from = $("[name='_from']", form),
       get_recipients = function(fields) {
         fields = $.map(fields, function(v) {
-          v = $.trim(v.val());
+          v = v.val().trim();
           return v.length ? v : null;
         });
         return fields.join(',').replace(/^[\s,;]+/, '').replace(/[\s,;]+$/, '');
@@ -5881,7 +5881,7 @@ function rcube_webmail()
       data = this.ksearch_data;
 
     // trim query string
-    q = $.trim(q);
+    q = q.trim();
 
     // Don't (re-)search if the last results are still active
     if (q == this.ksearch_value)
@@ -10106,7 +10106,7 @@ rcube_webmail.long_subject_title_ex = function(elem)
 {
   if (!elem.title) {
     var $elem = $(elem),
-      txt = $.trim($elem.text()),
+      txt = $elem.text().trim(),
       indent = $('span.branch', $elem).width() || 0,
       tmp = $('<span>').text(txt)
         .css({position: 'absolute', 'float': 'left', visibility: 'hidden',
@@ -10124,7 +10124,7 @@ rcube_webmail.subject_text = function(elem)
 {
   var t = $(elem).clone();
   t.find('.skip-on-drag,.skip-content,.voice').remove();
-  return $.trim(t.text());
+  return t.text().trim();
 };
 
 // set event handlers on all iframe elements (and their contents)

--- a/program/js/list.js
+++ b/program/js/list.js
@@ -1669,7 +1669,7 @@ drag_mouse_move: function(e)
 
           if (subject) {
             // remove leading spaces
-            subject = $.trim(subject);
+            subject = subject.trim();
             // truncate line to 50 characters
             subject = (subject.length > 50 ? subject.substring(0, 50) + '...' : subject);
 

--- a/program/js/treelist.js
+++ b/program/js/treelist.js
@@ -1284,7 +1284,7 @@ function rcube_treelist_widget(node, p)
         create: function(e, ui) { ui_draggable = ui; },
         helper: function(e) {
           return $('<div>').attr('id', 'rcmdraglayer')
-            .text($.trim($(e.target).first().text()));
+            .text($(e.target).first().text().trim());
         }
       }, opts);
 

--- a/skins/elastic/ui.js
+++ b/skins/elastic/ui.js
@@ -393,7 +393,7 @@ function rcube_elastic_ui()
             btn_class = target[0].className + (add_class ? ' ' + add_class : '');
 
         if (!menu_button) {
-            btn_class = $.trim(btn_class.replace('btn-primary', 'primary').replace(/(btn[a-z-]*|button|disabled)/g, ''))
+            btn_class = btn_class.replace('btn-primary', 'primary').replace(/(btn[a-z-]*|button|disabled)/g, '').trim()
             btn_class += ' button' + (!always_active ? ' disabled' : '');
         }
         else if (popup = target.data('popup')) {
@@ -2134,7 +2134,7 @@ function rcube_elastic_ui()
                     button = cloned ? create_cloned_button($(button), true, 'hidden-big hidden-large') : $(button).detach();
 
                 // Remove empty text nodes that break alignment of text of the menu item
-                button.contents().filter(function() { if (this.nodeType == 3 && !$.trim(this.nodeValue).length) $(this).remove(); });
+                button.contents().filter(function() { if (this.nodeType == 3 && this.nodeValue.trim().length == 0) $(this).remove(); });
 
                 if (button.is('.spacer')) {
                     item.addClass('spacer');
@@ -2984,7 +2984,7 @@ function rcube_elastic_ui()
 
                     if (txt) {
                         txt = txt.replace('<' + contact + '>', '');
-                        contact = '"' + $.trim(txt) + '" <' + contact + '>';
+                        contact = '"' + txt.trim() + '" <' + contact + '>';
                     }
 
                     return rcmail.command('add-contact', contact, this, e.originalEvent);
@@ -3295,7 +3295,7 @@ function rcube_elastic_ui()
     function recipient_input_parser(text)
     {
         // support new-line as a separator, for paste action (#6460)
-        text = $.trim(text.replace(/[,;\s]*[\r\n]+/g, ','));
+        text = text.replace(/[,;\s]*[\r\n]+/g, ',').trim();
 
         var recipients = [],
             address_rx_part = '(\\S+|("[^"]+"))@\\S+',
@@ -3307,7 +3307,7 @@ function rcube_elastic_ui()
         $.each(matches || [], function() {
             if (this.length && (recipient_rx1.test(this) || recipient_rx2.test(this))) {
                 var email = RegExp.$1,
-                    name = $.trim(this.replace(email, ''));
+                    name = this.replace(email, '').trim();
 
                 recipients.push({
                     name: name,


### PR DESCRIPTION
jQuery 3.5.0 depreciates the use of jQuery.trim() (ref: https://api.jquery.com/category/deprecated/deprecated-3.5/)

Native trim() function is supported by all browsers currently supported by Roundcube (ref: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trim)

Do not use 3.5.0 because it is bugged, see https://github.com/jquery/jquery/issues/4665 and https://github.com/twbs/bootstrap/issues/30553.

I searched for and replaced all references of `$.trim(` in all files in the repo.