### PR TITLE
Send IMAP ID only after authentication

### DIFF
--- a/program/lib/Roundcube/rcube_imap.php
+++ b/program/lib/Roundcube/rcube_imap.php
@@ -136,14 +136,7 @@ class rcube_imap extends rcube_storage
 
         if ($this->options['debug']) {
             $this->set_debug(true);
-
-            $this->options['ident'] = array(
-                'name'    => 'Roundcube',
-                'version' => RCUBE_VERSION,
-                'php'     => PHP_VERSION,
-                'os'      => PHP_OS,
-                'command' => $_SERVER['REQUEST_URI'],
-            );
+            $this->conn->imap_id['command'] = $_SERVER['REQUEST_URI'];
         }
 
         $attempt = 0;
@@ -178,6 +171,11 @@ class rcube_imap extends rcube_storage
             $session = null;
             if (preg_match('/\s+SESSIONID=([^=\s]+)/', $this->conn->result, $m)) {
                 $session = $m[1];
+            }
+
+            // Send ID info
+            if (!empty($this->conn->imap_id) && $this->conn->getCapability('ID')) {
+                $this->data['ID'] = $this->conn->id($this->conn->imap_id);
             }
 
             // get namespace and delimiter
@@ -632,12 +630,7 @@ class rcube_imap extends rcube_storage
         }
 
         if (($ident = $this->conn->data['ID']) === null && $this->get_capability('ID')) {
-            $ident = $this->conn->id(array(
-                    'name'    => 'Roundcube',
-                    'version' => RCUBE_VERSION,
-                    'php'     => PHP_VERSION,
-                    'os'      => PHP_OS,
-            ));
+            $ident = $this->conn->id($this->conn->imap_id);
         }
 
         $vendor  = (string) (!empty($ident) ? $ident['name'] : '');

--- a/program/lib/Roundcube/rcube_imap_generic.php
+++ b/program/lib/Roundcube/rcube_imap_generic.php
@@ -49,6 +49,13 @@ class rcube_imap_generic
         '*'        => '\\*',
     );
 
+    public $imap_id = array(
+        'name'    => 'Roundcube',
+        'version' => RCUBE_VERSION,
+        'php'     => PHP_VERSION,
+        'os'      => PHP_OS,
+    );
+
     protected $fp;
     protected $host;
     protected $cmd_tag;
@@ -911,11 +918,6 @@ class rcube_imap_generic
         // Connect
         if (!$this->_connect($host)) {
             return false;
-        }
-
-        // Send ID info
-        if (!empty($this->prefs['ident']) && $this->getCapability('ID')) {
-            $this->data['ID'] = $this->id($this->prefs['ident']);
         }
 
         $auth_method  = $this->prefs['auth_type'];


### PR DESCRIPTION
In case of IMAP proxy, that is doing authentication and routing, receiving ID command may result in `BAD Invalid command` error, as IMAP proxy does not yet know which server should receive the communications. Even if proxies would return correct output for ID command, the "name" field returned would not necessarily be the same as for "name" field value after authenticating.

This applies to Nginx + Dovecot stack.

iPhone Mail, Mac OS X Mail, Microsoft Outlook, Thunderbird, and other major (as 30+ minor) MUAs are sending ID command after authenticating, or even delay it until after NAMESPACE.





