### PR TITLE
Redesigned dark-mode toggle

### DIFF
--- a/skins/elastic/styles/dark.less
+++ b/skins/elastic/styles/dark.less
@@ -263,6 +263,24 @@ html.dark-mode {
         background-color: lighten(@color-dark-list-selected-background, 5%);
     }
 
+    .darkmode-toggle-label {
+        background-color: @color-taskmenu-button-selected-background;
+
+        &:before {
+            opacity: 1.0;
+        }
+    }
+
+    .darkmode-toggle-span {
+        background-color: @color-dark-font;
+    }
+
+    #layout-menu.popover {
+        .darkmode-toggle-label {
+            background-color: @color-taskmenu-button-selected-background;
+        }
+    }
+
     // ---------------------------------
     // Lists
     // ---------------------------------

--- a/skins/elastic/styles/widgets/menu.less
+++ b/skins/elastic/styles/widgets/menu.less
@@ -947,3 +947,106 @@ a.toolbar-button {
         }
     }
 }
+
+/*** Dark Mode Switch ***/
+
+.darkmode-toggle-input {
+    display: none; /* hides input */
+}
+
+.darkmode-toggle-label {
+    display: block;
+    position: relative;
+    border-radius: 100px;
+    width: 58%;
+    height: 1.3rem;
+    padding: 0.2rem;
+    margin: 0 auto .8rem auto;
+    background-color: @color-list-selected-background;
+    cursor: pointer;
+    box-sizing: content-box;
+
+    &:before,
+    &:after {
+        &:extend(.font-icon-class);
+        position: absolute;
+        left: 0.3rem;
+        top: 0.15rem;
+        z-index: 2;
+        font-size: 96%;
+        opacity: .85;
+    }
+
+    &:before {
+        content: @fa-var-sun;
+    }
+
+    &:after {
+        content: @fa-var-moon;
+        left: auto;
+        right: 0.1rem;
+    }
+}
+
+.darkmode-toggle-span {
+    position: absolute;
+    transition: all 0.3s ease-in-out;
+    left: 0.25rem;
+    height: 1.3rem;
+    width: 1.3rem;
+    border-radius: 50%;
+    background-color: @color-font;
+    z-index: 4;
+}
+
+.darkmode-toggle-input:checked ~ * .darkmode-toggle-span {
+    transform: translateX(132%);
+}
+
+@media screen and (min-width: (@screen-width-xs + 1px)) and (max-width: @screen-width-medium) {
+    .darkmode-toggle-label {
+        width: 1.3rem;
+        height: 3rem;
+
+        &:after {
+            top: auto;
+            bottom: 0.6rem;
+        }
+    }
+
+    .darkmode-toggle-span {
+        left: 0.2rem;
+        height: 1.3rem;
+    }
+
+    .darkmode-toggle-input:checked ~ * .darkmode-toggle-span {
+        transform: translateY(128%);
+    }
+}
+
+
+#layout-menu.popover {
+    .darkmode-toggle-label {
+        position: absolute;
+        bottom: 0.5rem;
+        left: 0.8rem;
+        width: 4.2rem;
+        height: 1.6rem;
+        background-color: #e0e0e0;
+
+        &:before,
+        &:after {
+            font-size: 135%;
+        }
+    }
+
+    .darkmode-toggle-span {
+        height: 1.6rem;
+        width: 1.6rem;
+    }
+
+    .darkmode-toggle-input:checked ~ * .darkmode-toggle-span {
+        transform: translateX(158%);
+    }
+}
+

--- a/skins/elastic/templates/includes/menu.html
+++ b/skins/elastic/templates/includes/menu.html
@@ -31,7 +31,11 @@
 			<roundcube:if condition="config:dark_mode_support" />
 				<roundcube:add_label name="darkmode" />
 				<roundcube:add_label name="lightmode" />
