### PR TITLE
distinctive icon for messages both replied to and forwarded

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -39,6 +39,7 @@ CHANGELOG Roundcube Webmail
 - Fix so anchor tags without href attribute are not modified (#7413)
 - Fix support for an error as a string in message_before_send hook (#7475)
 - Elastic: Fix redundant scrollbar in plain text editor on mail reply (#7500)
+- Elastic: distinctive icon for messages both replied to and forwarded (#7503)
 
 RELEASE 1.4.7
 -------------

--- a/skins/elastic/styles/widgets/lists.less
+++ b/skins/elastic/styles/widgets/lists.less
@@ -693,7 +693,7 @@ table.fixedcopy {
         }
 
         &.replied.forwarded:before {
-            .font-icon-solid(@fa-var-reply); // TODO
+            .font-icon-solid(@fa-var-retweet);
             font-size: 1rem;
         }
 


### PR DESCRIPTION
**what was broken?**
the message view does not indicate the difference between
1) a message replied to and
2) a message both replied to and forwarded

**How can we fix it?**
1) chose a separate icon from the fontawesome catalog (as proposed in #5004)
2) display both icons at once

**Why prefer fix 1)?**
because just placing the two icons on top of each other is less readable

**do we need documentation updates?**
no, the only documentation for this feature is the title (mouseover text) and that is correct already.

**regression potential?**
the new icon is slightly less self-explanatory than those already in use.

Keywords: \Answered $Forwarded