### PR TITLE
Fix issue with Modoboa driver for password plugin

### DIFF
--- a/plugins/password/drivers/modoboa.php
+++ b/plugins/password/drivers/modoboa.php
@@ -82,6 +82,7 @@ class rcube_modoboa_password
 
         // Encode json with new password
         $ret['username'] = $decoded[0]->username;
+        $ret['mailbox'] = $decoded[0]->mailbox;
         $ret['role']     = $decoded[0]->role;
         $ret['password'] = $passwd; // new password
         $encoded         = json_encode($ret);


### PR DESCRIPTION
I was having trouble with updating a password with the Modoboa API version 1.9.1 and Roundcube version 1.4.2. API responded with an error message but 200 HTTP status code, so roundcube displayed a success message even though the password wasn't being updated. Added a line to include a required field in the update request.