### PR TITLE
ensure rcmail_output object exists

### DIFF
--- a/plugins/newmail_notifier/newmail_notifier.php
+++ b/plugins/newmail_notifier/newmail_notifier.php
@@ -50,7 +50,7 @@ class newmail_notifier extends rcube_plugin
         }
         else { // if ($this->rc->task == 'mail') {
             // add script when not in ajax and not in frame and only in main window
-            if ($this->rc->output->type == 'html' && empty($_REQUEST['_framed']) && $this->rc->action == '') {
+            if ((is_object($this->rc->output) && $this->rc->output->type == 'html') && empty($_REQUEST['_framed']) && $this->rc->action == '') {
                 $this->add_texts('localization/');
                 $this->rc->output->add_label('newmail_notifier.title', 'newmail_notifier.body');
                 $this->include_script('newmail_notifier.js');


### PR DESCRIPTION
From reading the code I think the newmail_notifier plugin has a similar issue to https://github.com/johndoh/roundcube-contextmenu/issues/126. patch to fix.