### PR TITLE
add preauth_ident parameter

### DIFF
--- a/program/lib/Roundcube/rcube_imap_generic.php
+++ b/program/lib/Roundcube/rcube_imap_generic.php
@@ -936,6 +936,11 @@ class rcube_imap_generic
             return false;
         }
 
+        // Send pre authentication ID info (#7860)
+        if (!empty($this->prefs['preauth_ident']) && $this->getCapability('ID')) {
+            $this->data['ID'] = $this->id($this->prefs['preauth_ident']);
+        }
+
         $auth_method  = $this->prefs['auth_type'];
         $auth_methods = [];
         $result       = null;
@@ -997,7 +1002,7 @@ class rcube_imap_generic
 
             $this->logged = true;
 
-            // Send ID info
+            // Send ID info after authentication to ensure reliable result (#7517)
             if (!empty($this->prefs['ident']) && $this->getCapability('ID')) {
                 $this->data['ID'] = $this->id($this->prefs['ident']);
             }


### PR DESCRIPTION
ref #7860

I went with "set of separate ID parameters to use for an additional ID command call" because I think that is the most flexible. Also it covers a case (which can at least theoretically exist) where you want to send an ID command pre auth but the response can change after auth as in #7517.

As far as I can tell from RFC 2971 sending the ID command twice is fine as long as you do not send the same field more than once but plugins can prevent that by unsetting the `ident` parameter (after moving the contents to `preauth_ident`).
