### PR TITLE
CI: Update browser tests actions

### DIFF
--- a/.github/workflows/browser_tests.yml
+++ b/.github/workflows/browser_tests.yml
@@ -29,7 +29,8 @@ jobs:
       - name: Set up JDK 1.8
         uses: actions/setup-java@v2
         with:
-          java-version: '1.8'
+          distribution: 'zulu'
+          java-version: '8'
 
       - name: Setup problem matchers
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"

--- a/.github/workflows/browser_tests.yml
+++ b/.github/workflows/browser_tests.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   browser_tests:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[ci skip]')"
 
     strategy:
@@ -21,15 +21,15 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.0
+          php-version: '8.1'
           extensions: dom, curl, fileinfo, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd, ldap, intl, pspell
           tools: composer:v2
           coverage: none
 
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          java-version: '1.8'
 
       - name: Setup problem matchers
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
@@ -52,9 +52,9 @@ jobs:
         run: cp .github/config-test.inc.php config/config-test.inc.php
 
       - name: Setup NPM
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
-          node-version: '12.x'
+          node-version: '16'
 
       - name: Setup NPM deps
         run: |


### PR DESCRIPTION
Update the browser test GitHub Actions workflow:
- Use `ubuntu-latest` environment (currently [Ubuntu 20.04](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md) Focal)
- Setup PHP 8.1
- Use [actions/setup-java@v2](https://github.com/actions/setup-java)
- Use [actions/setup-node@v2](https://github.com/actions/setup-node) with Node 16 LTS