### PR TITLE
Specify 13px font-size for .html-editor > textarea

### DIFF
--- a/skins/elastic/styles/widgets/editor.less
+++ b/skins/elastic/styles/widgets/editor.less
@@ -897,6 +897,7 @@ html.touch .mce-grid td {
     & > .googie_edit_layer,
     & > textarea {
         font-family: monospace;
+        font-size: 13px;
         width: 100% !important;
         padding-top: 2.5rem;
         resize: none;


### PR DESCRIPTION
This is a followup to PR #7375 which set the plaintext message area from 14px to 13px for greater consistency with Classic and Larry skins. With that PR I neglected to consider the font size in the compose screen, which should probably match the 13px of the message area, but currently inherits 14px from the html element which causes an odd jump in font size when replying to a message.

This only affects composing in plaintext, not the mce editor.