### PR TITLE
Do not remove commas when importing a groups/categories list

### DIFF
--- a/program/lib/Roundcube/rcube_csv2vcard.php
+++ b/program/lib/Roundcube/rcube_csv2vcard.php
@@ -635,7 +635,6 @@ class rcube_csv2vcard
 
         if (!empty($contact['groups'])) {
             // categories/groups separator in vCard is ',' not ';'
-            $contact['groups'] = str_replace(',', '', $contact['groups']);
             $contact['groups'] = str_replace(';', ',', $contact['groups']);
 
             // remove "* " added by GMail


### PR DESCRIPTION
I probably don't getting the point, but why removing commas in this case if it's the right separator to use for a groups/categories list ? 
By doing this, importing a well separated groups/categories list never work