### PR TITLE
Fix dovecot passwdfile change

### DIFF
--- a/plugins/password/drivers/dovecot_passwdfile.php
+++ b/plugins/password/drivers/dovecot_passwdfile.php
@@ -63,7 +63,7 @@ class rcube_dovecot_passwdfile_password
             while (($line = fgets($fp, 40960)) !== false) {
                 if (strpos($line, "$username:") === 0) {
                     $pos  = strpos($line, ':', strlen("$username:") + 1);
-                    $line = "$username:$newhash" . substr($line, $pos);
+                    $line = "$username:$password" . substr($line, $pos);
                 }
 
                 $content .= $line;

--- a/plugins/password/drivers/dovecot_passwdfile.php
+++ b/plugins/password/drivers/dovecot_passwdfile.php
@@ -52,7 +52,6 @@ class rcube_dovecot_passwdfile_password
             return PASSWORD_ERROR;
         }
 
-        $password = escapeshellcmd($password); // FIXME: Do we need this?
         $username = escapeshellcmd($username); // FIXME: Do we need this?
         $content  = '';
 

--- a/plugins/password/drivers/dovecot_passwdfile.php
+++ b/plugins/password/drivers/dovecot_passwdfile.php
@@ -40,6 +40,18 @@ class rcube_dovecot_passwdfile_password
         $mailuserfile = $rcmail->config->get('password_dovecot_passwdfile_path') ?: '/etc/mail/imap.passwd';
 
         $password = password::hash_password($newpass);
+
+        if ($password === false) {
+            rcube::raise_error([
+                    'code' => 600, 'file' => __FILE__, 'line' => __LINE__,
+                    'message' => "Password plugin: Failed to hash password. Check for configuration issues."
+                ],
+                true, false
+            );
+
+            return PASSWORD_ERROR;
+        }
+
         $password = escapeshellcmd($password); // FIXME: Do we need this?
         $username = escapeshellcmd($username); // FIXME: Do we need this?
         $content  = '';

--- a/plugins/password/drivers/dovecot_passwdfile.php
+++ b/plugins/password/drivers/dovecot_passwdfile.php
@@ -60,7 +60,7 @@ class rcube_dovecot_passwdfile_password
 
         if (flock($fp, LOCK_EX)) {
             // Read the file and replace the user password
-            while (($line = fgets($handle, 40960)) !== false) {
+            while (($line = fgets($fp, 40960)) !== false) {
                 if (strpos($line, "$username:") === 0) {
                     $pos  = strpos($line, ':', strlen("$username:") + 1);
                     $line = "$username:$newhash" . substr($line, $pos);


### PR DESCRIPTION
Currently there is a few problems with the dovecot_passwdfile password-driver.

- Trying to use two variables that are not initialized (`$handle` and `$newhash` - introduced in commit `ca523bd7facf29aaabf08718252314fca05c83a5`)
- If the `password::hash_password`-function returns false (which could happen when using `dovecot` as `password_algorithm`), the code would still proceed to change the password to an empty string even though hashing failed. It now raises an error instead.
- Escaping the hashed password result is not needed and actually breaks if option 'password_dovecotpw_with_method' is set to true resulting in an escaped entry in the passwd-file, i.e. `\{SSHA256\}...`

Let me know if something needs to be changed.

Thanks for developing an awesome mail client!