### PR TITLE
Fix less mixins to be compatible with lessc 3.x and 4.x

### DIFF
--- a/skins/elastic/styles/embed.less
+++ b/skins/elastic/styles/embed.less
@@ -29,7 +29,7 @@
 }
 
 .rcmail-inline-message {
-    .font-family;
+    .font-family();
     font-size: @page-font-size;
     padding: .5em;
     margin: 0 0 .5em 0;
@@ -40,7 +40,7 @@
     align-items: center;
 
     &:before {
-        .font-icon-class;
+        .font-icon-class();
         font-size: 1.5em;
         line-height: 1;
         width: 1em;

--- a/skins/elastic/styles/global.less
+++ b/skins/elastic/styles/global.less
@@ -69,7 +69,7 @@
 /* Reset some Bootstrap style */
 
 body, button, input, optgroup, select, textarea, .popover {
-    .font-family;
+    .font-family();
 }
 
 button, input, select, textarea {

--- a/skins/elastic/styles/layout.less
+++ b/skins/elastic/styles/layout.less
@@ -80,7 +80,7 @@ body {
             background-color: @color-layout-header-background;
 
             .header-title {
-                .overflow-ellipsis;
+                .overflow-ellipsis();
                 flex: 1;
                 text-align: center;
                 margin: 0 -20rem;

--- a/skins/elastic/styles/styles.less
+++ b/skins/elastic/styles/styles.less
@@ -276,7 +276,7 @@ body.task-error-login #layout {
     }
 
     blockquote {
-        .overflow-ellipsis;
+        .overflow-ellipsis();
         color: @color-blockquote-0;
         border-left: 2px solid @color-blockquote-0-border;
         border-right: 2px solid @color-blockquote-0-border;
@@ -309,7 +309,7 @@ body.task-error-login #layout {
             border: 1px solid @color-black-shade-border;
             border-radius: .3rem;
             line-height: 1;
-            .font-family; // don't inherit monospace font
+            .font-family(); // don't inherit monospace font
 
             &:after {
                 &:extend(.font-icon-class);
@@ -351,7 +351,7 @@ body.task-error-login #layout {
     color: @color-mail-headers;
 
     .header-title {
-        .overflow-ellipsis;
+        .overflow-ellipsis();
         white-space: nowrap;
         max-width: 8em;
         font-weight: bold;

--- a/skins/elastic/styles/widgets/common.less
+++ b/skins/elastic/styles/widgets/common.less
@@ -35,7 +35,7 @@ font.bold {
 
     div {
         line-height: 1.6em;
-        .overflow-ellipsis;
+        .overflow-ellipsis();
     }
 }
 
@@ -145,7 +145,7 @@ p.image-attachment {
     }
 
     .image-filename {
-        .overflow-ellipsis;
+        .overflow-ellipsis();
         left: 0;
         top: 0;
         right: 0;
@@ -397,7 +397,7 @@ fieldset.image-attachment {
     }
 
     .nav-link {
-        .overflow-ellipsis;
+        .overflow-ellipsis();
     }
 }
 
@@ -447,7 +447,7 @@ fieldset.image-attachment {
             vertical-align: middle;
 
             &:first-child {
-                .overflow-ellipsis;
+                .overflow-ellipsis();
                 text-align: left;
             }
         }

--- a/skins/elastic/styles/widgets/editor.less
+++ b/skins/elastic/styles/widgets/editor.less
@@ -51,7 +51,7 @@
         border: 0;
 
         & :not(.mce-ico) {
-            .font-family;
+            .font-family();
         }
     }
 
@@ -155,7 +155,7 @@
         }
 
         .mce-btn {
-            .btn-secondary;
+            .btn-secondary();
             border-radius: .3rem;
             border-color: transparent;
 
@@ -166,7 +166,7 @@
             }
 
             &.mce-primary {
-                .btn-primary;
+                .btn-primary();
             }
 
             button:hover,
@@ -674,7 +674,7 @@ div.mce-menubtn.mce-opened {
 
             .mce-text {
                 font-size: 1.2rem;
-                .font-family;
+                .font-family();
                 line-height: @layout-touch-menu-record-height;
                 color: @color-font;
             }
@@ -689,7 +689,7 @@ div.mce-menubtn.mce-opened {
                     position: relative;
 
                     &:after {
-                        .font-icon-class; // :extend() does not work here
+                        .font-icon-class(); // :extend() does not work here
                         content: @fa-var-check;
                         position: absolute;
                         right: .5rem;
@@ -703,7 +703,7 @@ div.mce-menubtn.mce-opened {
                 position: relative;
 
                 &:after {
-                    .font-icon-class; // :extend() does not work here
+                    .font-icon-class(); // :extend() does not work here
                     content: @fa-var-angle-right;
                     position: absolute;
                     right: .5rem;
@@ -775,7 +775,7 @@ html.touch .mce-grid td {
     }
 
     button {
-        .btn-secondary;
+        .btn-secondary();
         padding: .5rem .75rem;
         line-height: 1.5;
         position: relative;
@@ -813,7 +813,7 @@ html.touch .mce-grid td {
                 flex: 1;
                 margin: auto;
                 padding-left: 1rem;
-                .overflow-ellipsis;
+                .overflow-ellipsis();
             }
 
             span.img {

--- a/skins/elastic/styles/widgets/forms.less
+++ b/skins/elastic/styles/widgets/forms.less
@@ -175,7 +175,7 @@ input.smart-upload {
             flex-wrap: nowrap;
 
             & > *:first-child {
-                .overflow-ellipsis;
+                .overflow-ellipsis();
                 min-width: 8rem;
 
                 &:not(select) {
@@ -774,7 +774,7 @@ html.ms .propform {
         border: 1px solid @color-input-border;
 
         &.focused {
-            .style-input-focus;
+            .style-input-focus();
         }
 
         // TODO: style button focus
@@ -933,7 +933,7 @@ html.ms .propform {
     height: auto; // reset .form-control height
 
     &.focus {
-        .style-input-focus;
+        .style-input-focus();
     }
 
     .recipient {
@@ -956,7 +956,7 @@ html.ms .propform {
     }
 
     .name {
-        .overflow-ellipsis;
+        .overflow-ellipsis();
         flex-grow: 1;
         line-height: 1.1;
         padding: floor(.25 * @page-font-size);
@@ -1030,7 +1030,7 @@ html.ms .propform {
     }
 
     &[tabindex="-1"] {
-        .style-input-focus;
+        .style-input-focus();
     }
 
     li.tagedit-listelement-new {
@@ -1078,7 +1078,7 @@ html.ms .propform {
         }
 
         span {
-            .overflow-ellipsis;
+            .overflow-ellipsis();
             flex-grow: 1;
             display: inline-block;
             line-height: 1.4;
@@ -1377,7 +1377,7 @@ html.ms .propform {
 
     .custom-file-label {
         white-space: nowrap;
-        .overflow-ellipsis;
+        .overflow-ellipsis();
         padding-right: 100px;
         line-height: 1.5 !important;
     }

--- a/skins/elastic/styles/widgets/jqueryui.less
+++ b/skins/elastic/styles/widgets/jqueryui.less
@@ -108,7 +108,7 @@
 
             a.btn-link,
             button {
-                .overflow-ellipsis;
+                .overflow-ellipsis();
                 min-width: 5rem;
                 margin: floor(.65 * @page-font-size) floor(.3 * @page-font-size);
 

--- a/skins/elastic/styles/widgets/lists.less
+++ b/skins/elastic/styles/widgets/lists.less
@@ -29,7 +29,7 @@
     }
 
     tbody td {
-        .overflow-ellipsis;
+        .overflow-ellipsis();
         outline: none;
 
         a {
@@ -65,7 +65,7 @@
     }
 
     td.name {
-        .overflow-ellipsis;
+        .overflow-ellipsis();
     }
 
     td.action {
@@ -151,7 +151,7 @@ ul.listing {
     }
 
     li {
-        .overflow-ellipsis;
+        .overflow-ellipsis();
         white-space: nowrap;
         position: relative;
         list-style: none;
@@ -381,7 +381,7 @@ html.ie11 .listing.iconized li a:before {
     }
 
     td {
-        .overflow-ellipsis;
+        .overflow-ellipsis();
     }
 }
 
@@ -408,7 +408,7 @@ ul.treelist {
         }
 
         & > a {
-            .overflow-ellipsis;
+            .overflow-ellipsis();
             padding-left: @listing-treetoggle-width;
         }
 
@@ -587,7 +587,7 @@ table.fixedcopy {
             }
 
             &.fromto {
-                .overflow-ellipsis;
+                .overflow-ellipsis();
                 flex: 1;
                 font-size: 90%;
                 color: @color-list-secondary;
@@ -596,7 +596,7 @@ table.fixedcopy {
             }
 
             &.subject {
-                .overflow-ellipsis;
+                .overflow-ellipsis();
                 width: 100%;
             }
         }
@@ -963,7 +963,7 @@ html.touch {
         }
 
         &.uploading:before {
-            .animated-icon-class;
+            .animated-icon-class();
             .font-icon-solid(@fa-var-circle-notch);
         }
 
@@ -974,7 +974,7 @@ html.touch {
         }
 
         .attachment-name {
-            .overflow-ellipsis;
+            .overflow-ellipsis();
             color: @color-font;
         }
 

--- a/skins/elastic/styles/widgets/menu.less
+++ b/skins/elastic/styles/widgets/menu.less
@@ -17,7 +17,7 @@
     white-space: nowrap;
 
     a {
-        .overflow-ellipsis;
+        .overflow-ellipsis();
         text-decoration: none;
 
         &:before {
@@ -141,7 +141,7 @@
         }
 
         .pagenav-text {
-            .overflow-ellipsis;
+            .overflow-ellipsis();
             color: @color-list-pagenav;
             flex-grow: 4;
             font-size: 80%;
@@ -297,7 +297,7 @@
                     }
 
                     & > span {
-                        .overflow-ellipsis;
+                        .overflow-ellipsis();
                         flex: 1;
                     }
                 }
@@ -312,7 +312,7 @@
             display: flex;
 
             a:first-child {
-                .overflow-ellipsis;
+                .overflow-ellipsis();
                 flex: 1;
             }
 

--- a/skins/elastic/styles/widgets/messages.less
+++ b/skins/elastic/styles/widgets/messages.less
@@ -54,7 +54,7 @@
 
         & > i.icon:before {
             content: @fa-var-circle-notch;
-            .animated-icon-class;
+            .animated-icon-class();
             width: 1em;
         }
     }
@@ -96,7 +96,7 @@
         white-space: nowrap;
 
         .btn {
-            .overflow-ellipsis;
+            .overflow-ellipsis();
             max-width: 220px;
         }
 


### PR DESCRIPTION
Hello, 

The only purpose of this PR is to provide the correct syntax of the Elastic style less files. So they are compatible with the lessc 3.x and 4.x. (Fix for #7813).

Test:
Resulting CSS files were generated
- from the unchanged release-1.4 using the less@3.13.1
- from the fixed release-1.4 using the less@3.13.1
- from the fixed release-1.4 using the less@4.0.0

*All three sets of output files are identical.*

# Commands for output generation
## less@4.0.0
```
lessc -m=always styles/styles.less >styles.css-v4
lessc styles/embed.less > embed.css-v4
lessc styles/print.less > print.css-v4
```

## less@3.13.1
```
lessc styles/styles.less >styles.css-v3
lessc styles/embed.less > embed.css-v3
lessc styles/print.less > print.css-v3
```


