### PR TITLE
IMAP "semi-asynchronous" backwards search in batches

### DIFF
--- a/program/actions/mail/search.php
+++ b/program/actions/mail/search.php
@@ -132,6 +132,9 @@ class rcmail_action_mail_search extends rcmail_action_mail_index
         
 
         if ($search_str) {
+            if (!empty($range)) {
+                $rcmail->storage->search_disable_sort();
+            }
             $_SESSION['search'] = $rcmail->storage->get_search_set();
             $_SESSION['last_text_search'] = $str;
         }
@@ -179,7 +182,7 @@ class rcmail_action_mail_search extends rcmail_action_mail_index
         else if (!empty($result) && !empty($result->incomplete)) {
             $rcmail->output->command('continue_search', $search_request);
         }
-        else if (empty($range) || $last_batch && ($count == 0 || $range[0] == 0)) {
+        else if (empty($range) || isset($last_batch) && ($count == 0 || $range[0] == 0)) {
             $rcmail->output->show_message('searchnomatch', 'notice');
             $rcmail->output->set_env('multifolder_listing', isset($result) ? !empty($result->multi) : false);
             

--- a/program/actions/mail/search.php
+++ b/program/actions/mail/search.php
@@ -181,8 +181,9 @@ class rcmail_action_mail_search extends rcmail_action_mail_index
         }
         else if (empty($range) || $last_batch && ($count == 0 || $range[0] == 0)) {
             $rcmail->output->show_message('searchnomatch', 'notice');
-            $rcmail->output->set_env('multifolder_listing', (bool)$result->multi);
-            if ($result->multi && $scope == 'all') {
+            $rcmail->output->set_env('multifolder_listing', isset($result) ? !empty($result->multi) : false);
+            
+            if (isset($result) && !empty($result->multi) && $scope == 'all') {
                 $rcmail->output->command('select_folder', '');
             }
         } else if (isset($last_batch)) {

--- a/program/actions/mail/search.php
+++ b/program/actions/mail/search.php
@@ -46,12 +46,21 @@ class rcmail_action_mail_search extends rcmail_action_mail_index
         $scope    = rcube_utils::get_input_value('_scope', rcube_utils::INPUT_GET);
         $interval = rcube_utils::get_input_value('_interval', rcube_utils::INPUT_GET);
         $continue = rcube_utils::get_input_value('_continue', rcube_utils::INPUT_GET);
+        $range    = rcube_utils::get_input_value('_range', rcube_utils::INPUT_GET);
 
         $filter         = trim($filter);
         $search_request = md5($mbox . $scope . $interval . $filter . $str);
 
         // Parse input
         list($subject, $search) = self::search_input($str, $headers, $scope, $mbox);
+        
+        if (!empty($range)) {
+            $range = explode("-", $range, 2);
+            $range[0] = (int) $range[0];
+            $range[1] = (int) $range[1];
+        } else {
+            $range = null;
+        }
 
         // add list filter string
         $search_str = $filter && $filter != 'ALL' ? $filter : '';
@@ -68,6 +77,7 @@ class rcmail_action_mail_search extends rcmail_action_mail_index
         }
 
         $search_str  = trim($search_str);
+        $sort_column = empty($range) ? self::sort_column() : 'ARRIVAL';
         $sort_column = self::sort_column();
         $sort_order  = self::sort_order();
 
@@ -76,8 +86,10 @@ class rcmail_action_mail_search extends rcmail_action_mail_index
             $rcmail->storage->set_search_set($_SESSION['search']);
             $search_str = $_SESSION['search'][0];
         }
-
+        
+        
         // execute IMAP search
+        $curr_count = 0;
         if ($search_str) {
             $mboxes = [];
 
@@ -99,13 +111,25 @@ class rcmail_action_mail_search extends rcmail_action_mail_index
                 $rcmail->output->set_env('mailbox', $mbox);
             }
 
-            $result = $rcmail->storage->search($mboxes, $search_str, RCUBE_CHARSET, $sort_column);
+            $result = $rcmail->storage->search($mboxes, $search_str, RCUBE_CHARSET, $sort_column, $range);
+            $curr_count = $rcmail->storage->count($mbox, $rcmail->storage->get_threading() ? 'THREADS' : 'ALL');
+            
+            if (!empty($range) && !$result) {
+                $rcmail->output->set_env('last_batch', 1);
+                $last_batch = 1;
+            }
+        }
+        
+        $batch_continue = !empty($range) && $range[0] != 0;
+        if ($batch_continue && isset($_SESSION['search'])) {
+            $rcmail->storage->prepend_search_set($_SESSION['search']);
         }
 
         // save search results in session
         if (!isset($_SESSION['search']) || !is_array($_SESSION['search'])) {
             $_SESSION['search'] = [];
         }
