### PR TITLE
[Feature] Localization: add greeting and forgot-password labels

### DIFF
--- a/program/localization/en_GB/labels.inc
+++ b/program/localization/en_GB/labels.inc
@@ -15,12 +15,14 @@
 */
 
 
+$labels['greeting'] = 'Hi';
 $labels['welcome'] = 'Welcome to $product';
 $labels['username'] = 'Username';
 $labels['password'] = 'Password';
 $labels['server'] = 'Server';
 $labels['login'] = 'Login';
 $labels['oauthlogin'] = 'Login with $provider';
+$labels['forgotpassword'] = 'Forgot password';
 $labels['menu'] = 'Menu';
 $labels['logout'] = 'Logout';
 $labels['mail'] = 'Mail';


### PR DESCRIPTION
## Description
Using Rouncubemail as our webmail client we have found missing localization for a couple of labels that we believe could prove useful to many other users as well.

## Changes
Added **2 new** labels, that our team would continue to translate into multiple languages:
- `greeting` label: meant to be a less formal way of saying **Hello** in any available language.
- `forgotpassword` label: quite self-explanatory. As it is currently not an available label, would provide localization option for the **Forgot password** link, regardless of the means it has been implemented into the webmail.