### PR TITLE
small text tweak in installer

### DIFF
--- a/installer/config.php
+++ b/installer/config.php
@@ -57,7 +57,7 @@ if (!empty($_POST['submit'])) {
 
     echo '<p class="notice">Copy or download the following configuration and save it';
     echo ' as <tt><b>config.inc.php</b></tt> within the <tt>'.RCUBE_CONFIG_DIR.'</tt> directory of your Roundcube installation.<br/>';
-    echo ' Make sure that there are no characters outside the <tt>&lt;?php ?&gt;</tt> brackets when saving the file.';
+    echo ' Make sure that there are no characters before the <tt>&lt;?php</tt> bracket when saving the file.';
     echo '&nbsp;<input type="button" onclick="location.href=\'index.php?_getconfig=1\'" value="Download" />';
     echo $save_button;
 


### PR DESCRIPTION
`rcmail_install::create_config()` produces output which has a start <?php but no close tag, and there is no close tag in config.inc.php.sample either. this is a small text tweak to remove the reference to the non-existent close tag