### PR TITLE
fix missing title in contacts list in larry skin

### DIFF
--- a/program/actions/contacts/list.php
+++ b/program/actions/contacts/list.php
@@ -41,7 +41,7 @@ class rcmail_action_contacts_list extends rcmail_action_contacts_index
         $_SESSION['page'] = $page;
 
         $page_size  = $rcmail->config->get('addressbook_pagesize', $rcmail->config->get('pagesize', 50));
-        $group_data = [];
+        $group_data = null;
 
         // Use search result
         if (($records = self::search_update(true)) !== false) {

--- a/tests/Actions/Contacts/List.php
+++ b/tests/Actions/Contacts/List.php
@@ -31,7 +31,7 @@ class Actions_Contacts_List extends ActionTestCase
         $commands = explode("\n", trim($result['exec']));
 
         $this->assertCount(8, $commands);
-        $this->assertSame('this.set_group_prop([]);', $commands[0]);
+        $this->assertSame('this.set_group_prop(null);', $commands[0]);
         $this->assertSame('this.set_rowcount("Contacts 1 to 6 of 6");', $commands[1]);
         $this->assertStringMatchesFormat(
             'this.add_contact_row("%i",{"name":"George Bush"},"person",'


### PR DESCRIPTION
The JS function set_group_prop() expects its only param to be null or a group object, not an empty object. The empty object causes the title of the contacts list in Larry skin to be removed rather than set to the default 'Contacts'.