### PR TITLE
Apple Mail send image files marked as inline even if it is not on body message (#7414)

### DIFF
--- a/program/steps/mail/compose.inc
+++ b/program/steps/mail/compose.inc
@@ -994,7 +994,8 @@ function rcmail_write_compose_attachments(&$message, $bodyIsHtml, &$message_body
                 if ($idx && isset($CID_MAP[$idx]) && strpos($message_body, $CID_MAP[$idx]) !== false) {
                     $replace = $CID_MAP[$idx];
                 }
-                else {
+                // Note: Apple Mail send image files marked as inline even if it is not on body message #7414
+                elseif (!isset($part->ctype_parameters['x-apple-part-url'])) {
                     continue;
                 }
             }


### PR DESCRIPTION
Fix to reported issue https://github.com/roundcube/roundcubemail/issues/7414

Attached two e-mails with reported problem:

[mail.txt](https://github.com/roundcube/roundcubemail/files/4795204/mail.txt)
[Comprovante de Up Grade.txt](https://github.com/roundcube/roundcubemail/files/4795209/Comprovante.de.Up.Grade.txt)

