### PR TITLE
MySQL: Don't reissue query after deadlock error

### DIFF
--- a/program/lib/Roundcube/db/mysql.php
+++ b/program/lib/Roundcube/db/mysql.php
@@ -247,29 +247,4 @@ class rcube_db_mysql extends rcube_db
             . " ON DUPLICATE KEY UPDATE $update", $values);
     }
 
-    /**
-     * Handle DB errors, re-issue the query on deadlock errors from InnoDB row-level locking
-     *
-     * @param string Query that triggered the error
-     * @return mixed Result to be stored and returned
-     */
-    protected function handle_error($query)
-    {
-        $error = $this->dbh->errorInfo();
-
-        // retry after "Deadlock found when trying to get lock" errors
-        $retries = 2;
-        while ($error[1] == 1213 && $retries >= 0) {
-            usleep(50000);  // wait 50 ms
-            $result = $this->dbh->query($query);
-            if ($result !== false) {
-                return $result;
-            }
-            $error = $this->dbh->errorInfo();
-            $retries--;
-        }
-
-        return parent::handle_error($query);
-    }
-
 }


### PR DESCRIPTION
Please see issue for a detailed description. (Fixes #7528)

When a deadlock error occurs, MySQL rolls back the _entire_ ongoing
transaction. The application would have to restart the transaction from
the beginning to retry if wanted.

Now roundcube in that case simply retries the statement that raised the
deadlock error, even though everything else in the transaction was
rolled back. This breaks transaction isolation, leaves the database in a
potentially inconsistent state (from the application's data consistency
model point of view), and does not indicate to the application there was
a problem at all to it may even continue executing other potentially
remaining statements of a transaction that has already been rolled back.

-> Remove the retries from roundcube. Retries have to be initiated by
the application if desired, not only retrying the last statement but the
entire transaction from the beginning.