### PR TITLE
Add config options for subject prefixes

### DIFF
--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -803,6 +803,20 @@ $config['assets_dir'] = '';
 // ]
 $config['http_client'] = [];
 
+// List of supported subject prefixes for a message reply
+// This list is used to clean the subject when replying or sorting messages
+$config['subject_reply_prefixes'] = ['Re:'];
+
+// List of supported subject prefixes for a message forward
+// This list is used to clean the subject when forwarding or sorting messages
+$config['subject_forward_prefixes'] = ['Fwd:', 'Fw:'];
+
+// Prefix to use in subject when replying to a message
+$config['response_prefix'] = 'Re:';
+
+// Prefix to use in subject when forwarding a message
+$config['forward_prefix'] = 'Fwd:';
+
 // ----------------------------------
 // PLUGINS
 // ----------------------------------

--- a/program/include/rcmail_sendmail.php
+++ b/program/include/rcmail_sendmail.php
@@ -1193,7 +1193,12 @@ class rcmail_sendmail
         $subject = trim($subject);
 
         // replace Re:, Re[x]:, Re-x (#1490497)
-        $prefix = '/^(re:|re\[\d\]:|re-\d:)\s*/i';
+        $response_prefixes = rcmail::get_instance()->config->get('subject_response_prefixes', ['Re:']);
+        $data = array_map(function($prefix) { 
+            $prefix = strtolower(str_replace(':', '', $prefix)); 
+            return $prefix.':|'.$prefix.'\[\d\]:|'.$prefix.'-\d:'; 
+        }, $response_prefixes);
+        $prefix = '/^('.implode('|', $data).')\s*/i';
         do {
             $subject = preg_replace($prefix, '', $subject, -1, $count);
         }
@@ -1202,7 +1207,7 @@ class rcmail_sendmail
         // replace (was: ...) (#1489375)
         $subject = preg_replace('/\s*\([wW]as:[^\)]+\)\s*$/', '', $subject);
 
