### PR TITLE
Avoid unnecessary page break before large blockquote

### DIFF
--- a/skins/elastic/styles/print.less
+++ b/skins/elastic/styles/print.less
@@ -43,6 +43,10 @@ body {
         padding-left: .1rem;
     }
 
+    blockquote {
+        page-break-inside: auto;
+    }
+
     // Overwrites for contact printouts
 
     .formcontent {


### PR DESCRIPTION
When printing a message with a large `<blockquote>` (e.g. a reply to a long thread), Firefox tries to avoid breaking the page within the blockquote so may add a page break before it, causing the unquoted part of the message to appear on a mostly-blank page.