### PR TITLE
When creating or forwarding email, entering email address in "to" field causes "internal server error" popup

### DIFF
--- a/program/lib/Roundcube/rcube_addresses.php
+++ b/program/lib/Roundcube/rcube_addresses.php
@@ -101,7 +101,7 @@ class rcube_addresses extends rcube_contacts
             $start_row,
             $length,
             $this->user_id,
-            $this->type,
+            $this->type
         );
 
         while ($sql_result && ($sql_arr = $this->db->fetch_assoc($sql_result))) {


### PR DESCRIPTION
Fixes syntax error when trying to fetch names from "Collected Recipients" and "Trusted Senders" when trying to address new or forwarded email. Syntax error noted in debug logging output. Extraneous comma removed. 