### PR TITLE
Try handle body part with body.peek when binary.peek cause an error on imap server (dovecot)

### DIFF
--- a/program/lib/Roundcube/rcube_imap.php
+++ b/program/lib/Roundcube/rcube_imap.php
@@ -2413,6 +2413,17 @@ class rcube_imap extends rcube_storage
             $formatted = $formatted && $o_part->ctype_primary == 'text';
             $body = $this->conn->handlePartBody($this->folder, $uid, true,
                 $part ? $part : 'TEXT', $o_part->encoding, $print, $fp, $formatted, $max_bytes);
+            if (!$body && $this->conn->errornum === rcube_imap_generic::ERROR_FETCH_BINARY) {
+                $this->connect(
+                    $this->options['host'],
+                    $this->options['user'],
+                    $this->options['password'],
+                    $this->options['port'],
+                    $this->options['ssl']
+                );
+                $body = $this->conn->handlePartBody($this->folder, $uid, true,
+                    $part ? $part : 'TEXT', $o_part->encoding, $print, $fp, $formatted, $max_bytes, false);
+            }
         }
 
         if ($fp || $print) {


### PR DESCRIPTION
**RC Version:** 1.4.10
**Dovecot Version:** 2.3.11.3
**Capability:** [CAPABILITY IMAP4rev1 SASL-IR LOGIN-REFERRALS ID ENABLE IDLE SORT SORT=DISPLAY THREAD=REFERENCES THREAD=REFS THREAD=ORDEREDSUBJECT MULTIAPPEND URL-PARTIAL CATENATE UNSELECT CHILDREN NAMESPACE UIDPLUS LIST-EXTENDED I18NLEVEL=1 CONDSTORE QRESYNC ESEARCH ESORT SEARCHRES WITHIN CONTEXT=SEARCH LIST-STATUS BINARY MOVE SNIPPET=FUZZY PREVIEW=FUZZY STATUS=SIZE SAVEDATE LITERAL+ NOTIFY SPECIAL-USE QUOTA]

Message examples: https://skybox.skymail.net.br/s/N5NLnZoeM9boaJm (Protected by password, please send a message to me to get it) 

These messages are being successfully read in Gmail, Thunderbird and Outlook.
