### PR TITLE
Support class and realname props for a folder

### DIFF
--- a/program/include/rcmail_action.php
+++ b/program/include/rcmail_action.php
@@ -1216,15 +1216,16 @@ abstract class rcmail_action
         $out = '';
         foreach ($arrFolders as $folder) {
             $title        = null;
-            $folder_class = self::folder_classname($folder['id']);
+            $folder_class = self::folder_classname($folder['id'], $folder['class'] ?: null);
             $is_collapsed = strpos($collapsed, '&'.rawurlencode($folder['id']).'&') !== false;
             $unread       = 0;
+            $realname     = $realnames || $folder['realname'] ?: false;
 
             if ($msgcounts && !empty($msgcounts[$folder['id']]['UNSEEN'])) {
                 $unread = intval($msgcounts[$folder['id']]['UNSEEN']);
             }
 
-            if ($folder_class && !$realnames && $rcmail->text_exists($folder_class)) {
+            if ($folder_class && !$realname && $rcmail->text_exists($folder_class)) {
                 $foldername = $rcmail->gettext($folder_class);
             }
             else {
@@ -1325,7 +1326,7 @@ abstract class rcmail_action
                 }
             }
 
-            if (!$realnames && ($folder_class = self::folder_classname($folder['id'])) && $rcmail->text_exists($folder_class)) {
+            if (!$realnames && ($folder_class = self::folder_classname($folder['id'], $folder['class'] ?: null)) && $rcmail->text_exists($folder_class)) {
                 $foldername = $rcmail->gettext($folder_class);
             }
             else {
@@ -1353,10 +1354,11 @@ abstract class rcmail_action
      * (including shared/other users namespace roots).
      *
      * @param string $folder_id IMAP Folder name
+     * @param string $folder_class failback folder CSS class name
      *
      * @return string|null CSS class name
      */
-    public static function folder_classname($folder_id)
+    public static function folder_classname($folder_id, $folder_class = null)
     {
         static $classes;
 
@@ -1385,7 +1387,7 @@ abstract class rcmail_action
             }
         }
 
-        return !empty($classes[$folder_id]) ? $classes[$folder_id] : null;
+        return !empty($classes[$folder_id]) ? $classes[$folder_id] : $folder_class;
     }
 
     /**

--- a/program/include/rcmail_action.php
+++ b/program/include/rcmail_action.php
@@ -1225,7 +1225,7 @@ abstract class rcmail_action
                 $unread = intval($msgcounts[$folder['id']]['UNSEEN']);
             }
 
-            if (isset($folder_class) && !$realname && $rcmail->text_exists($folder_class)) {
+            if ($folder_class && !$realname && $rcmail->text_exists($folder_class)) {
                 $foldername = $rcmail->gettext($folder_class);
             }
             else {
@@ -1329,7 +1329,7 @@ abstract class rcmail_action
             $folder_class = self::folder_classname($folder['id'], isset($folder['class']) ? $folder['class'] : null);
             $realname     = isset($folder['realname']) ? $folder['realname'] : $realnames;
 
-            if (isset($folder_class) && !$realname && $rcmail->text_exists($folder_class)) {
+            if ($folder_class && !$realname && $rcmail->text_exists($folder_class)) {
                 $foldername = $rcmail->gettext($folder_class);
             }
             else {

--- a/program/include/rcmail_action.php
+++ b/program/include/rcmail_action.php
@@ -1216,10 +1216,10 @@ abstract class rcmail_action
         $out = '';
         foreach ($arrFolders as $folder) {
             $title        = null;
-            $folder_class = self::folder_classname($folder['id'], $folder['class'] ?: null);
+            $folder_class = self::folder_classname($folder['id'], isset($folder['class']) ? $folder['class'] : null);
             $is_collapsed = strpos($collapsed, '&'.rawurlencode($folder['id']).'&') !== false;
             $unread       = 0;
-            $realname     = $realnames || $folder['realname'] ?: false;
+            $realname     = $realnames || isset($folder['realname']) ? $folder['realname'] : false;
 
             if ($msgcounts && !empty($msgcounts[$folder['id']]['UNSEEN'])) {
                 $unread = intval($msgcounts[$folder['id']]['UNSEEN']);
@@ -1326,7 +1326,7 @@ abstract class rcmail_action
                 }
             }
 
-            if (!$realnames && ($folder_class = self::folder_classname($folder['id'], $folder['class'] ?: null)) && $rcmail->text_exists($folder_class)) {
+            if (!$realnames && ($folder_class = self::folder_classname($folder['id'], isset($folder['class']) ? $folder['class'] : null)) && $rcmail->text_exists($folder_class)) {
                 $foldername = $rcmail->gettext($folder_class);
             }
             else {
@@ -1354,11 +1354,11 @@ abstract class rcmail_action
      * (including shared/other users namespace roots).
      *
      * @param string $folder_id IMAP Folder name
-     * @param string $folder_class failback folder CSS class name
+     * @param string $fallback fallback Folder CSS class name
      *
      * @return string|null CSS class name
      */
-    public static function folder_classname($folder_id, $folder_class = null)
+    public static function folder_classname($folder_id, $fallback = null)
     {
         static $classes;
 
@@ -1387,7 +1387,7 @@ abstract class rcmail_action
             }
         }
 
