### PR TITLE
Add support for XCLIENT ADDR and LOGIN extension

### DIFF
--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -292,6 +292,13 @@ $config['smtp_auth_cid'] = null;
 // Optional SMTP authentication password to be used for smtp_auth_cid
 $config['smtp_auth_pw'] = null;
 
+//Send XCLIENT LOGIN information where SMTP AUTH is disabled
+$config['smtp_xclient_login'] = null;
+
+//Use Remote IP instead of web server IP
+$config['smtp_xclient_addr'] = null;
+
+
 // SMTP HELO host
 // Hostname to give to the remote server for SMTP 'HELO' or 'EHLO' messages
 // Leave this blank and you will get the server variable 'server_name' or

--- a/program/lib/Roundcube/rcube_smtp.php
+++ b/program/lib/Roundcube/rcube_smtp.php
@@ -164,6 +164,14 @@ class rcube_smtp
             $this->conn->setTimeout($timeout);
         }
 
+        if (!$this->_process_xclient()) {
+            list($code,) = $this->conn->getResponse();
+            $this->error = ['label' => 'smtpconnerror', 'vars' => ['code' => $code]];
+            $this->conn  = null;
+
+            return false;
+        }
+
         $smtp_user = str_replace('%u', $rcube->get_user_name(), $CONFIG['smtp_user']);
         $smtp_pass = str_replace('%p', $rcube->get_user_password(), $CONFIG['smtp_pass']);
         $smtp_auth_type = $CONFIG['smtp_auth_type'] ?: null;
@@ -529,5 +537,40 @@ class rcube_smtp
         }
 
         return $addresses;
+    }
+
+    private function _process_xclient() {
+
+        $rcube = rcube::get_instance();
+
+        if (!is_object($this->conn)) {
+            return false;
+            }
+
+        $exts = $this->conn->getServiceExtensions();
+
+        if (!isset($exts['XCLIENT'])) {
+            return true;
+            }
+
+        $opts=explode(" ",$exts['XCLIENT']);
+        $cmd="";
+        if ($rcube->config->get('smtp_xclient_login') && in_array_nocase("login",$opts)) {
+            $cmd.=" LOGIN=".$rcube->get_user_name(); 
+            }
+        if ($rcube->config->get('smtp_xclient_addr') && in_array_nocase("addr",$opts)) {
+            $ip=rcube_utils::remote_addr();
+            if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
+                $r=$ip;
+            } elseif (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
+                $r="IPV6:".$ip;
+            } else {
+                $r="[UNAVAILABLE]";
+            }
+            $cmd.=" ADDR=".$r;
+            }
+        if ($cmd!="") { $this->conn->command("XCLIENT".$cmd,array(220)); }
+        
+        return true;
     }
 }


### PR DESCRIPTION
PR created from issue: #6411

PR Checks if XCLIENT extension is active.

Roundcube will send XCLIENT ADDR=x.y.z.z when configured and XCLIENT ADDR extension is available
In special configuration we want smtp server to use originating IP for policy checking instead of IP from web server.

Roundcube will send XCLIENT LOGIN=webmailuser@domain.com when configured and XCLIENT LOGIN extension is available
In some situation (f.e. SSO) there is no possibility use smtp_user and smtp_pass, but we want to process outgoing message as authenticated.