### PR TITLE
elastic: message headers view changes

### DIFF
--- a/program/localization/en_US/labels.inc
+++ b/program/localization/en_US/labels.inc
@@ -338,6 +338,7 @@ $labels['alwaysallow'] = 'Always allow from $sender';
 $labels['isdraft'] = 'This is a draft message.';
 $labels['andnmore'] = '$nr more...';
 $labels['details'] = 'Details';
+$labels['summary'] = 'Summary';
 $labels['headers'] = 'Headers';
 $labels['allheaders'] = 'All headers...';
 $labels['togglemoreheaders'] = 'Show more message headers';

--- a/skins/elastic/styles/colors.less
+++ b/skins/elastic/styles/colors.less
@@ -186,6 +186,9 @@
 @color-mail-signature:              @color-black-shade-text;
 @color-mail-headers:                @color-black-shade-text;
 
+@color-messagepart-border:          @color-black-shade-bg;
+@color-messagepart-background:      #fcfcfc;
+
 @color-spellcheck-link:             @color-error;
 
 @color-table-border:                @color-layout-border;

--- a/skins/elastic/styles/styles.less
+++ b/skins/elastic/styles/styles.less
@@ -187,18 +187,33 @@ body.task-error-login #layout {
         div.header-content {
             min-height: @mail-header-photo-height;
             flex: 1;
-        }
 
-        div.header-subject {
-            line-height: @mail-header-photo-height/2;
+            &:not(.details-view) {
+                .message-partheaders {
+                    display: none;
+                }
+            }
 
-            & > span {
-                line-height: 1.5;
-                display: inline-block;
-                vertical-align: middle;
+            &.details-view {
+                .header-subject {
+                    display: none;
+                }
             }
         }
 
+        div.header-envelope {
+            display: flex;
+        }
+
+        div.header-toggle > a {
+            margin: 0 !important;
+        }
+
+        div.header-subject > span {
+            display: inline-block;
+        }
+
+        div.header-toggle,
         div.header-links {
             a {
                 font-size: 90%;
@@ -213,8 +228,12 @@ body.task-error-login #layout {
                     line-height: 1.3;
                 }
 
-                &.envelope:before {
+                &.headers-details:before {
                     content: @fa-var-envelope;
+                }
+
+                &.headers-summary:before {
+                    .font-icon-regular(@fa-var-envelope);
                 }
 
                 &.html:before {
@@ -229,11 +248,6 @@ body.task-error-login #layout {
                     content: @fa-var-download;
                 }
             }
-        }
-
-        .message-partheaders {
-            margin: 0 !important;
-            padding: .25rem 0 !important;
         }
     }
 
@@ -344,10 +358,7 @@ body.task-error-login #layout {
 }
 
 .message-partheaders {
-    padding: .5rem 0;
-    margin: .5rem 0 0 0;
     font-size: 90%;
-    border-top: 1px solid @color-list-border;
     border-bottom: 1px solid @color-list-border;
     color: @color-mail-headers;
 

--- a/skins/elastic/styles/styles.less
+++ b/skins/elastic/styles/styles.less
@@ -173,7 +173,7 @@ body.task-error-login #layout {
         }
     }
 
