### PR TITLE
random_bytes -> random_string

### DIFF
--- a/plugins/password/password.php
+++ b/plugins/password/password.php
@@ -539,19 +539,19 @@ class password extends rcube_plugin
         switch ($method) {
         case 'des':
         case 'des-crypt':
-            $crypted = crypt($password, rcube_utils::random_bytes(2));
+            $crypted = crypt($password, rcube_utils::random_string(2));
             $prefix  = '{CRYPT}';
             break;
 
         case 'ext_des': // for BC
         case 'ext-des-crypt':
-            $crypted = crypt($password, '_' . rcube_utils::random_bytes(8));
+            $crypted = crypt($password, '_' . rcube_utils::random_string(8));
             $prefix  = '{CRYPT}';
             break;
 
         case 'md5crypt': // for BC
         case 'md5-crypt':
-            $crypted = crypt($password, '$1$' . rcube_utils::random_bytes(9));
+            $crypted = crypt($password, '$1$' . rcube_utils::random_string(9));
             $prefix  = '{MD5-CRYPT}';
             break;
 
@@ -563,7 +563,7 @@ class password extends rcube_plugin
                 $prefix .= 'rounds=' . $rounds . '$';
             }
 
-            $crypted = crypt($password, $prefix . rcube_utils::random_bytes(16));
+            $crypted = crypt($password, $prefix . rcube_utils::random_string(16));
             $prefix  = '{SHA256-CRYPT}';
             break;
 
@@ -575,7 +575,7 @@ class password extends rcube_plugin
                 $prefix .= 'rounds=' . $rounds . '$';
             }
 
-            $crypted = crypt($password, $prefix . rcube_utils::random_bytes(16));
+            $crypted = crypt($password, $prefix . rcube_utils::random_string(16));
             $prefix  = '{SHA512-CRYPT}';
             break;
 
@@ -585,7 +585,7 @@ class password extends rcube_plugin
             $cost   = $cost < 4 || $cost > 31 ? 12 : $cost;
             $prefix = sprintf('$2y$%02d$', $cost);
 
-            $crypted = crypt($password, $prefix . rcube_utils::random_bytes(22));
+            $crypted = crypt($password, $prefix . rcube_utils::random_string(22));
             $prefix  = '{BLF-CRYPT}';
             break;
 
@@ -614,7 +614,7 @@ class password extends rcube_plugin
             break;
 
         case 'ssha':