-        return !empty($classes[$folder_id]) ? $classes[$folder_id] : $folder_class;
+        return !empty($classes[$folder_id]) ? $classes[$folder_id] : $fallback;
     }
 
     /**

--- a/program/include/rcmail_action.php
+++ b/program/include/rcmail_action.php
@@ -1219,13 +1219,13 @@ abstract class rcmail_action
             $folder_class = self::folder_classname($folder['id'], isset($folder['class']) ? $folder['class'] : null);
             $is_collapsed = strpos($collapsed, '&'.rawurlencode($folder['id']).'&') !== false;
             $unread       = 0;
-            $realname     = $realnames || isset($folder['realname']) ? $folder['realname'] : false;
+            $realname     = isset($folder['realname']) ? $folder['realname'] : $realnames;
 
             if ($msgcounts && !empty($msgcounts[$folder['id']]['UNSEEN'])) {
                 $unread = intval($msgcounts[$folder['id']]['UNSEEN']);
             }
 
-            if ($folder_class && !$realname && $rcmail->text_exists($folder_class)) {
+            if (isset($folder_class) && !$realname && $rcmail->text_exists($folder_class)) {
                 $foldername = $rcmail->gettext($folder_class);
             }
             else {
@@ -1326,7 +1326,10 @@ abstract class rcmail_action
                 }
             }
 
-            if (!$realnames && ($folder_class = self::folder_classname($folder['id'], isset($folder['class']) ? $folder['class'] : null)) && $rcmail->text_exists($folder_class)) {
+            $folder_class = self::folder_classname($folder['id'], isset($folder['class']) ? $folder['class'] : null);
+            $realname     = isset($folder['realname']) ? $folder['realname'] : $realnames;
+
+            if (isset($folder_class) && !$realname && $rcmail->text_exists($folder_class)) {
                 $foldername = $rcmail->gettext($folder_class);
             }
             else {
@@ -1354,7 +1357,7 @@ abstract class rcmail_action
      * (including shared/other users namespace roots).
      *
      * @param string $folder_id IMAP Folder name
-     * @param string $fallback fallback Folder CSS class name
+     * @param string $fallback  Fallback Folder CSS class name
      *
      * @return string|null CSS class name
      */


### PR DESCRIPTION
Hooks like `render_mailboxlist` allow a plugin to customize the folder tree but are limited for the folder css class and the folder display name. 

With this PR a plugin can add a `class` prop and a `realname` boolean prop to customize the CSS class of the folder and the display name.