### PR TITLE
SMTP: Add support for sending XCLIENT LOGIN

### DIFF
--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -292,6 +292,9 @@ $config['smtp_auth_cid'] = null;
 // Optional SMTP authentication password to be used for smtp_auth_cid
 $config['smtp_auth_pw'] = null;
 
+//Send Xclient LOGIN information where SMTP AUTH is disabled
+$config['smtp_xclient_login'] = null;
+
 // SMTP HELO host
 // Hostname to give to the remote server for SMTP 'HELO' or 'EHLO' messages
 // Leave this blank and you will get the server variable 'server_name' or

--- a/program/lib/Roundcube/rcube_smtp.php
+++ b/program/lib/Roundcube/rcube_smtp.php
@@ -164,6 +164,12 @@ class rcube_smtp
             $this->conn->setTimeout($timeout);
         }
 
+        $exts = $this->conn->getServiceExtensions();
+        if (isset($exts['XCLIENT']) && $rcube->config->get('smtp_xclient_login')==1) {
+            $this->conn->command("XCLIENT LOGIN=".$rcube->get_user_name(),array(220));
+            }
+
+
         $smtp_user = str_replace('%u', $rcube->get_user_name(), $CONFIG['smtp_user']);
         $smtp_pass = str_replace('%p', $rcube->get_user_password(), $CONFIG['smtp_pass']);
         $smtp_auth_type = $CONFIG['smtp_auth_type'] ?: null;


### PR DESCRIPTION
PR created from issue: https://github.com/roundcube/roundcubemail/issues/6411

It will send XCLIENT LOGIN=webmailuser@domain.com when configured.
In some situation there is no possibility use  smtp_user and smtp_pass,
but we want to process outgoing message as authenticated.