### PR TITLE
Bump roundcube/plugin-installer to 0.3.1

### DIFF
--- a/composer.json-dist
+++ b/composer.json-dist
@@ -16,7 +16,7 @@
         "pear/net_smtp": "~1.10.0",
         "pear/crypt_gpg": "~1.6.3",
         "pear/net_sieve": "~1.4.5",
-        "roundcube/plugin-installer": "~0.3.0",
+        "roundcube/plugin-installer": "~0.3.1",
         "roundcube/rtf-html-php": "~2.1",
         "masterminds/html5": "~2.7.0",
         "bacon/bacon-qr-code": "^2.0.0",


### PR DESCRIPTION
### Reason for change

After updating my local docker images to roundcube 1.5.0, I found out that I could no longer install roundcube plugins.

After debugging I figured out that this was related to a recent bug in roundcube/plugin-installer https://github.com/roundcube/plugin-installer/commit/9c66c276b795eea1a32eb864b2c6c1f682cdc027 that always threw a PHP exception

"Undefined variable $installers" when trying to do pretty much anything with composer (update, require...).

This bug was fixed in roundcube/plugin-installer 0.3.1, but the current roundcube complete release ships 0.3.0. I cannot upgrade from 0.3.0 to 0.3.1 (via composer), because this throws the above exception.

The only workaround I've found so far is to *not* use the complete package of roundcube 1.5.0, but install the dependencies myself (and making sure to install 0.3.1 instead of 0.3.0).

In order to prevent other users from running into the same situation, the roundcube complete package should ship at least 0.3.1 in the next release.

This change ensures that new roundcube builds use at least plugin-installer version 0.3.1.