### PR TITLE
Fix Elastic's folders settings toggle button in search

### DIFF
--- a/program/js/treelist.js
+++ b/program/js/treelist.js
@@ -623,7 +623,14 @@ function rcube_treelist_widget(node, p)
             // append all elements like links and inputs, but not sub-trees
             .append(li.children(':not(div.treetoggle,ul)').clone(true, true))
             .appendTo(container);
-            hits.push(node.id);
+          
+          // let skins to do their magic, e.g. Elastic will fix pretty checkbox
+          rcmail.triggerEvent('clonerow', {
+            id: node.id,
+            row: sli.get(0)
+          });
+
+          hits.push(node.id);
         }
 
         if (node.children && node.children.length) {


### PR DESCRIPTION
Fix for #7652

For each search result, a new list element is created for which the child elements are cloned from the original folder list item. When cloning, the elements' IDs are also copied which breaks Bootstrap's checkbox construct.

This fix reuses a clonerow event that has been introduced for a similar problem when creating new folders.