### PR TITLE
style links in dark mode alerts

### DIFF
--- a/skins/elastic/styles/dark.less
+++ b/skins/elastic/styles/dark.less
@@ -165,6 +165,11 @@ html.dark-mode {
         }
     }
 
+    .ui.alert a:not(.btn) {
+        color: @color-dark-font;
+        text-decoration: underline;
+    }
+
     .iframe-loader {
         background-color: fadeout(@color-dark-background, 10%);
 


### PR DESCRIPTION
with dark mode enabled alert messages which have links in them can be hard to read

![Untitled-1](https://user-images.githubusercontent.com/88682/97414901-76452400-18fc-11eb-9620-ab5e4c01701d.png)

I couldn't find a color which worked with all alert messages like in light mode so I went with underlining instead.