-        return 'Re: ' . $subject;
+        return rcmail::get_instance()->config->get('default_response_prefix', 'Re:') . ' ' . $subject;
     }
 
     /**
@@ -1236,11 +1241,12 @@ class rcmail_sendmail
         }
         // create a forward-subject
         else if ($this->data['mode'] == self::MODE_FORWARD) {
-            if (preg_match('/^fwd:/i', $this->options['message']->subject)) {
+            $forward_prefixes = rcmail::get_instance()->config->get('subject_forward_prefixes', ['Fwd:', 'Fw:']);
+            if (preg_match('/^('.implode('|', $forward_prefixes).')/i', $this->options['message']->subject)) {
                 $subject = $this->options['message']->subject;
             }
             else {
-                $subject = 'Fwd: ' . $this->options['message']->subject;
+                $subject = $this->rcmail->config->get('default_forward_prefix', 'Fwd:') . ' ' . $this->options['message']->subject;
             }
         }
         // creeate a draft-subject

--- a/program/include/rcmail_sendmail.php
+++ b/program/include/rcmail_sendmail.php
@@ -1194,9 +1194,6 @@ class rcmail_sendmail
 
         //  Add config options for subject prefixes (#7929) 
         $subject = rcube_utils::remove_subject_prefix($subject, 'reply');
-
-        // replace (was: ...) (#1489375)
-        $subject = preg_replace('/\s*\([wW]as:[^\)]+\)\s*$/', '', $subject);
         $subject = rcmail::get_instance()->config->get('response_prefix', 'Re:') . ' ' . $subject;
 
         return trim($subject);

--- a/program/lib/Roundcube/rcube_imap_generic.php
+++ b/program/lib/Roundcube/rcube_imap_generic.php
@@ -2742,7 +2742,10 @@ class rcube_imap_generic
                     $value = str_replace('"', '', $value);
 
                     if ($field == 'subject') {
-                        $value = preg_replace('/^(Re:\s*|Fwd:\s*|Tr:\s*|Fw:\s*)+/i', '', $value);
+                        $forward_prefixes = rcmail::get_instance()->config->get('subject_forward_prefixes', ['Fwd:', 'Fw:']);
+                        $response_prefixes = rcmail::get_instance()->config->get('subject_response_prefixes', ['Re:']);
+                        $data = array_map(function($prefix) { return $prefix . '\s*'; }, array_merge($forward_prefixes, $response_prefixes));
+                        $value = preg_replace('/^('.implode('|', $data).')+/i', '', $value);
                     }
                 }
             }

--- a/program/lib/Roundcube/rcube_imap_generic.php
+++ b/program/lib/Roundcube/rcube_imap_generic.php
@@ -2742,10 +2742,7 @@ class rcube_imap_generic
                     $value = str_replace('"', '', $value);
 
                     if ($field == 'subject') {
-                        $forward_prefixes = rcmail::get_instance()->config->get('subject_forward_prefixes', ['Fwd:', 'Fw:']);
-                        $response_prefixes = rcmail::get_instance()->config->get('subject_response_prefixes', ['Re:']);
-                        $data = array_map(function($prefix) { return $prefix . '\s*'; }, array_merge($forward_prefixes, $response_prefixes));
-                        $value = preg_replace('/^('.implode('|', $data).')+/i', '', $value);
+                        $value = rcube_utils::remove_subject_prefix($value);
                     }
                 }
             }

--- a/program/lib/Roundcube/rcube_imap_generic.php
+++ b/program/lib/Roundcube/rcube_imap_generic.php
@@ -2742,7 +2742,7 @@ class rcube_imap_generic
                     $value = str_replace('"', '', $value);
 
                     if ($field == 'subject') {
-                        $value = preg_replace('/^(Re:\s*|Fwd:\s*|Fw:\s*)+/i', '', $value);
+                        $value = preg_replace('/^(Re:\s*|Fwd:\s*|Tr:\s*|Fw:\s*)+/i', '', $value);
                     }
                 }
             }

--- a/program/lib/Roundcube/rcube_utils.php
+++ b/program/lib/Roundcube/rcube_utils.php
@@ -1580,4 +1580,41 @@ class rcube_utils
 
         return $temp_path;
     }
+
+    /**
+     * Clean the subject from reply and forward prefix
+     * 
+     * @param string $subject Subject to clean
+     * @param string $mode Mode of cleaning : reply, forward or both
+     * 
+     * @return string Cleaned subject
+     */
+    public static function remove_subject_prefix($subject, $mode = 'both')
+    {
+        // Clean subject prefix for reply, forward or both
+        if ($mode == 'both') {
+            $reply_prefixes = rcmail::get_instance()->config->get('subject_reply_prefixes', ['Re:']);
+            $forward_prefixes = rcmail::get_instance()->config->get('subject_forward_prefixes', ['Fwd:', 'Fw:']);
+            $prefixes = array_merge($reply_prefixes, $forward_prefixes);
+        }
+        else if ($mode == 'reply') {
+            $prefixes = rcmail::get_instance()->config->get('subject_reply_prefixes', ['Re:']);
+        }
+        else if ($mode == 'forward') {
+            $prefixes = rcmail::get_instance()->config->get('subject_forward_prefixes', ['Fwd:', 'Fw:']);
+        }
+
+        // replace Re:, Re[x]:, Re-x (#1490497)
+        $pieces = array_map(function($prefix) {
+            $prefix = strtolower(str_replace(':', '', $prefix)); 
+            return $prefix.':|'.$prefix.'\[\d\]:|'.$prefix.'-\d:'; 
+        }, $prefixes);
+        $pattern = '/^('.implode('|', $pieces).')\s*/i';
+        do {
+            $subject = preg_replace($pattern, '', $subject, -1, $count);
+        }
+        while ($count);
+
+        return trim($subject);
+    }
 }

