### PR TITLE
Allow multiple messages to be bounced/resent at once

### DIFF
--- a/program/actions/mail/bounce.php
+++ b/program/actions/mail/bounce.php
@@ -49,7 +49,10 @@ class rcmail_action_mail_bounce extends rcmail_action
 
             // Initialize helper class to build the UI
             $SENDMAIL = new rcmail_sendmail(
-                ['mode' => rcmail_sendmail::MODE_FORWARD],
+                [
+                    'mode'  => rcmail_sendmail::MODE_FORWARD,
+                    'param' => ['sent_mbox' => $rcmail->config->get('bounce_save_mbox')]
+                ],
                 ['message' => $MESSAGES[0]]
             );
 
@@ -84,6 +87,7 @@ class rcmail_action_mail_bounce extends rcmail_action
                 'Resent-Date'       => $input_headers['Date'],
         ]);
 
+        $save_error = false;
 
         foreach ($MESSAGES as $MESSAGE) {
             $headers['Resent-Message-ID'] = $rcmail->gen_message_id($headers['Resent-From']);
@@ -105,7 +109,12 @@ class rcmail_action_mail_bounce extends rcmail_action
 
             if (!$saved && strlen($SENDMAIL->options['store_target'])) {
                 self::display_server_error('errorsaving');
+                $save_error = true;
             }
+        }
+
+        if (!$save_error) {
+            $rcmail->user->save_prefs(['bounce_save_mbox' => $SENDMAIL->options['store_target']]);
         }
 
         $rcmail->output->show_message('messagesent', 'confirmation', null, false);

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -1962,7 +1962,7 @@ function rcube_webmail()
     }
 
     // Multi-message commands
-    this.enable_command('delete', 'move', 'copy', 'mark', 'forward', 'forward-attachment', selected_count > 0);
+    this.enable_command('delete', 'move', 'copy', 'mark', 'forward', 'forward-attachment', 'bounce', selected_count > 0);
 
     // reset all-pages-selection
     if (selected || (selected_count && selected_count != list.rowcount))
@@ -4538,8 +4538,8 @@ function rcube_webmail()
   this.bounce = function(props, obj, event)
   {
     // get message uid and folder
-    var uid = this.get_single_uid(),
-      url = this.url('bounce', {_framed: 1, _uid: uid, _mbox: this.get_message_mailbox(uid)}),
+    var uids = this.env.uid ? [this.env.uid] : (this.message_list ? this.message_list.get_selection() : []),
+      url = this.url('bounce', {_framed: 1, _uids: this.uids_to_list(uids), _mbox: this.env.mailbox}),
       dialog = $('<iframe>').attr('src', url),
       get_form = function() {
         var rc = $('iframe', dialog)[0].contentWindow.rcmail;
@@ -4550,7 +4550,7 @@ function rcube_webmail()
 
         $.each($(form.form).serializeArray(), function() { post[this.name] = this.value; });
 
-        post._uid = form.rc.env.uid;
+        post._uids = form.rc.env.uids;
         post._mbox = form.rc.env.mailbox;
         delete post._action;
         delete post._task;


### PR DESCRIPTION
This PR extends the bounce interface to allow multiple messages to be selected and bounced to the same recipient.

It also sneaks in a change to remember (in a user pref) the folder the bounced messages were last saved in.  (I'm happy to separate this out if needed, though.)

Please let me know if any other changes are needed.  Thanks for all your work on Roundcube.