### PR TITLE
Correct documentation of password_login_exceptions parameter

### DIFF
--- a/plugins/password/config.inc.php.dist
+++ b/plugins/password/config.inc.php.dist
@@ -25,7 +25,7 @@ $config['password_minimum_score'] = 0;
 // Enables logging of password changes into logs/password
 $config['password_log'] = false;
 
-// Comma-separated list of login exceptions for which password change
+// Array of login exceptions for which password change
 // will be not available (no Password tab in Settings)
 $config['password_login_exceptions'] = null;
 


### PR DESCRIPTION
The documentation of the password_login_exceptions in password plugin is incorrect. It says that is a comma separated list while the plugin it only accepts an array.

Signed-off-by: Evili del Rio <evili.del.rio@gmail.com>