### PR TITLE
Add hook to modify the hint in the upload form

### DIFF
--- a/program/include/rcmail_action.php
+++ b/program/include/rcmail_action.php
@@ -505,6 +505,9 @@ abstract class rcmail_action
 
         $hint = html::div('hint', $rcmail->gettext(['name' => 'maxuploadsize', 'vars' => ['size' => $max_filesize]]));
 
+        $plugin = $rcmail->plugins->exec_hook('modify_hint', ['hint' => $hint]);
+        $hint = $plugin['hint'];
+
         if (!empty($attrib['mode']) && $attrib['mode'] == 'hint') {
             return $hint;
         }


### PR DESCRIPTION
I find this hook useful to add a more detailed description in case of attachment manipulation (i.e. replacing attachment with a download link) or company's restrictions on attachments.
Would you mind adding it?
Thank you anyway