### PR TITLE
bin: set error on exit for shell scripts

### DIFF
--- a/bin/cssshrink.sh
+++ b/bin/cssshrink.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+
+set -e
+
 PWD=`dirname "$0"`
 JAR_DIR='/tmp'
 VERSION='2.4.8'
@@ -47,8 +50,7 @@ DIRS="$PWD/../skins/* $PWD/../plugins/* $PWD/../plugins/*/skins/*"
 # default: compress application scripts
 for dir in $DIRS; do
     for file in $dir/*.css; do
-        echo "$file" | grep -e '.min.css$' >/dev/null
-        if [ $? -eq 0 ]; then
+        if echo "$file" | grep -q -e '.min.css$'; then
             continue
         fi
         if [ ! -f "$file" ]; then

--- a/bin/jsshrink.sh
+++ b/bin/jsshrink.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+
+set -e
+
 PWD=`dirname "$0"`
 JS_DIR="$PWD/../program/js"
 JAR_DIR='/tmp'
@@ -60,8 +63,7 @@ DIRS="$PWD/../program/js $PWD/../skins/* $PWD/../plugins/* $PWD/../plugins/*/ski
 # default: compress application scripts
 for dir in $DIRS; do
     for file in $dir/*.js; do
-        echo "$file" | grep -e '.min.js$' >/dev/null
-        if [ $? -eq 0 ]; then
+        if echo "$file" | grep -q -e '.min.js$'; then
             continue
         fi
         if [ ! -f "$file" ]; then

--- a/bin/makedoc.sh
+++ b/bin/makedoc.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 TITLE="Roundcube Webmail"
 PACKAGES="Webmail"
 

--- a/bin/transifexpull.sh
+++ b/bin/transifexpull.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 # In 'translator' mode files will contain empty translated texts
 # where translation is not available, we'll remove these later
 


### PR DESCRIPTION
I am building Roundcube via CI jobs, and also ran in #7567 (thank you
for the quick fix!).

The CI job I'm using runs css/js shrink and the build job itself
succeeded, although Roundcube wasn't working.

With this commit all shell scripts will propagate the exit code in case
of errors, e.g. failed downloads.