### PR TITLE
allow Junk icon label to be localized

### DIFF
--- a/plugins/markasjunk/markasjunk.php
+++ b/plugins/markasjunk/markasjunk.php
@@ -83,7 +83,7 @@ class markasjunk extends rcube_plugin
                         'classsel'   => 'button junk pressed',
                         'title'      => 'markasjunk.buttonjunk',
                         'innerclass' => 'inner',
-                        'label'      => 'junk'
+                        'label'      => 'markasjunk.junk'
                     ], 'toolbar');
 
                 $this->add_button([


### PR DESCRIPTION
Currently, it's not possible to override the default "Junk" label for the Junk mail icon in the toolbar. With this change, the user can add in something like to `$labels['junk'] = 'Spam';` to a localization file to change the label.