### PR TITLE
retry login if IMAP Servers timeout.

### DIFF
--- a/plugins/reconnect/composer.json
+++ b/plugins/reconnect/composer.json
@@ -1,0 +1,13 @@
+{
+    "name": "reconnect",
+    "type": "roundcube-plugin",
+    "description": "Reconnects to server for several attempts.",
+    "license": "GPLv3+",
+    "version": "0.1",
+    "authors": [
+        {
+            "name": "Sandro Knauß",
+            "email": "hefee@debian.org"
+        }
+    ]
+}

--- a/plugins/reconnect/config.inc.php.dist
+++ b/plugins/reconnect/config.inc.php.dist
@@ -1,0 +1,4 @@
+<?php
+
+// Maximum attempts to connect the IMAP server
+$config['reconnect_imap_max_attempts'] = 5;

--- a/plugins/reconnect/readme.md
+++ b/plugins/reconnect/readme.md
@@ -1,0 +1,13 @@
+# RoundCube Reconnect Plugin
+
+RoundCube reconnect Plugin is a small plugin that will try to reconnect to an
+IMAP server, if there is no explicit error code replied. If there is a know
+failure like wrong password, no additional attempts are triggered. This should
+help in cases, when the connection to the IMAP server is not 100% stable.
+
+## Configuration
+
+You can specify the maximum attempts to connect the IMAP server.
+
+  // Maximum attempts to connect the IMAP server
+  $config['reconnect_imap_max_attempts'] = 5;

--- a/plugins/reconnect/reconnect.php
+++ b/plugins/reconnect/reconnect.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * RoundCube Reconnect Plugin
+ *
+ * @version 0.1
+ * @author Sandro Knauß <hefee@debian.org>
+ * @license GPLv3+
+ */
+class reconnect extends rcube_plugin
+{
+    private $max_attempts;
+
+    function init()
+    {
+        $rcmail = rcmail::get_instance();
+
+        $this->load_config();
+
+        $this->imap_max_attempts = $rcmail->config->get('reconnect_imap_max_attempts', 5);
+
+        $this->add_hook('storage_connect', array($this, 'storage_connect'));
+    }
+
+    function storage_connect($args)
+    {
+        $args['retry'] = ($args['attempt'] <= $this->imap_max_attempts);
+
+        if ($args['attempt'] == 1) {
+            return $args;
+        }
+
+        $storage = rcmail::get_instance()->get_storage();
+        switch ($storage->get_error_code()) {
+        case rcube_imap_generic::ERROR_NO:
+        case rcube_imap_generic::ERROR_BAD:
+        case rcube_imap_generic::ERROR_BYE:
+            $args['retry'] = false;
+            break;
+        }
+
+        if ($args['retry']) {
+            // if we do a new attempt, sleep 50 to 150ms before retry.
+            usleep(rand(50*1000, 150*1000));
+        }
+
+        return $args;
+    }
+
+}
+
+?>

--- a/program/lib/Roundcube/rcube_imap.php
+++ b/program/lib/Roundcube/rcube_imap.php
@@ -157,6 +157,10 @@ class rcube_imap extends rcube_storage
 
             $data = $this->plugins->exec_hook('storage_connect', array_merge($this->options, $data));
 
+            if ($attempt > 1 && !$data['retry']) {
+                $break;
+            }
+
             if (!empty($data['pass'])) {
                 $pass = $data['pass'];
             }


### PR DESCRIPTION
When connection fails in a recoverable way, we should retry to connect
to the server again. This should help in cases, when the connection to the IMAP server is not 100% stable.

In #7402 it was suggested to implement this retry feature as plugin. In order to create such a plugin, it needs the information about the last login attempt. The last attempt is added to the `data['conn']`.

We also face the issue, that we only call `storage_connect` before the try to connect. That's why we need a way to stop instantly when no new attempt should be done.

(followup of #7402, #5393)