### PR TITLE
support providing skins for plugins inside the main skin folder

### DIFF
--- a/plugins/jqueryui/jqueryui.php
+++ b/plugins/jqueryui/jqueryui.php
@@ -18,6 +18,7 @@ class jqueryui extends rcube_plugin
 
     private static $features = [];
     private static $ui_theme;
+    private static $css_path;
     private static $skin_map = [
         'larry'   => 'larry',
         'default' => 'elastic',
@@ -47,10 +48,12 @@ class jqueryui extends rcube_plugin
         $skins[]  = 'elastic';
 
         foreach ($skins as $skin) {
-            self::$ui_theme = $ui_theme = !empty($ui_map[$skin]) ? $ui_map[$skin] : $skin;
+            self::$ui_theme = !empty($ui_map[$skin]) ? $ui_map[$skin] : $skin;
+            self::$css_path = $this->local_skin_path('themes', self::$ui_theme);
 
-            if (self::asset_exists("themes/$ui_theme/jquery-ui.css")) {
-                $this->include_stylesheet("themes/$ui_theme/jquery-ui.css");
+            $css = self::$css_path . '/jquery-ui.css';
+            if (self::asset_exists($css)) {
+                $this->include_stylesheet($css);
                 break;
             }
         }
@@ -107,20 +110,19 @@ class jqueryui extends rcube_plugin
 
         self::$features[] = 'miniColors';
 
-        $ui_theme = self::$ui_theme;
         $rcube    = rcube::get_instance();
         $script   = 'plugins/jqueryui/js/jquery.minicolors.min.js';
-        $css      = "themes/$ui_theme/jquery.minicolors.css";
+        $css      = self::$css_path . "/jquery.minicolors.css";
 
         if (!self::asset_exists($css)) {
-            $css = "themes/larry/jquery.minicolors.css";
+            $css = "plugins/jqueryui/themes/larry/jquery.minicolors.css";
         }
 
         $colors_theme = $rcube->config->get('jquery_ui_colors_theme', 'default');
         $config       = ['theme' => $colors_theme];
         $config_str   = rcube_output::json_serialize($config);
 
-        $rcube->output->include_css('plugins/jqueryui/' . $css);
+        $rcube->output->include_css($css);
         $rcube->output->include_script($script, 'head', false);
         $rcube->output->add_script('$.fn.miniColors = $.fn.minicolors; $("input.colors").minicolors(' . $config_str . ')', 'docready');
         $rcube->output->set_env('minicolors_config', $config);
@@ -139,15 +141,14 @@ class jqueryui extends rcube_plugin
 
         $script   = 'plugins/jqueryui/js/jquery.tagedit.js';
         $rcube    = rcube::get_instance();
-        $ui_theme = self::$ui_theme;
-        $css      = "themes/$ui_theme/tagedit.css";
+        $css      = self::$css_path. "/tagedit.css";
 
         if (!array_key_exists('elastic', (array) $rcube->output->skins)) {
             if (!self::asset_exists($css)) {
-                $css = "themes/larry/tagedit.css";
+                $css = "plugins/jqueryui/themes/larry/tagedit.css";
             }
 
-            $rcube->output->include_css('plugins/jqueryui/' . $css);
+            $rcube->output->include_css($css);
         }
 
         $rcube->output->include_script($script, 'head', false);
@@ -159,7 +160,8 @@ class jqueryui extends rcube_plugin
     protected static function asset_exists($path, $minified = true)
     {
         $rcube = rcube::get_instance();
+        $path = (strpos($path, 'plugins/') !== false ? '/' : '/plugins/jqueryui/') . $path;
 
-        return $rcube->find_asset('/plugins/jqueryui/' . $path, $minified) !== null;
+        return $rcube->find_asset($path, $minified) !== null;
     }
 }

--- a/program/include/rcmail_output_html.php
+++ b/program/include/rcmail_output_html.php
@@ -740,7 +740,10 @@ EOF;
 
             // apply skin search escalation list to plugin directory
             foreach ($this->skin_paths as $skin_path) {
+                // skin folder in plugin dir
                 $plugin_skin_paths[] = $this->app->plugins->url . $plugin . '/' . $skin_path;
+                // plugin folder in skin dir
+                $plugin_skin_paths[] = $skin_path . '/plugins/' . $plugin;
             }
 
             // prepend plugin skin paths to search list
@@ -751,7 +754,7 @@ EOF;
         $path = false;
         foreach ($this->skin_paths as $skin_path) {
             // when requesting a plugin template ignore global skin path(s)
-            if ($plugin && strpos($skin_path, $this->app->plugins->url) !== 0) {
+            if ($plugin && strpos($skin_path, $this->app->plugins->url) === false) {
                 continue;
             }
 

--- a/program/lib/Roundcube/rcube_plugin_api.php
+++ b/program/lib/Roundcube/rcube_plugin_api.php
@@ -700,22 +700,23 @@ class rcube_plugin_api
                 $devel_mode = $rcube->config->get('devel_mode');
                 $assets_dir = $rcube->config->get('assets_dir');
                 $path       = unslashify($assets_dir ?: RCUBE_INSTALL_PATH);
+                $dir        = $path . (strpos($fn, "plugins/") === false ? '/plugins' : '');
 
                 // Prefer .less files in devel_mode (assume less.js is loaded)
                 if ($devel_mode) {
                     $less = preg_replace('/\.css$/i', '.less', $fn);
-                    if ($less != $fn && is_file("$path/plugins/$less")) {
+                    if ($less != $fn && is_file("$dir/$less")) {
                         $fn = $less;
                     }
                 }
                 else if (!preg_match('/\.min\.css$/', $fn)) {
                     $min = preg_replace('/\.css$/i', '.min.css', $fn);
-                    if (is_file("$path/plugins/$min")) {
+                    if (is_file("$dir/$min")) {
                         $fn = $min;
                     }
                 }
 
-                if (!is_file("$path/plugins/$fn")) {
+                if (!is_file("$dir/$fn")) {
                     return;
                 }
             }
@@ -788,7 +789,8 @@ class rcube_plugin_api
      */
     protected function resource_url($fn)
     {
-        if ($fn[0] != '/' && !preg_match('|^https?://|i', $fn)) {
+        // pattern "skins/" used to identify plugin resources loaded from the core skin folder
+        if ($fn[0] != '/' && !preg_match('#^(https?://|skins/)#i', $fn)) {
             return $this->url . $fn;
         }
         else {


### PR DESCRIPTION
I have been [working on](https://github.com/roundcube/plugin-installer/pull/24) the `plugin-installer`, trying to fix the reported issues. Then I thought it would be good if skins could be delivered through composer just like plugins. I added support for a package type of `roundcube-skin` and the installer moves it into the `skins/` folder rather than the `plugins/` folder.

If someone is going to create a new skin though they will want to add skin assets for plugins. At the moment that has to be in the skins folder of a plugin. So I [made](https://github.com/roundcube/plugin-installer/pull/24/commits/3cf1462ae6a860ea8f97753a9d79106eaba741df) the `plugin-installer` copy plugin skins into the `plugins/` folder.

I think this method of copying files around is rather messy so then I thought what if skins could hold plugin assets themselves. A lot of the existing code for extended skins can be leveraged to achieve this.

This is a non-breaking change (assuming properly coded plugins), the only special case is the `jqueryui` plugin which uses a `themes` dir rather than `skins` (ref #266) so I added support for custom dir names and skin names (because of the skin mapping feature of the `jqueryui` plugin).

Any assets in the `plugins/myplugin/skins/myskin/` folder take priority but if none are found then the code checks in `skins/myskin/plugins/myplugin/`. It also works with extended skins.