### PR TITLE
Restore compatibility in rcube_addressbook::set_sort_order API

### DIFF
--- a/program/lib/Roundcube/rcube_addressbook.php
+++ b/program/lib/Roundcube/rcube_addressbook.php
@@ -206,12 +206,12 @@ abstract class rcube_addressbook
     /**
      * Set internal sort settings
      *
-     * @param string $sort_col   Sort column
-     * @param string $sort_order Sort order
+     * @param ?string $sort_col   Sort column
+     * @param ?string $sort_order Sort order
      */
     function set_sort_order($sort_col, $sort_order = null)
     {
-        if ($sort_col && in_array($sort_col, $this->coltypes)) {
+        if ($sort_col && (key_exists($sort_col, $this->coltypes) || in_array($sort_col, $this->coltypes))) {
             $this->sort_col = $sort_col;
         }
 

--- a/program/lib/Roundcube/rcube_addressbook.php
+++ b/program/lib/Roundcube/rcube_addressbook.php
@@ -211,7 +211,7 @@ abstract class rcube_addressbook
      */
     function set_sort_order($sort_col, $sort_order = null)
     {
-        if ($sort_col && (key_exists($sort_col, $this->coltypes) || in_array($sort_col, $this->coltypes))) {
+        if ($sort_col && (array_key_exists($sort_col, $this->coltypes) || in_array($sort_col, $this->coltypes))) {
             $this->sort_col = $sort_col;
         }
 


### PR DESCRIPTION
Addressbook plugins used to be either able to either store their supported column types as a flat list of column names (like
rcube_contacts does), or as an array where the column names are keys and additional attributes are provided for the columns (e.g. custom subtypes).

In the current master, only the former type is supported by the set_sort_order function in the rcube_addressbook class. It used to
supports both.

For the latter type, the original support was a bit broken though, as it did not allow the sort columns to map to an empty array. This is used in the carddav addressbook because it only requires custom properties for some attributes, and sets the others to empty arrays which roundcube then merges with its standard properties for these columns. This is fixed by using isset that only checks if the the key exists in coltypes.

I know a plugin can override this function, but this change unnecessarily breaks backwards compatibility.