### PR TITLE
Change headers in DSN and MDN requests

### DIFF
--- a/program/include/rcmail_sendmail.php
+++ b/program/include/rcmail_sendmail.php
@@ -201,10 +201,10 @@ class rcmail_sendmail
             $headers['Organization'] = $identity_arr['organization'];
         }
 
-        if ($mdn_enabled) {
-            $headers['Return-Receipt-To']           = $from_string;
-            $headers['Disposition-Notification-To'] = $from_string;
-        }
+
+		if ($mdn_enabled) {
+			$headers['Disposition-Notification-To'] = $from_string;
+		}
 
         if (!empty($_POST['_priority'])) {
             $priority     = intval($_POST['_priority']);
@@ -1192,7 +1192,7 @@ class rcmail_sendmail
     {
         $subject = trim($subject);
 
-        //  Add config options for subject prefixes (#7929) 
+        //  Add config options for subject prefixes (#7929)
         $subject = rcube_utils::remove_subject_prefix($subject, 'reply');
         $subject = rcmail::get_instance()->config->get('response_prefix', 'Re:') . ' ' . $subject;
 
@@ -1230,7 +1230,7 @@ class rcmail_sendmail
         }
         // create a forward-subject
         else if ($this->data['mode'] == self::MODE_FORWARD) {
-            //  Add config options for subject prefixes (#7929) 
+            //  Add config options for subject prefixes (#7929)
             $subject = rcube_utils::remove_subject_prefix($this->options['message']->subject, 'forward');
             $subject = trim($this->rcmail->config->get('forward_prefix', 'Fwd:') . ' ' . $subject);
         }

--- a/program/include/rcmail_sendmail.php
+++ b/program/include/rcmail_sendmail.php
@@ -206,6 +206,10 @@ class rcmail_sendmail
 			$headers['Disposition-Notification-To'] = $from_string;
 		}
 
+		if ($dsn_enabled){
+		    $headers['Return-Receipt-To']           = $from_string;
+		}
+
         if (!empty($_POST['_priority'])) {
             $priority     = intval($_POST['_priority']);
             $a_priorities = [1 => 'highest', 2 => 'high', 4 => 'low', 5 => 'lowest'];

--- a/program/lib/Roundcube/rcube.php
+++ b/program/lib/Roundcube/rcube.php
@@ -1782,8 +1782,8 @@ class rcube
         else {
             $this->plugins->exec_hook('message_sent', ['headers' => $headers, 'body' => $msg_body, 'message' => $message]);
 
-            // remove MDN headers after sending
-            unset($headers['Disposition-Notification-To']);
+            // remove MDN and DSN headers after sending
+            unset($headers['Return-Receipt-To'], $headers['Disposition-Notification-To']);
 
             if ($this->config->get('smtp_log')) {
                 // get all recipient addresses

--- a/program/lib/Roundcube/rcube.php
+++ b/program/lib/Roundcube/rcube.php
@@ -1783,7 +1783,7 @@ class rcube
             $this->plugins->exec_hook('message_sent', ['headers' => $headers, 'body' => $msg_body, 'message' => $message]);
 
             // remove MDN headers after sending
-            unset($headers['Return-Receipt-To'], $headers['Disposition-Notification-To']);
+            unset($headers['Disposition-Notification-To']);
 
             if ($this->config->get('smtp_log')) {
                 // get all recipient addresses


### PR DESCRIPTION
MDN sending "Return-Receipt-To" not only is not RFC compliant and can cause confusion in SMPT servers that expect this header for DSN requests. The first commit removes the "Return-Receipt-To" header, the second commit adds this header for DSN requests (The latter is not RFC compliant, but can make roundcube more compatible to exsisting SMTP solutions).

https://github.com/roundcube/roundcubemail/issues/8069