### PR TITLE
Faster random string generation

### DIFF
--- a/program/lib/Roundcube/rcube_utils.php
+++ b/program/lib/Roundcube/rcube_utils.php
@@ -1417,15 +1417,12 @@ class rcube_utils
             return random_bytes($length);
         }
 
-        $hextab  = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
-        $tabsize = strlen($hextab);
+        do {
+            $base64_random_string = base64_encode(random_bytes($length));
+            $base62_random_string = str_replace(array('+', '/', '='), '', $base64_random_string);
+        } while ( strlen($base62_random_string) < $length );
 
-        $result = '';
-        while ($length-- > 0) {
-            $result .= $hextab[random_int(0, $tabsize - 1)];
-        }
-
-        return $result;
+        return substr($base62_random_string, 0, $length);
     }
 
     /**


### PR DESCRIPTION
Calling  (pseudo-random) integers with random_int for longer keys, is kind of slow... because of the loop for each character.

Requesting multiple random bytes in one go, is quicker (~10x for 32 bytes). Random_bytes is "true random", not pseudo.

The conversion from base64 to base62 can cause a too short string in <1% of the cases, hence the loop. Benchmark code attached...
[r.php.gz](https://github.com/roundcube/roundcubemail/files/7576461/r.php.gz)
