### PR TITLE
Add newline when writing logs to stdout

### DIFF
--- a/program/lib/Roundcube/rcube.php
+++ b/program/lib/Roundcube/rcube.php
@@ -1272,7 +1272,7 @@ class rcube
         // write message with file name when configured to log to STDOUT
         if ($log_driver == 'stdout') {
             $stdout = "php://stdout";
-            $line = "$name: $line";
+            $line = "$name: $line\n";
             return file_put_contents($stdout, $line, FILE_APPEND) !== false;
         }
 


### PR DESCRIPTION
Add newline on the end of the logline when printing to stdout. 
Bumped into this problem when running roundcube on kubernetes.