### PR TITLE
Add exec_hook to new_user_dialog

### DIFF
--- a/plugins/new_user_dialog/new_user_dialog.php
+++ b/plugins/new_user_dialog/new_user_dialog.php
@@ -172,10 +172,10 @@ rcube_webmail.prototype.new_user_dialog_close = function() { newuserdialog.dialo
         }
         else {
             // execute hook
-            $plugin = $rcmail->plugins->exec_hook('identity_update', array(
+            $plugin = $rcmail->plugins->exec_hook('identity_update', [
                 'id' => $identity['identity_id'],
                 'record' => $save_data
-            ));
+            ]);
 
             if (!$plugin['abort']) {
                 // save data

--- a/plugins/new_user_dialog/new_user_dialog.php
+++ b/plugins/new_user_dialog/new_user_dialog.php
@@ -176,13 +176,24 @@ rcube_webmail.prototype.new_user_dialog_close = function() { newuserdialog.dialo
                 'id' => $identity['identity_id'],
                 'record' => $save_data
             ));
-            if ($plugin['abort']) return;
-            // save data
-            $rcmail->user->update_identity($plugin['id'], $plugin['record']);
-            $rcmail->user->save_prefs(['newuserdialog' => null]);
-            // hide dialog
-            $rcmail->output->command('new_user_dialog_close');
-            $rcmail->output->show_message('successfullysaved', 'confirmation');
+
+            if (!$plugin['abort']) {
+                // save data
+                $updated = $rcmail->user->update_identity($plugin['id'], $plugin['record']);
+                $rcmail->user->save_prefs(['newuserdialog' => null]);
+            } else {
+                $updated = $plugin['result'];
+            }
+
+            if ($updated) {
+                // hide dialog
+                $rcmail->output->command('new_user_dialog_close');
+                $rcmail->output->show_message('successfullysaved', 'confirmation');
+            } else {
+                //show error
+                $error = !empty($plugin['message']) ? $plugin['message'] : 'errorsaving';
+                $rcmail->output->show_message($error, 'error', null, false);
+            }
         }
 
         $rcmail->output->send();

--- a/plugins/new_user_dialog/new_user_dialog.php
+++ b/plugins/new_user_dialog/new_user_dialog.php
@@ -178,14 +178,15 @@ rcube_webmail.prototype.new_user_dialog_close = function() { newuserdialog.dialo
             ]);
 
             if (!$plugin['abort']) {
-                // save data
+                // update identity
                 $updated = $rcmail->user->update_identity($plugin['id'], $plugin['record']);
-                $rcmail->user->save_prefs(['newuserdialog' => null]);
             } else {
                 $updated = $plugin['result'];
             }
 
             if ($updated) {
+                // save identity
+                $rcmail->user->save_prefs(['newuserdialog' => null]);
                 // hide dialog
                 $rcmail->output->command('new_user_dialog_close');
                 $rcmail->output->show_message('successfullysaved', 'confirmation');

--- a/plugins/new_user_dialog/new_user_dialog.php
+++ b/plugins/new_user_dialog/new_user_dialog.php
@@ -171,6 +171,12 @@ rcube_webmail.prototype.new_user_dialog_close = function() { newuserdialog.dialo
             $rcmail->output->show_message('emailformaterror', 'error', ['email' => $save_data['email']]);
         }
         else {
+            // execute hook
+            $plugin = $rcmail->plugins->exec_hook('identity_update', array(
+                'id' => $identity['identity_id'],
+                'record' => $save_data
+            ));
+            if ($plugin['abort']) return;
             // save data
             $rcmail->user->update_identity($identity['identity_id'], $save_data);
             $rcmail->user->save_prefs(['newuserdialog' => null]);

--- a/plugins/new_user_dialog/new_user_dialog.php
+++ b/plugins/new_user_dialog/new_user_dialog.php
@@ -191,7 +191,7 @@ rcube_webmail.prototype.new_user_dialog_close = function() { newuserdialog.dialo
                 $rcmail->output->command('new_user_dialog_close');
                 $rcmail->output->show_message('successfullysaved', 'confirmation');
             } else {
-                //show error
+                // show error
                 $error = !empty($plugin['message']) ? $plugin['message'] : 'errorsaving';
                 $rcmail->output->show_message($error, 'error', null, false);
             }

--- a/plugins/new_user_dialog/new_user_dialog.php
+++ b/plugins/new_user_dialog/new_user_dialog.php
@@ -178,14 +178,14 @@ rcube_webmail.prototype.new_user_dialog_close = function() { newuserdialog.dialo
             ]);
 
             if (!$plugin['abort']) {
-                // update identity
+                // save identity
                 $updated = $rcmail->user->update_identity($plugin['id'], $plugin['record']);
             } else {
                 $updated = $plugin['result'];
             }
 
             if ($updated) {
-                // save identity
+                // save prefs to not show dialog again
                 $rcmail->user->save_prefs(['newuserdialog' => null]);
                 // hide dialog
                 $rcmail->output->command('new_user_dialog_close');

--- a/plugins/new_user_dialog/new_user_dialog.php
+++ b/plugins/new_user_dialog/new_user_dialog.php
@@ -178,7 +178,7 @@ rcube_webmail.prototype.new_user_dialog_close = function() { newuserdialog.dialo
             ));
             if ($plugin['abort']) return;
             // save data
-            $rcmail->user->update_identity($identity['identity_id'], $save_data);
+            $rcmail->user->update_identity($plugin['id'], $plugin['record']);
             $rcmail->user->save_prefs(['newuserdialog' => null]);
             // hide dialog
             $rcmail->output->command('new_user_dialog_close');


### PR DESCRIPTION
Executes `identity_update` hook before updating identity.

My goal is to update the provided name in hMailServer. For this I'm listening for `identity_update` hook. But it doesn't get called. So I've added a manual exec_hook to plugin `new_user_dialog`.

I was inspired by plugin `new_user_identity`.

I'm not quite sure if handling `abort` this way is correct.