### PR TITLE
Update composer.json file to show php-intl is required

### DIFF
--- a/composer.json-dist
+++ b/composer.json-dist
@@ -10,6 +10,7 @@
     ],
     "require": {
         "php": ">=7.3.0",
+        "ext-intl": "*",
         "pear/pear-core-minimal": "~1.10.1",
         "pear/auth_sasl": "~1.1.0",
         "pear/mail_mime": "~1.10.0",


### PR DESCRIPTION
As of roundcube 1.5, `php-intl` is a required php extension. `composer` should show it and warn as such.