### PR TITLE
fix(chpasswd): as reported on StackOverflow

### DIFF
--- a/plugins/password/helpers/chpass-wrapper.py
+++ b/plugins/password/helpers/chpass-wrapper.py
@@ -26,7 +26,7 @@ if username in BLACKLIST:
     sys.exit('Changing password for user %s is forbidden (user blacklisted)' %
              username)
 
-handle = subprocess.Popen('/usr/sbin/chpasswd', stdin = subprocess.PIPE)
+handle = subprocess.Popen('/usr/sbin/chpasswd', stdin = subprocess.PIPE, text=True)
 handle.communicate('%s:%s' % (username, password))
 
 sys.exit(handle.returncode)


### PR DESCRIPTION
See https://stackoverflow.com/questions/70051230/php-error-when-trying-to-use-password-reset-plugin-in-roundcube

Newer python versions may fail to change user passwords.
Fix from StevieD -- https://stackoverflow.com/users/1641112/stevied