+        
 
         if ($search_str) {
             $_SESSION['search'] = $rcmail->storage->get_search_set();
@@ -116,20 +140,25 @@ class rcmail_action_mail_search extends rcmail_action_mail_index
         $_SESSION['search_scope']    = $scope;
         $_SESSION['search_interval'] = $interval;
         $_SESSION['search_filter']   = $filter;
+        
+        $count = $rcmail->storage->count($mbox, $rcmail->storage->get_threading() ? 'THREADS' : 'ALL');
+        $all_count = $rcmail->storage->count(null, 'ALL');
 
         // Get the headers
         if (!isset($result) || empty($result->incomplete)) {
-            $result_h = $rcmail->storage->list_messages($mbox, 1, $sort_column, $sort_order);
+            $result_h = $rcmail->storage->list_messages($mbox, 1, $sort_column, $sort_order, 0, $count-$curr_count);
+        }
+        
+        if (!empty($range) && !$count == 0 && ($count>$curr_count || $range[0] == 0)) {
+            // replace existing message
+            $rcmail->output->show_message('searchsuccessful', 'confirmation', ['nr' => $all_count], true, 0, true);
         }
 
         // Make sure we got the headers
         if (!empty($result_h)) {
-            $count = $rcmail->storage->count($mbox, $rcmail->storage->get_threading() ? 'THREADS' : 'ALL');
-
             self::js_message_list($result_h, false);
 
-            if ($search_str) {
-                $all_count = $rcmail->storage->count(null, 'ALL');
+            if ($search_str && empty($range)) {
                 $rcmail->output->show_message('searchsuccessful', 'confirmation', ['nr' => $all_count]);
             }
 
@@ -144,24 +173,22 @@ class rcmail_action_mail_search extends rcmail_action_mail_index
         }
         // handle IMAP errors (e.g. #1486905)
         else if ($err_code = $rcmail->storage->get_error_code()) {
-            $count = 0;
             self::display_server_error();
         }
         // advice the client to re-send the (cross-folder) search request
         else if (!empty($result) && !empty($result->incomplete)) {
-            $count = 0;  // keep UI locked
             $rcmail->output->command('continue_search', $search_request);
         }
-        else {
-            $count = 0;
-
+        else if (empty($range) || $last_batch && ($count == 0 || $range[0] == 0)) {
             $rcmail->output->show_message('searchnomatch', 'notice');
-            $rcmail->output->set_env('multifolder_listing', isset($result) ? !empty($result->multi) : false);
-
-            if (isset($result) && !empty($result->multi) && $scope == 'all') {
+            $rcmail->output->set_env('multifolder_listing', (bool)$result->multi);
+            if ($result->multi && $scope == 'all') {
                 $rcmail->output->command('select_folder', '');
             }
+        } else if (isset($last_batch)) {
+            $rcmail->output->show_message('searchfinished', 'notice');
         }
+
 
         // update message count display
         $rcmail->output->set_env('search_request', $search_str ? $search_request : '');

--- a/program/include/rcmail_output_cli.php
+++ b/program/include/rcmail_output_cli.php
@@ -58,7 +58,7 @@ class rcmail_output_cli extends rcmail_output
      *
      * @see rcube_output::show_message()
      */
-    function show_message($message, $type = 'notice', $vars = null, $override = true, $timeout = 0)
+    function show_message($message, $type = 'notice', $vars = null, $override = true, $timeout = 0, $update = false)
     {
         if ($this->app->text_exists($message)) {
             $message = $this->app->gettext(['name' => $message, 'vars' => $vars]);

--- a/program/include/rcmail_output_html.php
+++ b/program/include/rcmail_output_html.php
@@ -523,10 +523,11 @@ EOF;
      * @param array   $vars     Key-value pairs to be replaced in localized text
      * @param bool    $override Override last set message
      * @param int     $timeout  Message display time in seconds
+     * @param bool    $update   Replace an existing message of the same type
      *
      * @uses self::command()
      */
-    public function show_message($message, $type = 'notice', $vars = null, $override = true, $timeout = 0)
+    public function show_message($message, $type = 'notice', $vars = null, $override = true, $timeout = 0, $update = false)
     {
         if ($override || !$this->message) {
             if ($this->app->text_exists($message)) {

--- a/program/include/rcmail_output_json.php
+++ b/program/include/rcmail_output_json.php
@@ -132,10 +132,11 @@ class rcmail_output_json extends rcmail_output
      * @param array  $vars     Key-value pairs to be replaced in localized text
      * @param bool   $override Override last set message
      * @param int    $timeout  Message displaying time in seconds
+     * @param bool   $update   Replace an existing message of the same type
      *
      * @uses self::command()
      */
-    public function show_message($message, $type = 'notice', $vars = null, $override = true, $timeout = 0)
+    public function show_message($message, $type = 'notice', $vars = null, $override = true, $timeout = 0, $update = false)
     {
         if ($override || !$this->message) {
             if ($this->app->text_exists($message)) {
@@ -149,7 +150,10 @@ class rcmail_output_json extends rcmail_output
             }
 
             $this->message = $message;
-            $this->command('display_message', $msgtext, $type, $timeout * 1000);
+            if ($update)
+                $this->command('replace_message', $msgtext, $type, $timeout * 1000);
+            else
+                $this->command('display_message', $msgtext, $type, $timeout * 1000);
         }
     }
 

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -70,7 +70,8 @@ function rcube_webmail()
     recipients_delimiter: ', ', // @deprecated
     popup_width: 1150,
     popup_width_small: 900,
-    thread_padding: '15px'
+    thread_padding: '15px',
+    qsearch: null
   };
 
   // create protected reference to myself
@@ -1346,28 +1347,43 @@ function rcube_webmail()
 
       // quicksearch
       case 'search':
-        return this.qsearch(props);
+        var batch_number = null;
+        if ($("[name='s_backwards']").is(":checked"))
+          batch_number = 1 ;
+          
+        if (this.message_list)
+          this.clear_message_list();
+        else if (this.contact_list)
+          this.list_contacts_clear();
+        
+        return this.qsearch(props, batch_number);
 
       // reset quicksearch
       case 'reset-search':
         var n, s = this.env.search_request || this.env.qsearch;
 
-        this.reset_qsearch(true);
-
-        if (s && this.env.action == 'compose') {
-          if (this.contact_list)
-            this.list_contacts_clear();
-        }
-        else if (s && this.env.mailbox) {
-          this.list_mailbox(this.env.mailbox, 1);
-        }
-        else if (s && this.task == 'addressbook') {
-          if (this.env.source == '') {
-            for (n in this.env.address_sources) break;
-            this.env.source = n;
-            this.env.group = '';
+        // only clear screen in case of non-batched search
+        if (!this.env.qsearch.batch_number) {
+          this.reset_qsearch(true);
+          
+          if (s && this.env.action == 'compose') {
+            if (this.contact_list)
+              this.list_contacts_clear();
           }
-          this.list_contacts(this.env.source, this.env.group, 1);
+          else if (s && this.env.mailbox) {
+            this.list_mailbox(this.env.mailbox, 1);
+          }
+          else if (s && this.task == 'addressbook') {
+            if (this.env.source == '') {
+              for (n in this.env.address_sources) break;
+              this.env.source = n;
+              this.env.group = '';
+            }
+            this.list_contacts(this.env.source, this.env.group, 1);
+          }
+        } else {
+          this.abort_request(this.env.qsearch);
+          this.env.qsearch = null;
         }
         break;
 
@@ -5601,20 +5617,17 @@ function rcube_webmail()
   };
 
   // send remote request to search mail or contacts
-  this.qsearch = function(value)
+  // if batch_number>0, this is #batch_number in a sequence of search requests
+  this.qsearch = function(value, batch_number = null)
   {
     // Note: Some plugins would like to do search without value,
     // so we keep value != '' check to allow that use-case. Which means
     // e.g. that qsearch() with no argument will execute the search.
     if (value != '' || $(this.gui_objects.qsearchbox).val() || $(this.gui_objects.search_interval).val()) {
       var r, lock = this.set_busy(true, 'searching'),
-        url = this.search_params(value),
+        url = this.search_params(value, null, batch_number),
         action = this.env.action == 'compose' && this.contact_list ? 'search-contacts' : 'search';
 
-      if (this.message_list)
-        this.clear_message_list();
-      else if (this.contact_list)
-        this.list_contacts_clear();
 
       if (this.env.source)
         url._source = this.env.source;
@@ -5624,9 +5637,9 @@ function rcube_webmail()
       // reset vars
       this.env.current_page = 1;
 
-      r = this.http_request(action, url, lock);
+      //r = this.http_request(action, url, lock);
 
-      this.env.qsearch = {lock: lock, request: r};
+      this.env.qsearch = {lock: lock, request: r, props: value, batch_number: batch_number};
       this.enable_command('set-listmode', this.env.threads && (this.env.search_scope || 'base') == 'base');
 
       return true;
@@ -5647,7 +5660,7 @@ function rcube_webmail()
   };
 
   // build URL params for search
-  this.search_params = function(search, filter)
+  this.search_params = function(search, filter, batch_number = null)
   {
     var n, url = {}, mods_arr = [],
       mods = this.env.search_mods,
@@ -5674,6 +5687,15 @@ function rcube_webmail()
           mods_arr.push(n);
         url._headers = mods_arr.join(',');
       }
+    }
+    
+    if (batch_number) {
+      var amount = 5000;
+      if (mods['text'] || mods['body'])
+        amount = 500;
+      first = (batch_number-1) * amount;
+      last = batch_number * amount - 1;
+      url._range = first + '-' + last;
     }
 
     url._layout = this.env.layout;
@@ -9297,7 +9319,14 @@ function rcube_webmail()
 
       case 'getunread':
       case 'search':
-        this.env.qsearch = null;
+        if (this.env.qsearch) {
+          if (!this.env.qsearch.batch_number || response.env.last_batch == 1) {
+            this.env.qsearch = null;
+          } else {
+            batch_number = this.env.qsearch.batch_number + 1;
+            this.qsearch(this.env.qsearch.props, batch_number);
+          }
+        }
       case 'list':
         if (this.task == 'mail') {
           var is_multifolder = this.is_multifolder_listing(),

--- a/program/lib/Roundcube/rcube_imap.php
+++ b/program/lib/Roundcube/rcube_imap.php
@@ -337,6 +337,7 @@ class rcube_imap extends rcube_storage
      *                   2 - searching character set, string
      *                   3 - sorting field, string
      *                   4 - true if sorted, bool
+     *                   5 - true disables sorting
      */
     public function set_search_set($set)
     {
@@ -351,6 +352,12 @@ class rcube_imap extends rcube_storage
 
         if (is_a($this->search_set, 'rcube_result_multifolder')) {
             $this->set_threading(false);
+        } else if (is_a($this->search_set, 'rcube_result_thread')) {
+            $this->set_threading(true);
+        }
+        
+        if (isset($set[5]) && $set[5] === true) {
+            $this->search_disable_sort();
         }
     }
     
@@ -392,6 +399,7 @@ class rcube_imap extends rcube_storage
             $this->search_charset,
             $this->search_sort_field,
             $this->search_sorted,
+            $this->disable_sort
         ];
     }
 
@@ -1619,7 +1627,7 @@ class rcube_imap extends rcube_storage
      */
     protected function sort_threads($threads)
     {
-        if ($threads->is_empty()) {
+        if ($threads->is_empty() || $this->disable_sort) {
             return;
         }
 

--- a/program/lib/Roundcube/rcube_imap.php
+++ b/program/lib/Roundcube/rcube_imap.php
@@ -353,6 +353,27 @@ class rcube_imap extends rcube_storage
             $this->set_threading(false);
         }
     }
+    
+    /**
+     * Save a search result, but prepend to the existing results
+     * 
+     * @param array $set Search set, result from rcube_imap::get_search_set():
+     *                   0 - searching criteria, string
+     *                   1 - search result, rcube_result_index|rcube_result_thread
+     *                   2 - searching character set, string
+     *                   3 - sorting field, string
+     *                   4 - true if sorted, bool
+     */
+    public function prepend_search_set($set)
+    {
+        $set = (array) $set;
+        if (empty($set[1]))
+            return;
+        if (!empty($this->search_set)) {
+            $this->search_set->prepend_index($set[1]);
+        } else
+            $this->set_search_set($set);
+    }
 
     /**
      * Return the saved search set as hash array
@@ -850,16 +871,17 @@ class rcube_imap extends rcube_storage
      * @param string $sort_field Header field to sort by
      * @param string $sort_order Sort order [ASC|DESC]
      * @param int    $slice      Number of slice items to extract from result array
+     * @param int    $offset     Omit items until offset
      *
      * @return array Indexed array with message header objects
      */
-    public function list_messages($folder = '', $page = null, $sort_field = null, $sort_order = null, $slice = 0)
+    public function list_messages($folder = '', $page = null, $sort_field = null, $sort_order = null, $slice = 0, $offset = 0)
     {
         if (!strlen($folder)) {
             $folder = $this->folder;
         }
 
-        return $this->_list_messages($folder, $page, $sort_field, $sort_order, $slice);
+        return $this->_list_messages($folder, $page, $sort_field, $sort_order, $slice, $offset);
     }
 
     /**
@@ -870,11 +892,12 @@ class rcube_imap extends rcube_storage
      * @param   string   $sort_field Header field to sort by
      * @param   string   $sort_order Sort order [ASC|DESC]
      * @param   int      $slice      Number of slice items to extract from result array
+     * @param   int      $offset     Omit items until offset
      *
      * @return array Indexed array with message header objects
      * @see rcube_imap::list_messages
      */
-    protected function _list_messages($folder = '', $page = null, $sort_field = null, $sort_order = null, $slice = 0)
+    protected function _list_messages($folder = '', $page = null, $sort_field = null, $sort_order = null, $slice = 0, $offset = 0)
     {
         if (!strlen($folder)) {
             return [];
@@ -885,11 +908,11 @@ class rcube_imap extends rcube_storage
 
         // use saved message set
         if ($this->search_string) {
-            return $this->list_search_messages($folder, $page, $slice);
+            return $this->list_search_messages($folder, $page, $slice, $offset);
         }
 
         if ($this->threading) {
-            return $this->list_thread_messages($folder, $page, $slice);
+            return $this->list_thread_messages($folder, $page, $slice, $offset);
         }
 
         // get UIDs of all messages in the folder, sorted
@@ -899,15 +922,22 @@ class rcube_imap extends rcube_storage
             return [];
         }
 
-        $from = ($page-1) * $this->page_size;
-        $to   = $from + $this->page_size;
+        $from = max($offset, ($page-1) * $this->page_size);
+        $to   = ($page-1) * $this->page_size + $this->page_size;
+        $length = $to - $from;
+        if ($length < 1)
+            return array();
 
-        $index->slice($from, $to - $from);
+        $index->slice($from, $length);
 
         if ($slice) {
             $index->slice(-$slice, $slice);
         }
 
+        if ($offset) {
+            $index->slice($offset, null);
+        }
+        
         // fetch reqested messages headers
         $a_index = $index->get();
         $a_msg_headers = $this->fetch_headers($folder, $a_index);
@@ -921,11 +951,12 @@ class rcube_imap extends rcube_storage
      * @param string $folder Folder name
      * @param int    $page   Current page to list
      * @param int    $slice  Number of slice items to extract from result array
+     * @param int    $offset Omit threads until offset
      *
      * @return array Indexed array with message header objects
      * @see rcube_imap::list_messages
      */
-    protected function list_thread_messages($folder, $page, $slice = 0)
+    protected function list_thread_messages($folder, $page, $slice = 0, $offset = 0)
     {
         // get all threads (not sorted)
         if ($mcache = $this->get_mcache_engine()) {
@@ -935,7 +966,7 @@ class rcube_imap extends rcube_storage
             $threads = $this->threads($folder);
         }
 
-        return $this->fetch_thread_headers($folder, $threads, $page, $slice);
+        return $this->fetch_thread_headers($folder, $threads, $page, $slice, $offset);
     }
 
     /**
@@ -990,18 +1021,22 @@ class rcube_imap extends rcube_storage
      * @param rcube_result_thread $threads    Threads data object
      * @param int                 $page       List page number
      * @param int                 $slice      Number of threads to slice
+     * @param int                 $offset     Omit threads until offset
      *
      * @return array Messages headers
      */
-    protected function fetch_thread_headers($folder, $threads, $page, $slice = 0)
+    protected function fetch_thread_headers($folder, $threads, $page, $slice = 0, $offset = 0)
     {
         // Sort thread structure
         $this->sort_threads($threads);
 
-        $from = ($page-1) * $this->page_size;
-        $to   = $from + $this->page_size;
+        $from = max($offset, ($page-1) * $this->page_size);
+        $to   = ($page-1) * $this->page_size + $this->page_size;
+        $length = $to - $from;
+        if ($length < 1)
+            return array();
 
-        $threads->slice($from, $to - $from);
+        $threads->slice($from, $length);
 
         if ($slice) {
             $threads->slice(-$slice, $slice);
@@ -1065,16 +1100,21 @@ class rcube_imap extends rcube_storage
      * @param string $folder Folder name
      * @param int    $page   Current page to list
      * @param int    $slice  Number of slice items to extract from the result array
+     * @param int    $offset Omit items until offset
      *
      * @return array Indexed array with message header objects
      */
-    protected function list_search_messages($folder, $page, $slice = 0)
+    protected function list_search_messages($folder, $page, $slice = 0, $offset = 0)
     {
         if (!strlen($folder) || empty($this->search_set) || $this->search_set->is_empty()) {
             return [];
         }
 
-        $from = ($page-1) * $this->page_size;
+        $from = max($offset, ($page-1) * $this->page_size);
+        $to   = ($page-1) * $this->page_size + $this->page_size;
+        $length = $to-$from;
+        if ($length < 1)
+            return [];
 
         // gather messages from a multi-folder search
         if (!empty($this->search_set->multi)) {
@@ -1109,7 +1149,7 @@ class rcube_imap extends rcube_storage
                 $search_set->set_message_index($a_msg_headers, $sort_field, $this->sort_order);
 
                 // only return the requested part of the set
-                $a_msg_headers = array_slice(array_values($a_msg_headers), $from, $page_size);
+                $a_msg_headers = array_slice(array_values($a_msg_headers), $from, $length);
             }
             else {
                 if ($this->sort_order != $search_set->get_parameters('ORDER')) {
@@ -1117,7 +1157,7 @@ class rcube_imap extends rcube_storage
                 }
 
                 // slice resultset first...
-                $index = array_slice($search_set->get(), $from, $page_size);
+                $index = array_slice($search_set->get(), $from, $length);
                 $fetch = [];
 
                 foreach ($index as $msg_id) {
@@ -1151,7 +1191,7 @@ class rcube_imap extends rcube_storage
 
         // use saved messages from searching
         if ($this->threading) {
-            return $this->list_search_thread_messages($folder, $page, $slice);
+            return $this->list_search_thread_messages($folder, $page, $slice, $offset);
         }
 
         // search set is threaded, we need a new one
@@ -1167,7 +1207,7 @@ class rcube_imap extends rcube_storage
         }
 
         // quickest method (default sorting)
-        if (!$this->search_sort_field && !$this->sort_field) {
+        if ((!$this->search_sort_field && !$this->sort_field) || $this->disable_sort) {
             $got_index = true;
         }
         // sorted messages, so we can first slice array and then fetch only wanted headers
@@ -1187,12 +1227,12 @@ class rcube_imap extends rcube_storage
         }
 
         if (!empty($got_index)) {
-            if ($this->sort_order != $index->get_parameters('ORDER')) {
+            if (!$this->disable_sort && $this->sort_order != $index->get_parameters('ORDER')) {
                 $index->revert();
             }
 
             // get messages uids for one page
-            $index->slice($from, $this->page_size);
+            $index->slice($from, $length);
 
             if ($slice) {
                 $index->slice(-$slice, $slice);
@@ -1213,7 +1253,7 @@ class rcube_imap extends rcube_storage
             // use memory less expensive (and quick) method for big result set
             $index = clone $this->index('', $this->sort_field, $this->sort_order);
             // get messages uids for one page...
-            $index->slice($from, $this->page_size);
+            $index->slice($from, $length);
 
             if ($slice) {
                 $index->slice(-$slice, $slice);
@@ -1239,7 +1279,7 @@ class rcube_imap extends rcube_storage
             $a_msg_headers = rcube_imap_generic::sortHeaders(
                 $a_msg_headers, $this->sort_field, $this->sort_order);
 
-            $a_msg_headers = array_slice(array_values($a_msg_headers), $from, $this->page_size);
+            $a_msg_headers = array_slice(array_values($a_msg_headers), $from, $length);
 
             if ($slice) {
                 $a_msg_headers = array_slice($a_msg_headers, -$slice, $slice);
@@ -1259,7 +1299,7 @@ class rcube_imap extends rcube_storage
      * @return array Indexed array with message header objects
      * @see rcube_imap::list_search_messages()
      */
-    protected function list_search_thread_messages($folder, $page, $slice = 0)
+    protected function list_search_thread_messages($folder, $page, $slice = 0, $offset = 0)
     {
         // update search_set if previous data was fetched with disabled threading
         if (!$this->search_threads) {
@@ -1269,7 +1309,7 @@ class rcube_imap extends rcube_storage
             $this->search('', $this->search_string, $this->search_charset, $this->sort_field);
         }
 
-        return $this->fetch_thread_headers($folder, clone $this->search_set, $page, $slice);
+        return $this->fetch_thread_headers($folder, clone $this->search_set, $page, $slice, $offset);
     }
 
     /**
@@ -1599,6 +1639,35 @@ class rcube_imap extends rcube_storage
             $threads->revert();
         }
     }
+    
+    /**
+     * Create IMAP seq-range for mailbox by inverting input range
+     * 
+     * @param  string  $folder     Folder name to get range for
+     * @param  array   $range      Input range. 0 = newest item in folder
+     * 
+     * @return string              IMAP message sequence range
+     */
+     public function seq_range($folder, $range)
+     {
+         if ($msg_count = $this->countmessages($folder, $no_search = true)) {
+             $first = max(0, $msg_count - $range[1]);
+             $last = max(0, $msg_count - $range[0]);
+             $imap_range = $first . ":" . "$last";
+             return $imap_range . " ";
+         } else {
+             return false;
+         }
+     }
+    
+    /**
+     * Prevent search results from being sorted
+     */
+    public function search_disable_sort()
+    {
+        $this->search_sorted = true;
+        $this->disable_sort = true;
+    }
 
     /**
      * Invoke search request to IMAP server
@@ -1607,11 +1676,12 @@ class rcube_imap extends rcube_storage
      * @param  string  $search     Search criteria
      * @param  string  $charset    Search charset
      * @param  string  $sort_field Header field to sort by
+     * @param  array   $range      Range of messages to consider. 0 = newest item in folder 
      *
      * @return rcube_result_index  Search result object
      * @todo: Search criteria should be provided in non-IMAP format, eg. array
      */
-    public function search($folder = '', $search = 'ALL', $charset = null, $sort_field = null)
+    public function search($folder = '', $search = 'ALL', $charset = null, $sort_field = null, $range = null)
     {
         if (!$search) {
             $search = 'ALL';
@@ -1660,16 +1730,27 @@ class rcube_imap extends rcube_storage
                 $search,
                 $charset ? $charset : $this->default_charset,
                 $sort_field && $this->get_capability('SORT') ? $sort_field : null,
-                $this->threading
+                $this->threading,
+                
             );
         }
         else if (!$results) {
             $folder  = is_array($folder) ? $folder[0] : $folder;
             $search  = is_array($search) ? $search[$folder] : $search;
+            if (!empty($range)) {
+                $seq_range = $this->seq_range($folder, $range);
+                $search = $seq_range . $search;
+                if ($seq_range == '0:0 ') {
+                    return false; // hack to inform caller that no more search batches are needed
+                }
+            }
             $results = $this->search_index($folder, $search, $charset, $sort_field);
         }
 
         $sorted = $this->threading || $this->search_sorted || !empty($plugin['search_sorted']);
+
+        if ($sorted && $results->get_parameters('ORDER') != $this->sort_order)
+            $results->revert();
 
         $this->set_search_set([$search, $results, $charset, $sort_field, $sorted]);
 

--- a/program/lib/Roundcube/rcube_imap_search.php
+++ b/program/lib/Roundcube/rcube_imap_search.php
@@ -50,8 +50,9 @@ class rcube_imap_search
      * @param  string  $charset    Search charset
      * @param  string  $sort_field Header field to sort by
      * @param  bool    $threading  True if threaded listing is active
+     * @param  array   $range      Range of messages to consider. 0 = newest item in folder 
      */
-    public function exec($folders, $str, $charset = null, $sort_field = null, $threading = null)
+    public function exec($folders, $str, $charset = null, $sort_field = null, $threading = null, $range = null)
     {
         $start   = floor(microtime(true));
         $results = new rcube_result_multifolder($folders);

--- a/program/lib/Roundcube/rcube_output.php
+++ b/program/lib/Roundcube/rcube_output.php
@@ -118,8 +118,9 @@ abstract class rcube_output
      * @param array   $vars     Key-value pairs to be replaced in localized text
      * @param bool    $override Override last set message
      * @param int     $timeout  Message displaying time in seconds
+     * @param bool    $update   Replace an existing message of the same type
      */
-    abstract function show_message($message, $type = 'notice', $vars = null, $override = true, $timeout = 0);
+    abstract function show_message($message, $type = 'notice', $vars = null, $override = true, $timeout = 0, $update = false);
 
     /**
      * Redirect to a certain url.

--- a/program/lib/Roundcube/rcube_result_index.php
+++ b/program/lib/Roundcube/rcube_result_index.php
@@ -239,6 +239,31 @@ class rcube_result_index
         $this->meta['count'] = count($data);
         $this->raw_data      = implode(self::SEPARATOR_ELEMENT, $data);
     }
+    
+    /**
+     * Prepend result index to self
+     * 
+     * @param rcube_result_index Result index to append
+     */
+    public function prepend_index($append_index)
+    {
+        $append_data = implode(self::SEPARATOR_ELEMENT, $append_index->get());
+
+        if (empty($append_data))
+            return;  
+        
+        if ($this->meta['count'] === null)
+            $this->count();
+        $old_count = $this->meta['count'];
+        $this->meta = [];
+
+        if (empty($this->raw_data))
+            $this->raw_data = $append_data;
+        else
+            $this->raw_data = $append_data . self::SEPARATOR_ELEMENT . $this->raw_data;
+
+        $this->meta['count'] = $old_count + $append_index->count();
+    }
 
     /**
      * Reverts order of elements in the result

--- a/program/lib/Roundcube/rcube_result_thread.php
+++ b/program/lib/Roundcube/rcube_result_thread.php
@@ -29,7 +29,7 @@ class rcube_result_thread
 {
     public $incomplete = false;
 
-    protected $raw_data;
+    public $raw_data;
     protected $mailbox;
     protected $meta  = [];
     protected $order = 'ASC';
@@ -245,7 +245,7 @@ class rcube_result_thread
      */
     public function prepend_index($append_index)
     {
-        $append_data = implode(self::SEPARATOR_ELEMENT, $append_index->get());
+        $append_data = $append_index->raw_data;
 
         if (empty($append_data))
             return;  

--- a/program/lib/Roundcube/rcube_result_thread.php
+++ b/program/lib/Roundcube/rcube_result_thread.php
@@ -237,6 +237,36 @@ class rcube_result_thread
 
         $this->raw_data = ltrim($result, self::SEPARATOR_ELEMENT);
     }
+    
+    /**
+     * Prepend result index to self
+     * 
+     * @param rcube_result_index Result index to append
+     */
+    public function prepend_index($append_index)
+    {
+        $append_data = implode(self::SEPARATOR_ELEMENT, $append_index->get());
+
+        if (empty($append_data))
+            return;  
+        
+        if ($this->meta['count'] === null)
+            $this->count();
+        if ($this->meta['messages'] === null)
+            $this->count_messages();
+        
+        $old_count = $this->meta['count'];
+        $old_message_count = $this->meta['messages'];
+        $this->meta = [];
+
+        if (empty($this->raw_data))
+            $this->raw_data = $append_data;
+        else
+            $this->raw_data = $append_data . self::SEPARATOR_ELEMENT . $this->raw_data;
+
+        $this->meta['count'] = $old_count + $append_index->count();
+        $this->meta['messages'] = $old_message_count + $append_index->count_messages();
+    }
 
     /**
      * Reverts order of elements in the result

--- a/program/lib/Roundcube/rcube_storage.php
+++ b/program/lib/Roundcube/rcube_storage.php
@@ -387,10 +387,11 @@ abstract class rcube_storage
      * @param  string  $str        Search criteria
      * @param  string  $charset    Search charset
      * @param  string  $sort_field Header field to sort by
+     * @param  array   $range      Range of messages to consider. 0 = newest item in folder
      *
      * @todo: Search criteria should be provided in non-IMAP format, eg. array
      */
-    abstract function search($folder = null, $str = 'ALL', $charset = null, $sort_field = null);
+    abstract function search($folder = null, $str = 'ALL', $charset = null, $sort_field = null, $range = null);
 
     /**
      * Direct (real and simple) search request (without result sorting and caching).

--- a/program/localization/en_US/labels.inc
+++ b/program/localization/en_US/labels.inc
@@ -259,6 +259,7 @@ $labels['searchinterval-1Y'] = 'older than a year';
 $labels['searchinterval1W'] = 'younger than a week';
 $labels['searchinterval1M'] = 'younger than a month';
 $labels['searchinterval1Y'] = 'younger than a year';
+$labels['searchbackwards'] = 'Search backwards';
 
 $labels['openinextwin'] = 'Open in new window';
 $labels['emlsave'] = 'Download (.eml)';

--- a/program/localization/en_US/messages.inc
+++ b/program/localization/en_US/messages.inc
@@ -112,6 +112,7 @@ $messages['notuploadedwarning'] = 'Not all attachments have been uploaded yet. P
 $messages['searchsuccessful'] = '$nr messages found.';
 $messages['contactsearchsuccessful'] = '$nr contacts found.';
 $messages['searchnomatch'] = 'Search returned no matches.';
+$messages['searchfinished'] = 'Finished searching.';
 $messages['searching'] = 'Searching...';
 $messages['checking'] = 'Checking...';
 $messages['stillsearching'] = 'Still searching...';

--- a/skins/elastic/templates/mail.html
+++ b/skins/elastic/templates/mail.html
@@ -80,6 +80,9 @@
 					<option value="all"><roundcube:label name="allfolders" /></option>
 				</select>
 			</div>
+			<ul class="proplist">
+				<li><label><input type="checkbox" name="s_backwards" value="backwards" /><roundcube:label name="searchbackwards" /></label></li>
+			</ul>
 		</div>
 		<div class="formbuttons">
 			<button type="button" class="btn btn-primary icon search" onclick="return rcmail.command('search')"><roundcube:label name="search" /></button>


### PR DESCRIPTION
IMAP searches can take a very long time if you have a large inbox. In my inbox it is common that the HTTP timeout occurs before the search has finished. This feature is intended to resolve this problem and would greatly enhance user experience, in my opinion.

If you turn on "backwards" search, the IMAP search command will use an RFC 3501 message sequence range to search the _n_ most recent messages in the folder. Once the web client receives a reply, it will send a search request for the next _n_ emails in the folder. I have hardcoded _n_ to 500 for body and full text searches and 5000 for other searches.

**Open issues:**
1. Everything is sorted DESC according to the internal IMAP server arrival date and the user cannot change this. This should still be made clear in the UI.
2. There is no implementation for multi folder search yet. Perhaps this should be disabled and made clear in the UI.
3. ~~Backwards search with threads listing is still buggy. The threads implementation looks complicated and I have run out of time to study it.~~
4. The feature is only available with the Elastic skin.
5. The length _n_ of the sequence range is set client-side, which is a bit awkward. It should probably be a server-side configuration parameter instead.
6. Maybe it should also be implemented for contacts search.