### PR TITLE
Update rcube_user.php : preferences' column initialization in user_create

### DIFF
--- a/program/lib/Roundcube/rcube_user.php
+++ b/program/lib/Roundcube/rcube_user.php
@@ -621,6 +621,7 @@ class rcube_user
             'user_email' => $user_email,
             'email_list' => $email_list,
             'language'   =>  $_SESSION['language'],
+            'preferences'   => array(),
         ));
 
         // plugin aborted this operation
@@ -630,12 +631,13 @@ class rcube_user
 
         $insert = $dbh->query(
             "INSERT INTO ".$dbh->table_name('users', true).
-            " (`created`, `last_login`, `username`, `mail_host`, `language`)".
-            " VALUES (".$dbh->now().", ".$dbh->now().", ?, ?, ?)",
+            " (`created`, `last_login`, `username`, `mail_host`, `language`, `preferences`)".
+            " VALUES (".$dbh->now().", ".$dbh->now().", ?, ?, ?, ?)",
             $data['user'],
             $data['host'],
-            $data['language']);
-
+            $data['language'],
+            serialize($data['preferences']));
+        
         if ($dbh->affected_rows($insert) && ($user_id = $dbh->insert_id('users'))) {
             // create rcube_user instance to make plugin hooks work
             $user_instance = new rcube_user($user_id, array(
@@ -643,6 +645,7 @@ class rcube_user
                 'username'  => $data['user'],
                 'mail_host' => $data['host'],
                 'language'  => $data['language'],
+                'preferences'  => serialize($data['preferences'])
             ));
             $rcube->user = $user_instance;
             $mail_domain = $rcube->config->mail_domain($data['host']);


### PR DESCRIPTION
I am working on an update of the squirrelmail_usercopy plugin,
to permit the transfer of address groups and the equivalent of the
roundcube's "message_highlight" plugin when creating à new user on
roundcube with data taken from a current squirrelmail account.
Many of our squirrelmail users use these features.

If the addition of address groups has been done updating only the
original plugin's code, I had to make some change in the "create"
function in the program/lib/Roundcube/rcube_user.php file to permit the
import of the message highlight preferences.

This change is simply the addition of the field 'preferences' for the
call of the "user_create" hook, and the storage of the returned value in the
"preferences" column of the "users"  table of the database.

The change has to be made because if the user_create hook permits to
populate all columns of the "users" table, the "preferences" column is
not treated by the hook, while the "messages highlight" plugin stores its
preferences there.

Adding the change as I suggest could be seen only as a measure of
consistency about the initialization of the "users" table.
When I searched in the code to understand why my updated plugin didn't
work, I was surprised to see that the "preferences" field was simply not
treated...

And even beyond the squirrelmail_usercopy plugin, I think this change
could help others user-creation related plugins.
