### PR TITLE
add basic error message on fatal PHP error

### DIFF
--- a/program/include/iniset.php
+++ b/program/include/iniset.php
@@ -38,6 +38,29 @@ if (!defined('RCUBE_LOCALIZATION_DIR')) {
 define('RCUBE_INSTALL_PATH', INSTALL_PATH);
 define('RCUBE_CONFIG_DIR',  RCMAIL_CONFIG_DIR.'/');
 
+// show basic error message on fatal PHP error
+function roundcube_fatal_error() {
+    $error = error_get_last();
+    if ($error['type'] === E_ERROR || $error['type'] === E_PARSE) {
+        if (php_sapi_name() === 'cli') {
+            echo "Fatal error: Please check the Roundcube error log and/or server error logs for more information.\n";
+        }
+        elseif (!empty($_REQUEST['_remote'])) {
+            // Ajax request from UI
+            header('Content-Type: application/json; charset=UTF-8');
+            echo json_encode(array('code' => 500, 'message' => 'Internal Server Error'));
+        }
+        else {
+            if (!defined('RCUBE_FATAL_ERROR_MSG')) {
+                define('RCUBE_FATAL_ERROR_MSG', INSTALL_PATH . 'program/resources/error.html');
+            }
+
+            $msg = file_get_contents(RCUBE_FATAL_ERROR_MSG);
+            echo $msg;
+        }
+    }
+}
+register_shutdown_function('roundcube_fatal_error');
 
 // RC include folders MUST be included FIRST to avoid other
 // possible not compatible libraries (i.e PEAR) to be included

--- a/program/resources/error.html
+++ b/program/resources/error.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta http-equiv="content-type" content="text/html; charset=UTF-8">
+<title>Internal Error</title>
+<style>
+div {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-family: sans-serif;
+}
+p.admin {
+  font-style: italic;
+  font-size: 0.8em;
+  color: #888;
+}
+</style>
+</head>
+<body>
+<div>
+  <h1>Oops... something went wrong!</h1>
+  <p>An internal error has occurred. Your request cannot be processed at this time.</p>
+  <p class="admin">For administrators: Please check the application and/or server error logs for more information.</p>
+</div>
+</body>
+</html>


### PR DESCRIPTION
rather than showing a blank screen on a fatal PHP error this adds a simple error message:
![Untitled-1](https://user-images.githubusercontent.com/88682/81494074-c45a6280-929d-11ea-9e70-2c5971187c00.jpg)
this will catch common errors like typos in the config file which cause a parse error or missing PHP extensions such as Mbstring and give admins a hint to check the log files for info.