### PR TITLE
handle http 500 error on message send

### DIFF
--- a/program/include/rcmail_output_html.php
+++ b/program/include/rcmail_output_html.php
@@ -48,7 +48,7 @@ class rcmail_output_html extends rcmail_output
     protected $assets_path;
     protected $assets_dir   = RCUBE_INSTALL_PATH;
     protected $devel_mode   = false;
-    protected $default_template = "<html>\n<head><title></title></head>\n<body></body>\n</html>";
+    protected $default_template = "<html>\n<head><meta name='generator' content='Roundcube'><title></title></head>\n<body></body>\n</html>";
 
     // deprecated names of templates used before 0.5
     protected $deprecated_templates = [


### PR DESCRIPTION
ref: #7494, #7488, #7522

in cases where the user tries to send a message but the request cannot be processed by Roundcude the UI remains locked on "sending message" until timeout.

if the request was successfully processed by Roundcube the UI is always unlocked and either the success message is shown or the error that Roundcube got from the server so if the UI is still locked after the iframe is loaded then something unexpected must have happened and in this case we can show a connection error to the user.