### PR TITLE
Fixe shift + drag & drop popover on chromium

### DIFF
--- a/skins/elastic/ui.js
+++ b/skins/elastic/ui.js
@@ -2582,7 +2582,11 @@ function rcube_elastic_ui()
                 }
 
                 menus[p.name] = {target: target};
-                $(target).popover('show');
+                
+                //Fixe popover on chromium
+                setTimeout(() => {
+                    $(target).popover('show');
+                }, 1);
             }
 
             fn();


### PR DESCRIPTION
On chromium based navigator, shift + drag & drop a mail doesn't show the popup, this correction correct this.