### PR TITLE
Fixing a typo in csv mapping fields

### DIFF
--- a/program/lib/Roundcube/rcube_csv2vcard.php
+++ b/program/lib/Roundcube/rcube_csv2vcard.php
@@ -140,7 +140,7 @@ class rcube_csv2vcard
         'user_photo'            => 'photo',
         'url'                   => 'website:homepage',
         'work_company'          => 'organization',
-        'work_dept'             => 'departament',
+        'work_dept'             => 'department',
         'work_fax'              => 'phone:work,fax',
         'work_mobile'           => 'phone:work,cell',
         'work_title'            => 'jobtitle',


### PR DESCRIPTION
There is a typo for work_dept value in csv mapping fields