### PR TITLE
phpdoc type annotations to aid static analysis tools

### DIFF
--- a/program/lib/Roundcube/rcube_addressbook.php
+++ b/program/lib/Roundcube/rcube_addressbook.php
@@ -224,7 +224,7 @@ abstract class rcube_addressbook
     /**
      * Returns the last error occurred (e.g. when updating/inserting failed)
      *
-     * @return array Hash array with the following fields: type, message
+     * @return ?array Hash array with the following fields: type, message
      */
     function get_error()
     {

--- a/program/lib/Roundcube/rcube_addressbook.php
+++ b/program/lib/Roundcube/rcube_addressbook.php
@@ -448,6 +448,7 @@ abstract class rcube_addressbook
     function get_group($group_id)
     {
         // empty for address books don't supporting groups
+        return null;
     }
 
     /**

--- a/program/lib/Roundcube/rcube_addressbook.php
+++ b/program/lib/Roundcube/rcube_addressbook.php
@@ -443,7 +443,7 @@ abstract class rcube_addressbook
      *
      * @param string $group_id Group identifier
      *
-     * @return array Group properties as hash array
+     * @return ?array Group properties as hash array, null in case of error.
      */
     function get_group($group_id)
     {

--- a/program/lib/Roundcube/rcube_addressbook.php
+++ b/program/lib/Roundcube/rcube_addressbook.php
@@ -154,8 +154,8 @@ abstract class rcube_addressbook
     /**
      * List the current set of contact records
      *
-     * @param array $cols   List of cols to show
-     * @param int   $subset Only return this number of records, use negative values for tail
+     * @param ?array $cols   List of cols to show (null means all)
+     * @param int    $subset Only return this number of records, use negative values for tail
      *
      * @return rcube_result_set Indexed list of contact records, each a hash array
      */

--- a/program/lib/Roundcube/rcube_addressbook.php
+++ b/program/lib/Roundcube/rcube_addressbook.php
@@ -108,7 +108,7 @@ abstract class rcube_addressbook
      */
     public $vcard_map = [];
 
-    /** @var array Error state - hash array with the following fields: type, message */
+    /** @var ?array Error state - hash array with the following fields: type, message */
     protected $error;
 
 
@@ -224,7 +224,7 @@ abstract class rcube_addressbook
     /**
      * Returns the last error occurred (e.g. when updating/inserting failed)
      *
-     * @return ?array Hash array with the following fields: type, message
+     * @return ?array Hash array with the following fields: type, message. Null if no error set.
      */
     function get_error()
     {

--- a/program/lib/Roundcube/rcube_addressbook.php
+++ b/program/lib/Roundcube/rcube_addressbook.php
@@ -417,7 +417,7 @@ abstract class rcube_addressbook
     /**
      * Setter for the current group
      *
-     * @param string|int $group_id A group identifier
+     * @param null|0|string $gid Database identifier of the group. 0/"0"/null to reset the group filter.
      */
     function set_group($group_id)
     {

--- a/program/lib/Roundcube/rcube_contacts.php
+++ b/program/lib/Roundcube/rcube_contacts.php
@@ -181,7 +181,7 @@ class rcube_contacts extends rcube_addressbook
      *
      * @param string $group_id Group identifier
      *
-     * @return ?array Group properties as hash array
+     * @return ?array Group properties as hash array, null in case of error.
      */
     function get_group($group_id)
     {

--- a/program/lib/Roundcube/rcube_contacts.php
+++ b/program/lib/Roundcube/rcube_contacts.php
@@ -181,7 +181,7 @@ class rcube_contacts extends rcube_addressbook
      *
      * @param string $group_id Group identifier
      *
-     * @return array Group properties as hash array
+     * @return ?array Group properties as hash array
      */
     function get_group($group_id)
     {

--- a/program/lib/Roundcube/rcube_plugin_api.php
+++ b/program/lib/Roundcube/rcube_plugin_api.php
@@ -32,9 +32,13 @@ class rcube_plugin_api
 {
     static protected $instance;
 
+    /** @var string */
     public $dir;
+    /** @var string */
     public $url = 'plugins/';
+    /** @var string */
     public $task = '';
+    /** @var bool */
     public $initialized = false;
 
     public $output;


### PR DESCRIPTION
This adds / corrects a couple of phpdoc type annotations to aid static analysis tools. They are based on the actual behavior of the roundcube code.