### PR TITLE
managesieve: Keep angle brackets in reason

### DIFF
--- a/plugins/managesieve/lib/Roundcube/rcube_sieve_vacation.php
+++ b/plugins/managesieve/lib/Roundcube/rcube_sieve_vacation.php
@@ -199,7 +199,7 @@ class rcube_sieve_vacation extends rcube_sieve_engine
 
         $interval_type                   = $interval_type == 'seconds' ? 'seconds' : 'days';
         $vacation_action['type']         = 'vacation';
-        $vacation_action['reason']       = $this->strip_value(str_replace("\r\n", "\n", $reason));
+        $vacation_action['reason']       = $this->strip_value(str_replace("\r\n", "\n", $reason), true);
         $vacation_action['subject']      = trim($subject);
         $vacation_action['from']         = trim($from);
         $vacation_action['addresses']    = $addresses;
@@ -743,7 +743,7 @@ class rcube_sieve_vacation extends rcube_sieve_engine
         $regex_extension = in_array('regex', $this->exts);
 
         $vacation['type']      = 'vacation';
-        $vacation['reason']    = $this->strip_value(str_replace("\r\n", "\n", $data['message']));
+        $vacation['reason']    = $this->strip_value(str_replace("\r\n", "\n", $data['message']), true);
         $vacation['addresses'] = $data['addresses'];
         $vacation['subject']   = trim($data['subject']);
         $vacation['from']      = trim($data['from']);


### PR DESCRIPTION
Angle brackets (and other characters considered special by HTML) should be allowed in the message body. The current implementation sends a plaintext body anyways.
[When fetching the `vacation_reason` from the POST arguments using `rcube_utils::get_input_value()`](https://github.com/roundcube/roundcubemail/blob/17deadfe564c770cc3e5077a091c196a36485cdf/plugins/managesieve/lib/Roundcube/rcube_sieve_vacation.php#L187), HTML was already allowed.

Fixes #7518 