### PR TITLE
Check that PHP supports the encoding

### DIFF
--- a/program/lib/Roundcube/rcube_charset.php
+++ b/program/lib/Roundcube/rcube_charset.php
@@ -257,6 +257,12 @@ class rcube_charset
             }
         }
 
+        // check that PHP supports the encoding
+        $mb_list_encodings_lower = array_map('strtolower', mb_list_encodings());
+        if (! in_array(strtolower($result), $mb_list_encodings_lower)) {
+            $result = null;
+        }
+
         $charsets[$input] = $result;
 
         return $result;

--- a/tests/Framework/Charset.php
+++ b/tests/Framework/Charset.php
@@ -46,7 +46,7 @@ class Framework_Charset extends PHPUnit\Framework\TestCase
     {
         return [
             ['UTF8', 'UTF-8'],
-            ['WIN1250', 'WINDOWS-1250'],
+            ['WIN1252', 'WINDOWS-1252'],
         ];
     }
 


### PR DESCRIPTION
In parse_charset, check that PHP supports the encoding before returning it for use.

Fixes #7850