### PR TITLE
Fixed emails dropdown hiding when the user scrolls it.

### DIFF
--- a/program/js/app.js
+++ b/program/js/app.js
@@ -4733,7 +4733,12 @@ function rcube_webmail()
       .attr({autocomplete: 'off', 'aria-autocomplete': 'list', 'aria-expanded': 'false', role: 'combobox'});
 
     // hide the popup on any click
-    var callback = function() { ref.ksearch_hide(); };
+    var callback = function(e) {
+      if (e.target.id === 'rcmKSearchpane') {
+        return;
+      }
+      ref.ksearch_hide();
+    };
     $(document).on('click', callback);
     // and on scroll (that cannot be jQuery.on())
     document.addEventListener('scroll', callback, true);


### PR DESCRIPTION
The emails dropdown window from the field "From" on the Compose-page hides when the user scrolls it. And it doesn't matter how he scrolls - by the mouse wheel or clicking on the scrollbar.

![emails_dropdown](https://user-images.githubusercontent.com/70898196/92391925-27fa7c80-f126-11ea-8e5b-996f8c72d658.png)
