### PR TITLE
Fix phpdoc for rcube::decrypt()

### DIFF
--- a/program/lib/Roundcube/rcube.php
+++ b/program/lib/Roundcube/rcube.php
@@ -924,9 +924,9 @@ class rcube
      *
      * @param string $cipher Encrypted text
      * @param string $key    Encryption key to retrieve from the configuration, defaults to 'des_key'
-     * @param boo    $base64 Whether or not input is base64-encoded
+     * @param bool   $base64 Whether or not input is base64-encoded
      *
-     * @return string Decrypted text
+     * @return string|false Decrypted text, false on error
      */
     public function decrypt($cipher, $key = 'des_key', $base64 = true)
     {

--- a/program/lib/Roundcube/rcube.php
+++ b/program/lib/Roundcube/rcube.php
@@ -890,7 +890,7 @@ class rcube
      * @param string $key    Encryption key to retrieve from the configuration, defaults to 'des_key'
      * @param bool   $base64 Whether or not to base64_encode() the result before returning
      *
-     * @return string Encrypted text
+     * @return string|false Encrypted text, false on error
      */
     public function encrypt($clear, $key = 'des_key', $base64 = true)
     {
@@ -930,11 +930,17 @@ class rcube
      */
     public function decrypt($cipher, $key = 'des_key', $base64 = true)
     {
-        if (!$cipher) {
-            return '';
+        if (strlen($cipher) == 0) {
+            return false;
         }
 
-        $cipher  = $base64 ? base64_decode($cipher) : $cipher;
+        if ($base64) {
+            $cipher = base64_decode($cipher);
+            if ($cipher === false) {
+                return false;
+            }
+        }
+
         $ckey    = $this->config->get_crypto_key($key);
         $method  = $this->config->get_crypto_method();
         $opts    = defined('OPENSSL_RAW_DATA') ? OPENSSL_RAW_DATA : true;
@@ -943,7 +949,7 @@ class rcube
 
         // session corruption? (#1485970)
         if (strlen($iv) < $iv_size) {
-            return '';
+            return false;
         }
 
         $cipher = substr($cipher, $iv_size);


### PR DESCRIPTION
openssl_decrypt() may return false on error (e.g. if the cipher cannot
be decrypted with the given key), and therefore this function can also
return false.

Note: Alternatively, it would be possible to return an empty string like the function does for other errors. I don't know what's intended for this interface and went without code change.