### PR TITLE
Don't extract image data URIs into message attachments

### DIFF
--- a/program/include/rcmail_sendmail.php
+++ b/program/include/rcmail_sendmail.php
@@ -342,9 +342,6 @@ class rcmail_sendmail
                 // add a plain text version of the e-mail as an alternative part.
                 $MAIL_MIME->setTXTBody($plugin['body']);
             }
-
-            // Extract image Data URIs into message attachments (#1488502)
-            $this->extract_inline_images($MAIL_MIME, $this->options['from']);
         }
         else {
             $body = $this->format_plain_body($plugin['body'], $flowed);


### PR DESCRIPTION
Hello,

As Data URIs are now well supported by a lot of email clients I think this feature can be removed. It is not useful anymore and it adds a lot of trouble for companies that are using base64 images in email signature. The conversations are quickly flooded with attached files from the signature.

Thank you for looking!