### PR TITLE
implement trim() to password input field

### DIFF
--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -1409,3 +1409,7 @@ $config['message_show_email'] = false;
 // 0 - Reply-All always
 // 1 - Reply-List if mailing list is detected
 $config['reply_all_mode'] = 0;
+
+// Enables the trim of leading and trailing spaces in passwords during login and password plugin
+// If enabled and existing users did use spaces in front or end of passwords, they cannot login
+$config['password_trim'] = false;

--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -1412,4 +1412,4 @@ $config['reply_all_mode'] = 0;
 
 // Enables the trim of leading and trailing spaces in passwords during login and password plugin
 // If enabled and existing users did use spaces in front or end of passwords, they cannot login
-$config['password_trim'] = false;
+$config['trim_password'] = false;

--- a/index.php
+++ b/index.php
@@ -104,16 +104,22 @@ $RCMAIL->action = $startup['action'];
 if ($RCMAIL->task == 'login' && $RCMAIL->action == 'login') {
     $request_valid = $_SESSION['temp'] && $RCMAIL->check_request();
     $pass_charset  = $RCMAIL->config->get('password_charset', 'UTF-8');
+    $trim_password = $RCMAIL->config->get('password_trim', false);
 
     // purge the session in case of new login when a session already exists
     if ($request_valid) {
         $RCMAIL->kill_session();
     }
 
+    $password = rcube_utils::get_input_value('_pass', rcube_utils::INPUT_POST, true, $pass_charset);
+    if ($trim_password) {
+        $password = trim($password);
+    }
+
     $auth = $RCMAIL->plugins->exec_hook('authenticate', array(
             'host'  => $RCMAIL->autoselect_host(),
             'user'  => trim(rcube_utils::get_input_value('_user', rcube_utils::INPUT_POST)),
-            'pass'  => trim(rcube_utils::get_input_value('_pass', rcube_utils::INPUT_POST, true, $pass_charset)),
+            'pass'  => $password,
             'valid' => $request_valid,
             'cookiecheck' => true,
     ));

--- a/index.php
+++ b/index.php
@@ -113,7 +113,7 @@ if ($RCMAIL->task == 'login' && $RCMAIL->action == 'login') {
     $auth = $RCMAIL->plugins->exec_hook('authenticate', array(
             'host'  => $RCMAIL->autoselect_host(),
             'user'  => trim(rcube_utils::get_input_value('_user', rcube_utils::INPUT_POST)),
-            'pass'  => rcube_utils::get_input_value('_pass', rcube_utils::INPUT_POST, true, $pass_charset),
+            'pass'  => trim(rcube_utils::get_input_value('_pass', rcube_utils::INPUT_POST, true, $pass_charset)),
             'valid' => $request_valid,
             'cookiecheck' => true,
     ));

--- a/index.php
+++ b/index.php
@@ -104,7 +104,7 @@ $RCMAIL->action = $startup['action'];
 if ($RCMAIL->task == 'login' && $RCMAIL->action == 'login') {
     $request_valid = $_SESSION['temp'] && $RCMAIL->check_request();
     $pass_charset  = $RCMAIL->config->get('password_charset', 'UTF-8');
-    $trim_password = $RCMAIL->config->get('password_trim', false);
+    $trim_password = $RCMAIL->config->get('trim_password', false);
 
     // purge the session in case of new login when a session already exists
     if ($request_valid) {

--- a/plugins/password/password.php
+++ b/plugins/password/password.php
@@ -135,7 +135,7 @@ class password extends rcube_plugin
         $confirm         = $this->rc->config->get('password_confirm_current');
         $required_length = intval($this->rc->config->get('password_minimum_length'));
         $force_save      = $this->rc->config->get('password_force_save');
-        $trim_password   = $this->rc->config->get('password_trim', false);
+        $trim_password   = $this->rc->config->get('trim_password', false);
 
         if (($confirm && !isset($_POST['_curpasswd'])) || !isset($_POST['_newpasswd']) || !strlen($_POST['_newpasswd'])) {
             $this->rc->output->command('display_message', $this->gettext('nopassword'), 'error');

--- a/plugins/password/password.php
+++ b/plugins/password/password.php
@@ -135,6 +135,7 @@ class password extends rcube_plugin
         $confirm         = $this->rc->config->get('password_confirm_current');
         $required_length = intval($this->rc->config->get('password_minimum_length'));
         $force_save      = $this->rc->config->get('password_force_save');
+        $trim_password = $this->rc->config->get('password_trim', false);
 
         if (($confirm && !isset($_POST['_curpasswd'])) || !isset($_POST['_newpasswd']) || !strlen($_POST['_newpasswd'])) {
             $this->rc->output->command('display_message', $this->gettext('nopassword'), 'error');
@@ -157,6 +158,11 @@ class password extends rcube_plugin
             // We're doing this for consistence with Roundcube core
             $newpwd = rcube_charset::convert($newpwd, $rc_charset, $charset);
             $conpwd = rcube_charset::convert($conpwd, $rc_charset, $charset);
+
+            if ($trim_password) {
+                $newpwd = trim($newpwd);
+                $conpwd = trim($conpwd);
+            }
 
             if ($chk_pwd != $orig_pwd || preg_match('/[\x00-\x1F\x7F]/', $newpwd)) {
                 $this->rc->output->command('display_message', $this->gettext('passwordforbidden'), 'error');

--- a/plugins/password/password.php
+++ b/plugins/password/password.php
@@ -135,7 +135,7 @@ class password extends rcube_plugin
         $confirm         = $this->rc->config->get('password_confirm_current');
         $required_length = intval($this->rc->config->get('password_minimum_length'));
         $force_save      = $this->rc->config->get('password_force_save');
-        $trim_password = $this->rc->config->get('password_trim', false);
+        $trim_password   = $this->rc->config->get('password_trim', false);
 
         if (($confirm && !isset($_POST['_curpasswd'])) || !isset($_POST['_newpasswd']) || !strlen($_POST['_newpasswd'])) {
             $this->rc->output->command('display_message', $this->gettext('nopassword'), 'error');


### PR DESCRIPTION
We had a long discussion within our team, if we should trim a password and remove leading and trailing spaces within an existing environment.

We come to the conclusion, that it will provide more stability and default users do not use leading and trailing spaces.
We save more time by get rid of Copy & Paste errors in support requests, then it will cost one time to help users fix their password.

Because we want to push this into main repo, we implement a configuration option to enable this. 
Per default this feature is disabled and not used. 
We also implement this into the "passwords" plugin to transparent remove leading/trailing spaces.

Because this is our first contribution to roundcube, please let me know when some formatting is not correct or the feature is not wanted.

Regards,
Stefan