--- a/program/lib/Roundcube/rcube_utils.php
+++ b/program/lib/Roundcube/rcube_utils.php
@@ -1591,23 +1591,27 @@ class rcube_utils
      */
     public static function remove_subject_prefix($subject, $mode = 'both')
     {
+        $config = rcmail::get_instance()->config;
+
         // Clean subject prefix for reply, forward or both
         if ($mode == 'both') {
-            $reply_prefixes = rcmail::get_instance()->config->get('subject_reply_prefixes', ['Re:']);
-            $forward_prefixes = rcmail::get_instance()->config->get('subject_forward_prefixes', ['Fwd:', 'Fw:']);
+            $reply_prefixes = $config->get('subject_reply_prefixes', ['Re:']);
+            $forward_prefixes = $config->get('subject_forward_prefixes', ['Fwd:', 'Fw:']);
             $prefixes = array_merge($reply_prefixes, $forward_prefixes);
         }
         else if ($mode == 'reply') {
-            $prefixes = rcmail::get_instance()->config->get('subject_reply_prefixes', ['Re:']);
+            $prefixes = $config->get('subject_reply_prefixes', ['Re:']);
+            // replace (was: ...) (#1489375)
+            $subject = preg_replace('/\s*\([wW]as:[^\)]+\)\s*$/', '', $subject);
         }
         else if ($mode == 'forward') {
-            $prefixes = rcmail::get_instance()->config->get('subject_forward_prefixes', ['Fwd:', 'Fw:']);
+            $prefixes = $config->get('subject_forward_prefixes', ['Fwd:', 'Fw:']);
         }
 
         // replace Re:, Re[x]:, Re-x (#1490497)
         $pieces = array_map(function($prefix) {
-            $prefix = strtolower(str_replace(':', '', $prefix)); 
-            return $prefix.':|'.$prefix.'\[\d\]:|'.$prefix.'-\d:'; 
+            $prefix = strtolower(str_replace(':', '', $prefix));
+            return "$prefix:|$prefix\[\d\]:|$prefix-\d:";
         }, $prefixes);
         $pattern = '/^('.implode('|', $pieces).')\s*/i';
         do {

--- a/tests/Framework/Utils.php
+++ b/tests/Framework/Utils.php
@@ -779,4 +779,29 @@ class Framework_Utils extends PHPUnit\Framework\TestCase
     {
         $this->assertEquals(rcube_utils::parse_host($name, $host), $result);
     }
+
+    /**
+     * Test-Cases for test_remove_subject_prefix()
+     */
+    function data_remove_subject_prefix() {
+        return [
+            ['both',    'Fwd: Re: Test subject both', 'Test subject both'],
+            ['both',    'Re: Fwd: Test subject both', 'Test subject both'],
+            ['reply',   'Fwd: Re: Test subject reply', 'Fwd: Re: Test subject reply'],
+            ['reply',   'Re: Fwd: Test subject reply', 'Fwd: Test subject reply'],
+            ['reply',   'Re: Fwd: Test subject reply (was: other test)', 'Fwd: Test subject reply'],
+            ['forward', 'Re: Fwd: Test subject forward', 'Re: Fwd: Test subject forward'],
+            ['forward', 'Fwd: Re: Test subject forward', 'Re: Test subject forward'],
+            ['forward', 'Fw: Re: Test subject forward', 'Re: Test subject forward'],
+        ];
+    }
+
+    /**
+     * Test remove_subject_prefix
+     * 
+     * @dataProvider data_remove_subject_prefix
+     */
+    function test_remove_subject_prefix($mode, $subject, $result) {
+        $this->assertEquals(rcube_utils::remove_subject_prefix($subject, $mode), $result);
+    }
 }


### PR DESCRIPTION
Some french mail clients use "Tr:" instead of "Fwd:" as forward indicator in subject. 
I don't know if there is such exceptions in others languages in which case this maybe worth the use of a configuration parameter instead of an hardcoded regex ?