-    .short-header {
+    .headers {
         display: flex;
 
         img.contactphoto {
@@ -189,23 +189,19 @@ body.task-error-login #layout {
             flex: 1;
 
             &:not(.details-view) {
-                .message-partheaders {
+                .headers-table {
                     display: none;
                 }
             }
 
             &.details-view {
-                .header-subject {
+                .header-summary {
                     display: none;
                 }
             }
         }
 
-        div.header-envelope {
-            display: flex;
-        }
-
-        div.header-subject > span {
+        div.header-summary > span {
             display: inline-block;
         }
 
@@ -252,6 +248,41 @@ body.task-error-login #layout {
 
     a.extwin {
         text-decoration: none;
+    }
+}
+
+.message-partheaders {
+    padding: .5rem;
+    margin: .5rem 0 -0.5rem 0;
+    border-top: 1px solid @color-list-border;
+    color: @color-mail-headers;
+    background-color: @color-attachmentlist-background;
+}
+
+#message-header,
+.message-partheaders {
+    table.headers-table {
+        font-size: 90%;
+        color: @color-mail-headers;
+
+        .header-title {
+            .overflow-ellipsis;
+            white-space: nowrap;
+            max-width: 8em;
+            font-weight: bold;
+            padding-right: 1rem;
+            vertical-align: top;
+        }
+
+        .subject {
+            font-weight: bold;
+        }
+
+        & + .message-part,
+        & + .message-htmlpart {
+            border-top: 0;
+            margin: 0;
+        }
     }
 }
 
@@ -352,30 +383,6 @@ body.task-error-login #layout {
     div.pre {
         font-family: monospace;
         font-size: 13px;
-    }
-}
-
-.message-partheaders {
-    font-size: 90%;
-    color: @color-mail-headers;
-
-    .header-title {
-        .overflow-ellipsis;
-        white-space: nowrap;
-        max-width: 8em;
-        font-weight: bold;
-        padding-right: 1rem;
-        vertical-align: top;
-    }
-
-    .subject {
-        font-weight: bold;
-    }
-
-    & + .message-part,
-    & + .message-htmlpart {
-        border-top: 0;
-        margin: 0;
     }
 }
 

--- a/skins/elastic/styles/styles.less
+++ b/skins/elastic/styles/styles.less
@@ -253,10 +253,9 @@ body.task-error-login #layout {
 
 .message-partheaders {
     padding: .5rem;
-    margin: .5rem 0 -0.5rem 0;
-    border-top: 1px solid @color-list-border;
-    color: @color-mail-headers;
-    background-color: @color-attachmentlist-background;
+    margin: .5rem 0 -.5rem 0;
+    border-top: 1px solid @color-messagepart-border;
+    background-color: @color-messagepart-background;
 }
 
 #message-header,
@@ -309,7 +308,7 @@ body.task-error-login #layout {
     position: relative;
 
     &:not(:first-child) {
-        border-top: 1px solid lighten(@color-mail-headers, 50%);
+        border-top: 1px solid @color-messagepart-border;
         margin-top: .5rem;
     }
 

--- a/skins/elastic/styles/styles.less
+++ b/skins/elastic/styles/styles.less
@@ -231,6 +231,10 @@ body.task-error-login #layout {
                     .font-icon-regular(@fa-var-envelope);
                 }
 
+                &.headers-all:before {
+                    content: @fa-var-info-circle;
+                }
+
                 &.html:before {
                     content: @fa-var-image;
                 }
@@ -246,8 +250,7 @@ body.task-error-login #layout {
         }
     }
 
-    a.extwin,
-    a.headers {
+    a.extwin {
         text-decoration: none;
     }
 }
