### PR TITLE
[Bugfix] Re-init plugins when changing task

### DIFF
--- a/program/include/rcmail.php
+++ b/program/include/rcmail.php
@@ -161,6 +161,11 @@ class rcmail extends rcube
             $task = asciiwords($task, true) ?: 'mail';
         }
 
+        // Re-initialize plugins if task is changing
+        if (!empty($this->task) && $this->task != $task) {
+            $this->plugins->init($this, $task);
+        }
+
         $this->task      = $task;
         $this->comm_path = $this->url(array('task' => $this->task));
 


### PR DESCRIPTION
When roundcube initializes on a different task, plugins for just the
login task do not get initialized, and hence do not get executed when
the exec_hook call is made

One example is if check_auth fails, the login page will render,
but the plugins with 'login' task will not be fired

## Quick reproduction
1) Get any plugin with only the 'login' (and say 'logout') task that does something visible on the login page (e.g. [roundcube-oidc](https://packagist.org/packages/radialapps/roundcube-oidc), which adds a "Login with OIDC" link)
2) Login to roundcube with username and password
3) Change the first character of `roundcube_sessauth` cookie to something else (deliberately fail `check_auth`)
4) Refresh the page. The plugin will not be fired.