### PR TITLE
Detect all variants of @ in suspicious emails

### DIFF
--- a/program/actions/mail/index.php
+++ b/program/actions/mail/index.php
@@ -1382,9 +1382,7 @@ class rcmail_action_mail_index extends rcmail_action
             $valid  = rcube_utils::check_email($mailto, false);
 
             // phishing email prevention (#1488981), e.g. "valid@email.addr <phishing@email.addr>"
-            if (!$show_email && $valid && $name && $name != $mailto
-                && (strpos($name, '@') || strpos($name, '＠'))
-            ) {
+            if (!$show_email && $valid && $name && $name != $mailto && preg_match('/@|＠|﹫/', $name)) {
                 $name = '';
             }
 


### PR DESCRIPTION
There are three Unicode variants of the at sign: "@", "＠", and "﹫". For future flexibility and conciseness, I've consolidated the logic here to one `preg_match` call.