### PR TITLE
Fix warning in http_authentication.php

### DIFF
--- a/plugins/http_authentication/http_authentication.php
+++ b/plugins/http_authentication/http_authentication.php
@@ -90,7 +90,7 @@ class http_authentication extends rcube_plugin
         }
     }
 
-    function shutdown()
+    static function shutdown()
     {
         // There's no need to store password (even if encrypted) in session
         // We'll set it back on startup (#1486553)


### PR DESCRIPTION
Hello ! This is a one line PR

Declare the shutdown function static because it is and to suppress the warnings
For example: 
[14-Mar-2021 20:05:16 Europe/Zurich] PHP Deprecated:  Non-static method http_authentication::shutdown() should not be called statically in /path/to/roundcubemail/program/lib/Roundcube/rcube.php on line 1016