### PR TITLE
Fix inconsistencies in phpdoc type annotations

### DIFF
--- a/program/lib/Roundcube/rcube_addressbook.php
+++ b/program/lib/Roundcube/rcube_addressbook.php
@@ -101,7 +101,7 @@ abstract class rcube_addressbook
      * @param array $cols   List of cols to show
      * @param int   $subset Only return this number of records, use negative values for tail
      *
-     * @return array Indexed list of contact records, each a hash array
+     * @return rcube_result_set Indexed list of contact records, each a hash array
      */
     abstract function list_records($cols=null, $subset=0);
 
@@ -129,7 +129,7 @@ abstract class rcube_addressbook
     /**
      * Return the last result set
      *
-     * @return rcube_result_set Current result set or NULL if nothing selected yet
+     * @return ?rcube_result_set Current result set or NULL if nothing selected yet
      */
     abstract function get_result();
 
@@ -397,7 +397,7 @@ abstract class rcube_addressbook
      * @param string $newname  New name to set for this group
      * @param string &$newid   New group identifier (if changed, otherwise don't set)
      *
-     * @return boolean New name on success, false if no data was changed
+     * @return boolean|string New name on success, false if no data was changed
      */
     function rename_group($group_id, $newname, &$newid)
     {

--- a/program/lib/Roundcube/rcube_db.php
+++ b/program/lib/Roundcube/rcube_db.php
@@ -370,7 +370,7 @@ class rcube_db
      * @param string SQL query to execute
      * @param mixed  Values to be inserted in query
      *
-     * @return number  Query handle identifier
+     * @return PDOStatement|bool  Query handle or False on error
      */
     public function query()
     {

--- a/program/lib/Roundcube/rcube_plugin.php
+++ b/program/lib/Roundcube/rcube_plugin.php
@@ -256,7 +256,7 @@ abstract class rcube_plugin
     /**
      * Wrapper for rcube::gettext() adding the plugin ID as domain
      *
-     * @param string $p Message identifier
+     * @param mixed $p Named parameters array or label name
      *
      * @return string Localized text
      * @see rcube::gettext()


### PR DESCRIPTION
Hello,

  I'm co-author of the rcmcarddav plugin for roundcube and started using psalm to check the plugin for typing errors.

I found several inconsistencies in the type annotations contained within roundcube interfaces used by the plugin resulting in spurious errors. Therefore, I would appreciate if you'd consider merging the changes included with this pull request.