### PR TITLE
Ensure potential phishing addresses are valid

### DIFF
--- a/program/actions/mail/index.php
+++ b/program/actions/mail/index.php
@@ -1382,7 +1382,7 @@ class rcmail_action_mail_index extends rcmail_action
             $valid  = rcube_utils::check_email($mailto, false);
 
             // phishing email prevention (#1488981), e.g. "valid@email.addr <phishing@email.addr>"
-            if (!$show_email && $valid && $name && $name != $mailto && strpos($name, '@')) {
+            if (!$show_email && $valid && $name && $name != $mailto && rcube_utils::check_email($name, false)) {
                 $name = '';
                 self::$SUSPICIOUS_EMAIL = true;
             }


### PR DESCRIPTION
Currently, Roundcube will mark emails with a "From" header name containing an "@" as potentially fraudulent. I've noticed this catches GitLab comment notification emails, which are marked as from the person and their username e.g. "Justin Sleep (@justin-sleep)".

I've modified this to use the `check_email` helper function instead.