-            $salt = rcube_utils::random_bytes(8);
+            $salt = rcube_utils::random_string(8);
 
             if (function_exists('sha1')) {
                 $salt    = substr(pack("H*", sha1($salt . $password)), 0, 4);
@@ -637,7 +637,7 @@ class password extends rcube_plugin
             break;
 
         case 'ssha512':
-            $salt = rcube_utils::random_bytes(8);
+            $salt = rcube_utils::random_string(8);
 
             if (function_exists('hash')) {
                 $salt    = substr(pack("H*", hash('sha512', $salt . $password)), 0, 4);
@@ -656,7 +656,7 @@ class password extends rcube_plugin
             break;
 
         case 'smd5':
-            $salt = rcube_utils::random_bytes(8);
+            $salt = rcube_utils::random_string(8);
 
             if (function_exists('hash')) {
                 $salt    = substr(pack("H*", hash('md5', $salt . $password)), 0, 4);

--- a/program/include/rcmail_install.php
+++ b/program/include/rcmail_install.php
@@ -179,7 +179,7 @@ class rcmail_install
         $value = $this->config[$name] ?? null;
 
         if ($name == 'des_key' && !$this->configured && !isset($_REQUEST["_$name"])) {
-            $value = rcube_utils::random_bytes(24);
+            $value = rcube_utils::random_string(24);
         }
 
         return $value !== null && $value !== '' ? $value : $default;
@@ -206,7 +206,7 @@ class rcmail_install
 
             // generate new encryption key, never use the default value
             if ($prop == 'des_key' && $value == $this->defaults[$prop]) {
-                $value = rcube_utils::random_bytes(24);
+                $value = rcube_utils::random_string(24);
             }
 
             // convert some form data

--- a/program/include/rcmail_oauth.php
+++ b/program/include/rcmail_oauth.php
@@ -167,7 +167,7 @@ class rcmail_oauth
     {
         if (!empty($this->options['auth_uri']) && !empty($this->options['client_id'])) {
             // create a secret string
-            $_SESSION['oauth_state'] = rcube_utils::random_bytes(12);
+            $_SESSION['oauth_state'] = rcube_utils::random_string(12);
 
             // compose full oauth login uri
             $delimiter = strpos($this->options['auth_uri'], '?') > 0 ? '&' : '?';

--- a/program/lib/Roundcube/rcube.php
+++ b/program/lib/Roundcube/rcube.php
@@ -899,7 +899,7 @@ class rcube
 
         $ckey   = $this->config->get_crypto_key($key);
         $method = $this->config->get_crypto_method();
-        $iv     = rcube_utils::random_bytes(openssl_cipher_iv_length($method), true);
+        $iv     = random_bytes(openssl_cipher_iv_length($method));
         $tag    = null;
 
         // This distinction is for PHP 7.3 which throws a warning when
@@ -988,7 +988,7 @@ class rcube
             if (empty($_SESSION['secure_token']) && $generate) {
                 // generate x characters long token
                 $length = $len > 1 ? $len : 16;
-                $token  = rcube_utils::random_bytes($length);
+                $token  = rcube_utils::random_string($length);
 
                 $plugin = $this->plugins->exec_hook('secure_token', ['value' => $token, 'length' => $length]);
 
@@ -1009,7 +1009,7 @@ class rcube
     public function get_request_token()
     {
         if (empty($_SESSION['request_token'])) {
-            $plugin = $this->plugins->exec_hook('request_token', ['value' => rcube_utils::random_bytes(32)]);
+            $plugin = $this->plugins->exec_hook('request_token', ['value' => rcube_utils::random_string(32)]);
 
             $_SESSION['request_token'] = $plugin['value'];
         }

--- a/program/lib/Roundcube/rcube_session.php
+++ b/program/lib/Roundcube/rcube_session.php
@@ -202,7 +202,7 @@ abstract class rcube_session
     public function create($data)
     {
         $length = strlen(session_id());
-        $key    = rcube_utils::random_bytes($length);
+        $key    = rcube_utils::random_string($length);
 
         // create new session
         if ($this->write($key, $this->serialize($data))) {
@@ -641,7 +641,7 @@ abstract class rcube_session
                 $secret = $_SESSION['auth_secret'];
             }
             else {
-                $secret = rcube_utils::random_bytes(strlen($this->key));
+                $secret = rcube_utils::random_string(strlen($this->key));
             }
         }
 

--- a/program/lib/Roundcube/rcube_user.php
+++ b/program/lib/Roundcube/rcube_user.php
@@ -263,7 +263,7 @@ class rcube_user
 
         // generate a random hash and store it in user prefs
         if (empty($prefs['client_hash'])) {
-            $prefs['client_hash'] = rcube_utils::random_bytes(16);
+            $prefs['client_hash'] = rcube_utils::random_string(16);
             $this->save_prefs(['client_hash' => $prefs['client_hash']]);
         }
 

--- a/program/lib/Roundcube/rcube_utils.php
+++ b/program/lib/Roundcube/rcube_utils.php
@@ -1406,17 +1406,11 @@ class rcube_utils
      * Generate a random string
      *
      * @param int  $length String length
-     * @param bool $raw    Return RAW data instead of ascii
      *
      * @return string The generated random string
      */
-    public static function random_bytes($length, $raw = false)
+    public static function random_string($length)
     {
-        // Use PHP7 true random generator
-        if ($raw) {
-            return random_bytes($length);
-        }
-
         $hextab  = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
         $tabsize = strlen($hextab);
 

--- a/tests/Framework/Utils.php
+++ b/tests/Framework/Utils.php
@@ -691,15 +691,14 @@ class Framework_Utils extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * rcube:utils::random_bytes()
+     * rcube:utils::random_string()
      */
-    function test_random_bytes()
+    function test_random_string()
     {
-        $this->assertMatchesRegularExpression('/^[a-zA-Z0-9]{15}$/', rcube_utils::random_bytes(15));
-        $this->assertSame(15, strlen(rcube_utils::random_bytes(15, true)));
-        $this->assertSame(1, strlen(rcube_utils::random_bytes(1)));
-        $this->assertSame(0, strlen(rcube_utils::random_bytes(0)));
-        $this->assertSame(0, strlen(rcube_utils::random_bytes(-1)));
+        $this->assertMatchesRegularExpression('/^[a-zA-Z0-9]{15}$/', rcube_utils::random_string(15));
+        $this->assertSame(1, strlen(rcube_utils::random_string(1)));
+        $this->assertSame(0, strlen(rcube_utils::random_string(0)));
+        $this->assertSame(0, strlen(rcube_utils::random_string(-1)));
     }
 
     /**


### PR DESCRIPTION
For PHP version < 7 the custom roundcube implementation for random_bytes made sense, but now not anymore IMHO. Actually only once it returns bytes and in all other cases a string.

Suggest to clean up the code and use the native random_bytes from PHP 7+ and rename random_bytes to random_string.