### PR TITLE
replace browser confirm box for mdn confirmation with dialog box

### DIFF
--- a/program/js/app.js
+++ b/program/js/app.js
@@ -486,13 +486,36 @@ function rcube_webmail()
 
         // ask user to send MDN
         if (this.env.mdn_request && this.env.uid) {
-          var postact = 'sendmdn',
-            postdata = {_uid: this.env.uid, _mbox: this.env.mailbox};
-          if (!confirm(this.get_label('mdnrequest'))) {
-            postdata._flag = 'mdnsent';
-            postact = 'mark';
-          }
-          this.http_post(postact, postdata);
+            this.env.mdn_props = {
+                'action': 'mark',
+                'data': { _uid: this.env.uid, _mbox: this.env.mailbox, _flag: 'mdnsent' }
+            };
+
+            var buttons = [{
+                text: this.get_label('send'),
+                'class': 'mainaction send',
+                click: function(e, ui, dialog) {
+                    delete ref.env.mdn_props['data']['_flag'];
+                    ref.env.mdn_props['action'] = 'sendmdn';
+                    (ref.is_framed() ? parent.$ : $)(dialog || this).dialog('close');
+                }
+            },
+            {
+                text: this.get_label('ignore'),
+                'class': 'cancel',
+                click: function(e, ui, dialog){
+                    (ref.is_framed() ? parent.$ : $)(dialog || this).dialog('close');
+                }
+            }],
+            mdn_func = function(event, ui) {
+                var props = ref.env.mdn_props;
+                ref.http_post(props.action, props.data);
+
+                // from default close function
+                $(this).remove();
+            };
+
+            this.show_popup_dialog(this.get_label('mdnrequest'), this.get_label('sendreceipt'), buttons, { close: mdn_func });
         }
 
         // detect browser capabilities

--- a/program/localization/en_US/labels.inc
+++ b/program/localization/en_US/labels.inc
@@ -359,6 +359,7 @@ $labels['addreplyto'] = 'Add Reply-To';
 $labels['addfollowupto'] = 'Add Followup-To';
 
 // mdn
+$labels['sendreceipt'] = 'Send read receipt?';
 $labels['mdnrequest'] = 'The sender of this message has asked to be notified when you read this message. Do you wish to notify the sender?';
 $labels['receiptread'] = 'Return Receipt (read)';
 $labels['yourmessage'] = 'This is a Return Receipt for your message';

--- a/program/steps/mail/show.inc
+++ b/program/steps/mail/show.inc
@@ -135,7 +135,7 @@ if ($uid) {
         }
         else if ($mdn_cfg != 2 && $mdn_cfg != 4) {
             // Ask user
-            $OUTPUT->add_label('mdnrequest');
+            $OUTPUT->add_label('sendreceipt', 'mdnrequest', 'send', 'ignore');
             $OUTPUT->set_env('mdn_request', true);
         }
     }


### PR DESCRIPTION
related to #7614, in case replacing the confirm box with a roundcube dialog box is chosen as the way forward.

I have deliberately used `show_popup_dialog() ` here as it will easily allow for a third button to be added should that be needed (see discussion in #7614)