### PR TITLE
fixes for #8098

### DIFF
--- a/program/js/app.js
+++ b/program/js/app.js
@@ -4884,7 +4884,7 @@ function rcube_webmail()
           recipients.push(name);
 
           // group is added, expand it
-          if (id.charAt(0) == 'E' && name.indexOf('@') < 0 && input.length) {
+          if (id.charAt(0) == 'E' && input.length) {
             var gid = id.substr(1);
             this.group2expand[gid] = {name: name, input: input.get(0)};
             this.http_request('group-expand', {_source: data.source || this.env.source, _gid: gid}, false);
@@ -5959,7 +5959,7 @@ function rcube_webmail()
       trigger = true;
     }
 
-    this.ksearch_input_replace(this.ksearch_value, insert);
+    this.ksearch_input_replace(this.ksearch_value, insert, null, trigger);
 
     if (trigger) {
       this.triggerEvent('autocomplete_insert', {field: this.ksearch_input, insert: insert, data: contact, search: this.ksearch_value_last, result_type: 'person'});
@@ -6166,7 +6166,7 @@ function rcube_webmail()
 
   // Setter for input value
   // replaces 'from' string with 'to' and sets cursor position at the end
-  this.ksearch_input_replace = function(from, to, input)
+  this.ksearch_input_replace = function(from, to, input, trigger)
   {
     if (!this.ksearch_input && !input)
       return;
@@ -6185,7 +6185,7 @@ function rcube_webmail()
     this.set_caret_pos(input, cpos + to.length - from.length);
 
     // run onchange action on the element
-    $(input).trigger('change', [true]);
+    $(input).trigger('change', [true, trigger]);
   };
 
   this.ksearch_click = function(node)

--- a/skins/elastic/ui.js
+++ b/skins/elastic/ui.js
@@ -3221,8 +3221,13 @@ function rcube_elastic_ui()
 
                 return result.recipients.length > 0;
             },
-            parse_func = function(e, ac) {
+            parse_func = function(e, ac, trigger) {
                 var last, paste, value = this.value;
+
+                // #8098: ignore changes when autocomplete_insert is not triggered
+                if (trigger === false) {
+                    return;
+                }
 
                 // On paste the text is not yet in the input we have to use clipboard.
                 // Also because on paste new-line characters are replaced by spaces (#6460)


### PR DESCRIPTION
- By removing the `name.indexOf('@') < 0` check in `compose_add_recipient` the behavior becomes the same as with autocomplete - groups are always expanded. To me this makes sense, the check for a @ char seems a little arbitrary.
- Make Elastic skip the recipient name/address processing on group names. Group names are always replaced out with a list of the group members so processing that text is a waste of time and can lead to errors like with group names that contain an @.