### PR TITLE
Specify 13px font-size for .message-part div.pre

### DIFF
--- a/skins/elastic/styles/styles.less
+++ b/skins/elastic/styles/styles.less
@@ -338,6 +338,7 @@ body.task-error-login #layout {
 
     div.pre {
         font-family: monospace;
+        font-size: 13px;
     }
 }
 


### PR DESCRIPTION
Default monospace fonts are larger than proportional fonts and so make the plain text message look oddly large, upsetting the aesthetics of the page.

12px font sizes brings the Elastic skin into consistency with Larry and Classic.