-				<roundcube:button name="theme" label="darkmode" type="link" innerClass="inner" class="theme dark" />
+				<input type="checkbox" id="darkmode-toggle-input" class="darkmode-toggle-input nopretty" />
+				<label for="darkmode-toggle-input" class="darkmode-toggle-label">
+					<span class="darkmode-toggle-span"></span>
+					<span class="darkmode-toggle-text sr-only"><roundcube:label name="darkmode" /></span>
+				</label>
 			<roundcube:endif />
 			<roundcube:button name="about" label="about" type="link"
 				class="about" innerClass="inner" onclick="UI.about_dialog(this)" />

--- a/skins/elastic/ui.js
+++ b/skins/elastic/ui.js
@@ -305,7 +305,7 @@ function rcube_elastic_ui()
         // Modify normal checkboxes on lists so they are different
         // than those used for row selection, i.e. use icons
         $('[data-list]').each(function() {
-            $('input[type=checkbox]', this).each(function() { pretty_checkbox(this); });
+            $('input[type=checkbox]:not(.nopretty)', this).each(function() { pretty_checkbox(this); });
         });
 
         // Assign .formcontainer class to the iframe body, when it
@@ -781,21 +781,22 @@ function rcube_elastic_ui()
             },
             switch_color_mode = function() {
                 if (color_mode == 'dark') {
-                    $('#taskmenu a.theme').removeClass('dark').addClass('light').find('span').text(rcmail.gettext('lightmode'));
+                    $('#taskmenu label.theme').removeClass('dark').addClass('light').find('span').text(rcmail.gettext('lightmode'));
                     $('html').addClass('dark-mode');
                 }
                 else {
-                    $('#taskmenu a.theme').removeClass('light').addClass('dark').find('span').text(rcmail.gettext('darkmode'));
+                    $('#taskmenu label.theme').removeClass('light').addClass('dark').find('span').text(rcmail.gettext('darkmode'));
                     $('html').removeClass('dark-mode');
                 }
 
                 screen_logo(mode);
+                $('#darkmode-toggle-input').prop('checked', color_mode == 'dark');
                 $('iframe').each(switch_iframe_color_mode);
             };
 
         // Add onclick action to the menu button
-        $('#taskmenu a.theme').on('click', function() {
-            color_mode = $(this).is('.dark') ? 'dark' : 'light';
+        $('#darkmode-toggle-input').on('click', function() {
+            color_mode = this.checked ? 'dark' : 'light';
             switch_color_mode();
             rcmail.set_cookie('colorMode', color_mode);
         });
@@ -1080,7 +1081,7 @@ function rcube_elastic_ui()
 
         // The same for some other checkboxes
         // We do this here, not in setup() because we want to cover dialogs
-        $('input.pretty-checkbox, .propform input[type=checkbox], .form-check input[type=checkbox], .popupmenu.form input[type=checkbox], .menu input[type=checkbox]', context)
+        $('input.pretty-checkbox, .propform input[type=checkbox], .form-check input[type=checkbox], .popupmenu.form input[type=checkbox], .menu input[type=checkbox]:not(.nopretty)', context)
             .each(function() { pretty_checkbox(this); });
 
         // Also when we add action-row of the form, e.g. Managesieve plugin adds them after the page is ready


### PR DESCRIPTION
Make the taskbar button to switch dark/light mode an actual toggle element as it is widely seen in the web.

This is how the toggle looks like in different screen sizes:
<img width="320" alt="dark-mode-toggle-dark" src="https://user-images.githubusercontent.com/1577511/113055530-fd980b80-91aa-11eb-84c2-4fc7ac0e7c79.png">
<img width="314" alt="dark-mode-toggle-tablet" src="https://user-images.githubusercontent.com/1577511/113055610-12749f00-91ab-11eb-9c38-a77fd81ca792.png">
<img width="375" alt="dark-mode-toggle-popover" src="https://user-images.githubusercontent.com/1577511/113055626-17395300-91ab-11eb-82eb-ee5b54661776.png">

