### PR TITLE
Fix XSS in $file_extension

### DIFF
--- a/program/actions/mail/get.php
+++ b/program/actions/mail/get.php
@@ -204,7 +204,7 @@ class rcmail_action_mail_get extends rcmail_action_mail_index
                             $rcmail->gettext([
                                     'name' => 'attachmentvalidationerror',
                                     'vars' => [
-                                        'expected' => $mimetype . ($file_extension ? " (.$file_extension)" : ''),
+                                        'expected' => $mimetype . ($file_extension ? " (.".htmlentities($file_extension).")" : ''),
                                         'detected' => $real_mimetype . ($extensions[0] ? " (.$extensions[0])" : ''),
                                     ]
                             ]),


### PR DESCRIPTION
It is possible to inject arbitrary html/js code through attachment's $file_extension variable that will be executed while displaying "attachmentvalidationerror" warning.