### PR TITLE
remove redudant php version checks

### DIFF
--- a/program/lib/Roundcube/rcube.php
+++ b/program/lib/Roundcube/rcube.php
@@ -470,8 +470,7 @@ class rcube
             ini_set('session.cookie_path', $sess_path);
         }
         // set session samesite attribute
-        // requires PHP >= 7.3.0, see https://wiki.php.net/rfc/same-site-cookie for more info
-        if (version_compare(PHP_VERSION, '7.3.0', '>=') && $sess_samesite) {
+        if ($sess_samesite) {
             ini_set('session.cookie_samesite', $sess_samesite);
         }
         // set session garbage collecting time according to session_lifetime

--- a/program/lib/Roundcube/rcube_utils.php
+++ b/program/lib/Roundcube/rcube_utils.php
@@ -75,13 +75,7 @@ class rcube_utils
         // session_get_cookie_params() return includes 'lifetime' but setcookie() does not use it, instead it uses 'expires'
         unset($attrib['lifetime']);
 
-        if (version_compare(PHP_VERSION, '7.3.0', '>=')) {
-            // An alternative signature for setcookie supporting an options array added in PHP 7.3.0
-            setcookie($name, $value, $attrib);
-        }
-        else {
-            setcookie($name, $value, $attrib['expires'], $attrib['path'], $attrib['domain'], $attrib['secure'], $attrib['httponly']);
-        }
+        setcookie($name, $value, $attrib);
     }
 
     /**


### PR DESCRIPTION
I added in these PHP version checks when I did the samesite cookie stuff (#6772). Now 7.3 is the min version I guess they can come out.