### PR TITLE
[zipdownload] Use rcmail.url instead of hard coded url

### DIFF
--- a/plugins/zipdownload/zipdownload.js
+++ b/plugins/zipdownload/zipdownload.js
@@ -68,7 +68,7 @@ function rcmail_zipdownload(mode)
                     target: id,
                     style: 'display: none',
                     method: 'post',
-                    action: '?_task=mail&_action=plugin.zipdownload.messages'
+                    action: rcmail.url('mail/plugin.zipdownload.messages')
                 });
 
         post._mode = mode;


### PR DESCRIPTION
With hard coded url we can lose important parameters, rcmail.url seems better in this case