### PR TITLE
Fix bug where 'start' and 'reversed' on ol tag were ignored(#8059)

### DIFF
--- a/program/lib/Roundcube/rcube_washtml.php
+++ b/program/lib/Roundcube/rcube_washtml.php
@@ -103,7 +103,7 @@ class rcube_washtml
         'bordercolordark', 'face', 'marginwidth', 'marginheight', 'axis', 'border',
         'abbr', 'char', 'charoff', 'clear', 'compact', 'coords', 'vspace', 'hspace',
         'cellborder', 'size', 'lang', 'dir', 'usemap', 'shape', 'media',
-        'background', 'src', 'poster', 'href', 'headers',
+        'background', 'src', 'poster', 'href', 'headers', 'start', 'reversed',
         // attributes of form elements
         'type', 'rows', 'cols', 'disabled', 'readonly', 'checked', 'multiple', 'value', 'for',
         // SVG


### PR DESCRIPTION
Fix #8059 

"start" and "reversed" attributes on `<ol>` tag are added to allowed attributes.