### PR TITLE
Avoiding duplicate attachment images with same name on reply/forwarding when database_attachments plugin is activated

### DIFF
--- a/plugins/database_attachments/database_attachments.php
+++ b/plugins/database_attachments/database_attachments.php
@@ -158,7 +158,7 @@ class database_attachments extends filesystem_attachments
     protected function _key($args)
     {
         $uname = $args['path'] ?: $args['name'];
-        return $args['group'] . md5(time() . $uname . $_SESSION['user_id']);
+        return $args['group'] . md5(microtime() . $uname . $_SESSION['user_id']);
     }
 
     /**


### PR DESCRIPTION
Changing from time to microtime to add on key of cached attachment to avoid display error on attachments with same name.

This error was founded on issue https://github.com/roundcube/roundcubemail/issues/7455 