### PR TITLE
fix typo in rcube::gettext()

### DIFF
--- a/program/lib/Roundcube/rcube.php
+++ b/program/lib/Roundcube/rcube.php
@@ -586,7 +586,7 @@ class rcube
         if (isset($attrib[$slang])) {
             $this->texts[$name] = $attrib[$slang];
         }
-        if ($slang != 'en_us' && isset($attrib['en_us'])) {
+        else if ($slang != 'en_us' && isset($attrib['en_us'])) {
             $this->texts[$name] = $attrib['en_us'];
         }
 


### PR DESCRIPTION
There is a missing `else` in one of the if statements in rcube::gettext() which causes it to always return the `en_us` text when passing in the values through the `$attrib` param. The issue does not exist in 1.4.