### PR TITLE
cleanup: Remove PHP warnings that could appear in error.log on failed authentication

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 CHANGELOG Roundcube Webmail
 ===========================
 
+- Fix some PHP warnings in the main index.php that can clutter the error.log
+  file on failed user authentication
 - Require PHP >= 5.5
 - Require php-intl
 - Remove use of ext-iconv

--- a/index.php
+++ b/index.php
@@ -157,7 +157,7 @@ if ($RCMAIL->task == 'login' && $RCMAIL->action == 'login') {
             $error_code = rcmail::ERROR_INVALID_REQUEST;
         }
         else {
-            $error_code = is_numeric($auth['error']) ? $auth['error'] : $RCMAIL->login_error();
+            $error_code = isset($auth['error']) && is_numeric($auth['error']) ? $auth['error'] : $RCMAIL->login_error();
         }
 
         $error_labels = [
@@ -168,7 +168,7 @@ if ($RCMAIL->task == 'login' && $RCMAIL->action == 'login') {
             rcmail::ERROR_RATE_LIMIT       => 'accountlocked',
         ];
 
-        $error_message = !empty($auth['error']) && !is_numeric($auth['error']) ? $auth['error'] : ($error_labels[$error_code] ?: 'loginfailed');
+        $error_message = !empty($auth['error']) && !is_numeric($auth['error']) ? $auth['error'] : (isset($error_labels[$error_code]) && $error_labels[$error_code] ?: 'loginfailed');
 
         $RCMAIL->output->show_message($error_message, 'warning');
 


### PR DESCRIPTION
Self-explanatory. With PHP 7+, you can use the null coalescing operator '??' to avoid an E_NOTICE error on an undefined value. But since roundcubemail wants to be compatible with PHP back to 5.5, you need to use an isset to avoid the E_NOTICE. These changes to index.php do this at the top level file only, around a failed user authentication.