@@ -354,7 +357,6 @@ body.task-error-login #layout {
 
 .message-partheaders {
     font-size: 90%;
-    border-bottom: 1px solid @color-list-border;
     color: @color-mail-headers;
 
     .header-title {

--- a/skins/elastic/styles/styles.less
+++ b/skins/elastic/styles/styles.less
@@ -205,15 +205,10 @@ body.task-error-login #layout {
             display: flex;
         }
 
-        div.header-toggle > a {
-            margin: 0 !important;
-        }
-
         div.header-subject > span {
             display: inline-block;
         }
 
-        div.header-toggle,
         div.header-links {
             a {
                 font-size: 90%;

--- a/skins/elastic/templates/message.html
+++ b/skins/elastic/templates/message.html
@@ -24,15 +24,11 @@
 						label="openinextwin" title="openinextwin" data-hidden="small" />
 				<roundcube:endif />
 			</h2>
-			<div class="short-header">
+			<div class="headers">
 				<roundcube:object name="contactphoto" class="contactphoto" placeholder="/images/contactpic.svg" />
 				<div class="header-content">
-					<div class="header-envelope">
-						<roundcube:object name="messageSummary" addicon="virtual" class="header-subject" />
-						<div class="message-partheaders">
-							<roundcube:object name="messageHeaders" class="headers-table" addicon="virtual" exclude="subject" max="10" />
-						</div>
-					</div>
+					<roundcube:object name="messageSummary" class="header-summary" addicon="virtual" />
+					<roundcube:object name="messageHeaders" class="headers-table" addicon="virtual" exclude="subject" max="10" />
 					<div class="header-links">
 						<roundcube:add_label name="details" />
 						<roundcube:add_label name="summary" />

--- a/skins/elastic/templates/message.html
+++ b/skins/elastic/templates/message.html
@@ -27,13 +27,19 @@
 			<div class="short-header">
 				<roundcube:object name="contactphoto" class="contactphoto" placeholder="/images/contactpic.svg" />
 				<div class="header-content">
-					<roundcube:object name="messageSummary" addicon="virtual" class="header-subject" />
-					<div class="message-partheaders hidden">
-						<roundcube:object name="messageHeaders" class="headers-table" addicon="virtual" exclude="subject" max="10" />
-						<a href="#all-headers" class="headers" onclick="return UI.headers_dialog()"><roundcube:label name="allheaders" /></a>
+					<div class="header-envelope">
+						<div class="header-toggle">
+							<roundcube:add_label name="details" />
+							<roundcube:add_label name="summary" />
+							<a href="#headers" onclick="return UI.headers_show(true)"></a>
+						</div>
+						<roundcube:object name="messageSummary" addicon="virtual" class="header-subject" />
+						<div class="message-partheaders">
+							<roundcube:object name="messageHeaders" class="headers-table" addicon="virtual" exclude="subject" max="10" />
+							<a href="#all-headers" class="headers" onclick="return UI.headers_dialog()"><roundcube:label name="allheaders" /></a>
+						</div>
 					</div>
 					<div class="header-links">
-						<a href="#headers" class="envelope" onclick="return UI.headers_show(this)"><roundcube:label name="details" /></a>
 						<roundcube:add_label name="arialabelmessageheaders" />
 						<roundcube:if condition="env:optional_format=='text'" />
 							<roundcube:button command="change-format" prop="text" type="link" class="plain" innerClass="inner"

--- a/skins/elastic/templates/message.html
+++ b/skins/elastic/templates/message.html
@@ -28,11 +28,6 @@
 				<roundcube:object name="contactphoto" class="contactphoto" placeholder="/images/contactpic.svg" />
 				<div class="header-content">
 					<div class="header-envelope">
-						<div class="header-toggle">
-							<roundcube:add_label name="details" />
-							<roundcube:add_label name="summary" />
-							<a href="#headers" onclick="return UI.headers_show(true)"></a>
-						</div>
 						<roundcube:object name="messageSummary" addicon="virtual" class="header-subject" />
 						<div class="message-partheaders">
 							<roundcube:object name="messageHeaders" class="headers-table" addicon="virtual" exclude="subject" max="10" />
@@ -40,6 +35,9 @@
 						</div>
 					</div>
 					<div class="header-links">
+						<roundcube:add_label name="details" />
+						<roundcube:add_label name="summary" />
+						<a href="#headers" data-toggle="headers" onclick="return UI.headers_show(true)"></a>
 						<roundcube:add_label name="arialabelmessageheaders" />
 						<roundcube:if condition="env:optional_format=='text'" />
 							<roundcube:button command="change-format" prop="text" type="link" class="plain" innerClass="inner"

--- a/skins/elastic/templates/message.html
+++ b/skins/elastic/templates/message.html
@@ -31,13 +31,13 @@
 						<roundcube:object name="messageSummary" addicon="virtual" class="header-subject" />
 						<div class="message-partheaders">
 							<roundcube:object name="messageHeaders" class="headers-table" addicon="virtual" exclude="subject" max="10" />
-							<a href="#all-headers" class="headers" onclick="return UI.headers_dialog()"><roundcube:label name="allheaders" /></a>
 						</div>
 					</div>
 					<div class="header-links">
 						<roundcube:add_label name="details" />
 						<roundcube:add_label name="summary" />
 						<a href="#headers" data-toggle="headers" onclick="return UI.headers_show(true)"></a>
+						<a href="#all-headers" class="headers-all" onclick="return UI.headers_dialog()"><roundcube:label name="headers" /></a>
 						<roundcube:add_label name="arialabelmessageheaders" />
 						<roundcube:if condition="env:optional_format=='text'" />
 							<roundcube:button command="change-format" prop="text" type="link" class="plain" innerClass="inner"

--- a/skins/elastic/templates/messageprint.html
+++ b/skins/elastic/templates/messageprint.html
@@ -7,12 +7,10 @@
 		<h2 class="subject">
 			<roundcube:object name="messageHeaders" valueOf="subject" />
 		</h2>
-		<div class="short-header">
+		<div class="headers">
 			<roundcube:object name="contactphoto" class="contactphoto" placeholder="/images/contactpic.svg" />
 			<div class="header-content details-view">
-				<div class="message-partheaders">
-					<roundcube:object name="messageHeaders" class="headers-table" addicon="virtual" exclude="subject" max="10" />
-				</div>
+				<roundcube:object name="messageHeaders" class="headers-table" addicon="virtual" exclude="subject" max="10" />
 			</div>
 		</div>
 	</div>

--- a/skins/elastic/templates/messageprint.html
+++ b/skins/elastic/templates/messageprint.html
@@ -9,7 +9,7 @@
 		</h2>
 		<div class="short-header">
 			<roundcube:object name="contactphoto" class="contactphoto" placeholder="/images/contactpic.svg" />
-			<div class="header-content">
+			<div class="header-content details-view">
 				<div class="message-partheaders">
 					<roundcube:object name="messageHeaders" class="headers-table" addicon="virtual" exclude="subject" max="10" />
 				</div>

--- a/skins/elastic/ui.js
+++ b/skins/elastic/ui.js
@@ -1020,7 +1020,7 @@ function rcube_elastic_ui()
             .filter(function() {
                 // exclude direct propform children and external content
                 return !$(this).parent().is('.propform')
-                    && !$(this).parents('.message-htmlpart,.message-partheaders,.boxinformation,.raw-tables').length;
+                    && !$(this).parents('#message-header,.message-htmlpart,.message-partheaders,.boxinformation,.raw-tables').length;
             })
             .each(function() {
                 // TODO: Consider implementing automatic setting of table-responsive on window resize

--- a/skins/elastic/ui.js
+++ b/skins/elastic/ui.js
@@ -721,6 +721,9 @@ function rcube_elastic_ui()
                 $('a').filter('[href^="mailto:"]').each(function() {
                     mailtomenu_append(this);
                 });
+
+                // restore headers view to last state
+                headers_show();
             }
         }
         else if (rcmail.task == 'settings') {
@@ -2691,10 +2694,22 @@ function rcube_elastic_ui()
     /**
      * Show/hide more mail headers (envelope)
      */
-    function headers_show(button)
+    function headers_show(toggle)
     {
-        var headers = $(button).parent().prev();
-        headers[headers.is('.hidden') ? 'removeClass' : 'addClass']('hidden');
+        var key = 'mail.show.envelope',
+            pref = get_pref(key),
+            show = toggle ? !pref : pref,
+            label = rcmail.gettext(show ? 'summary' : 'details'),
+            css = 'headers-' + (show ? 'summary' : 'details'),
+            headers = $('div.header-content');
+
+        $('div.header-toggle > a').removeClass().addClass(css).attr('title', label);
+        headers[show ? 'addClass' : 'removeClass']('details-view');
+
+        if (toggle) {
+            // save new pref
+            save_pref(key, show);
+        }
     };
 
     /**

--- a/skins/elastic/ui.js
+++ b/skins/elastic/ui.js
@@ -2703,7 +2703,7 @@ function rcube_elastic_ui()
             css = 'headers-' + (show ? 'summary' : 'details'),
             headers = $('div.header-content');
 
-        $('div.header-toggle > a').removeClass().addClass(css).attr('title', label);
+        $("div.header-links > a[data-toggle='headers']").removeClass().addClass(css).text(label);
         headers[show ? 'addClass' : 'removeClass']('details-view');
 
         if (toggle) {

--- a/tests/Browser/Mail/PreviewTest.php
+++ b/tests/Browser/Mail/PreviewTest.php
@@ -120,7 +120,7 @@ class PreviewTest extends \Tests\Browser\TestCase
                     ->assertVisible('.message-part div.pre .sig');
 
                 $browser->assertMissing('.headers-table')
-                    ->click('a.envelope')
+                    ->click('a.headers-details')
                     ->waitFor('.headers-table')
                     ->assertVisible('.header.cc')
                     ->assertSeeIn('.header.cc', 'test10@domain.tld')


### PR DESCRIPTION
reference #7224

based on comments in the referenced issue this pr moves the "details" link up to the envelope summary line and changes the icon for expand/collapse. it also makes the status of the envelope block remembered between page loads.

![Untitled-1](https://user-images.githubusercontent.com/88682/84599956-ba63ea80-ae6d-11ea-9df1-d3c50dade710.png)
