### PR TITLE
new option for configurable cookie lifetime

### DIFF
--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -570,8 +570,12 @@ $config['skin_include_php'] = false;
 // 0 - hide product name and version number, 1 - show product name only, 2 - show product name and version number
 $config['display_product_info'] = 1;
 
-// Session lifetime in minutes
+// Session lifetime in minutes (server side)
 $config['session_lifetime'] = 10;
+
+// Cookie lifetime in minutes for session id and auth cookies
+// 0 - session cookies (expire on browser exit)
+$config['cookie_lifetime'] = 0;
 
 // Session domain: .example.org
 $config['session_domain'] = '';

--- a/program/lib/Roundcube/rcube.php
+++ b/program/lib/Roundcube/rcube.php
@@ -444,6 +444,7 @@ class rcube
         $sess_path     = $this->config->get('session_path');
         $sess_samesite = $this->config->get('session_samesite');
         $lifetime      = $this->config->get('session_lifetime', 0) * 60;
+        $c_lifetime    = $this->config->get('cookie_lifetime', 0) * 60;
         $is_secure     = $this->config->get('use_https') || rcube_utils::https_check();
 
         // set session domain
@@ -464,8 +465,7 @@ class rcube
             ini_set('session.gc_maxlifetime', $lifetime * 2);
         }
 
-        // set session cookie lifetime so it never expires (#5961)
-        ini_set('session.cookie_lifetime', 0);
+        ini_set('session.cookie_lifetime', $c_lifetime);
         ini_set('session.cookie_secure', $is_secure);
         ini_set('session.name', $sess_name ?: 'roundcube_sessid');
         ini_set('session.use_cookies', 1);

--- a/program/lib/Roundcube/rcube_session.php
+++ b/program/lib/Roundcube/rcube_session.php
@@ -701,7 +701,7 @@ abstract class rcube_session
      */
     public function set_auth_cookie()
     {
-        $clifetime = $this->config->get('cookie_lifetime', 1) * 60;
+        $clifetime = $this->config->get('cookie_lifetime', 0) * 60;
         if (!$clifetime) { $expiration = 0; }
         else { $expiration = time() + $clifetime; }
         $this->cookie = $this->_mkcookie($this->now);

--- a/program/lib/Roundcube/rcube_session.php
+++ b/program/lib/Roundcube/rcube_session.php
@@ -701,7 +701,9 @@ abstract class rcube_session
      */
     public function set_auth_cookie()
     {
-        $expiration = time() + $this->config->get('cookie_lifetime', 1) * 60;
+        $clifetime = $this->config->get('cookie_lifetime', 1) * 60;
+        if (!$clifetime) { $expiration = 0; }
+        else { $expiration = time() + $clifetime; }
         $this->cookie = $this->_mkcookie($this->now);
         rcube_utils::setcookie($this->cookiename, $this->cookie, $expiration);
         $_COOKIE[$this->cookiename] = $this->cookie;

--- a/program/lib/Roundcube/rcube_session.php
+++ b/program/lib/Roundcube/rcube_session.php
@@ -701,8 +701,9 @@ abstract class rcube_session
      */
     public function set_auth_cookie()
     {
+        $expiration = time() + $this->config->get('cookie_lifetime', 1) * 60;
         $this->cookie = $this->_mkcookie($this->now);
-        rcube_utils::setcookie($this->cookiename, $this->cookie, 0);
+        rcube_utils::setcookie($this->cookiename, $this->cookie, $expiration);
         $_COOKIE[$this->cookiename] = $this->cookie;
     }
 


### PR DESCRIPTION
Implementing #5050 by introducing a new config option `cookie_lifetime`.

The default is the current behavior (i.e. set session cookies with lifetime 0).