### PR TITLE
make auto generated button ids unique between main screen and iframe

### DIFF
--- a/program/include/rcmail_output_html.php
+++ b/program/include/rcmail_output_html.php
@@ -1643,8 +1643,12 @@ EOF;
         }
 
         if (!$attrib['id']) {
-            $attrib['id'] =  sprintf('rcmbtn%d', $s_button_count++);
+            // ensure auto generated IDs are unique between main window and content frame
+            // Elastic skin duplicates buttons between the two on smaller screens (#7618)
+            $prefix       = ($this->framed || $this->env['framed']) ? 'frm' : '';
+            $attrib['id'] = sprintf('rcmbtn%s%d', $prefix, $s_button_count++);
         }
+
         // get localized text for labels and titles
         if ($attrib['title']) {
             $attrib['title'] = html::quote($this->app->gettext($attrib['title'], $attrib['domain']));


### PR DESCRIPTION
when using the Elastic skin on small/phone screens buttons can be copied from the main screen to the content iframe. Eg. list options are copied to the contact view/edit screens.

this change guarantees that auto-generated button ids are unique between the main window and the content iframe so when if buttons are cloned between the two they will still have unique ids.