### PR TITLE
Elastic: move scrollbar settings to variables

### DIFF
--- a/skins/elastic/styles/colors.less
+++ b/skins/elastic/styles/colors.less
@@ -216,6 +216,11 @@
 @color-image-tools-hover:               fadeout(@color-main, 50%);
 
 
+// Scrollbars
+@color-scrollbar-thumb:     #c1c1c1;
+@color-scrollbar-track:     #f1f1f1;
+
+
 // Dark mode colors
 @color-dark-main:           darken(@color-main, 30%);
 @color-dark-background:     #21292c;

--- a/skins/elastic/styles/dark.less
+++ b/skins/elastic/styles/dark.less
@@ -13,7 +13,7 @@
 
 html.dark-mode {
     scrollbar-color: @color-dark-scrollbar-thumb @color-dark-scrollbar-track;
-    scrollbar-width: thin;
+    scrollbar-width: @scrollbar-dark-width;
 
     textarea,
     select,
@@ -26,20 +26,23 @@ html.dark-mode {
     .table-responsive-sm,
     .scroller {
         // Firefox does not inherit scrollbar size from the html element
-        scrollbar-width: thin;
+        scrollbar-width: @scrollbar-dark-width;
     }
 
     &:not(.touch) {
-        ::-webkit-scrollbar {
+        ::-webkit-scrollbar when (@scrollbar-dark-width = auto) {
+            width: 14px;
+        }
+        ::-webkit-scrollbar when (@scrollbar-dark-width = thin) {
             width: 6px;
         }
 
         ::-webkit-scrollbar-track {
-            background-color: @color-dark-border;
+            background-color: @color-dark-scrollbar-track;
         }
 
         ::-webkit-scrollbar-thumb {
-            background-color: @color-dark-main;
+            background-color: @color-dark-scrollbar-thumb;
         }
     }
 
@@ -774,7 +777,7 @@ html.dark-mode {
         }
 
         .tox-menu {
-            scrollbar-width: thin;
+            scrollbar-width: @scrollbar-dark-width;
             background-color: @color-dark-popover-background;
             border-color: @color-dark-popover-border;
             box-shadow: none;
@@ -782,7 +785,7 @@ html.dark-mode {
 
         .tox-dialog__body-nav,
         .tox-collection__group {
-            scrollbar-width: thin;
+            scrollbar-width: @scrollbar-dark-width;
         }
 
         .tox-collection__item-caret svg {
@@ -978,7 +981,7 @@ html.dark-mode {
     }
 
     .ui-menu {
-        scrollbar-width: thin;
+        scrollbar-width: @scrollbar-dark-width;
         background-color: @color-dark-popover-background;
         border-color: @color-dark-popover-border;
         box-shadow: none;

--- a/skins/elastic/styles/global.less
+++ b/skins/elastic/styles/global.less
@@ -95,3 +95,27 @@ a {
         opacity: .5;
     }
 }
+
+/* Scrollbar styles */
+
+html {
+    scrollbar-color: @color-scrollbar-thumb @color-scrollbar-track;
+    scrollbar-width: @scrollbar-width;
+
+    &:not(.touch) {
+        ::-webkit-scrollbar when (@scrollbar-width = auto) {
+            width: 14px;
+        }
+        ::-webkit-scrollbar when (@scrollbar-width = thin) {
+            width: 6px;
+        }
+
+        ::-webkit-scrollbar-track {
+            background-color: @color-scrollbar-track;
+        }
+
+        ::-webkit-scrollbar-thumb {
+            background-color: @color-scrollbar-thumb;
+        }
+    }
+}

--- a/skins/elastic/styles/variables.less
+++ b/skins/elastic/styles/variables.less
@@ -53,6 +53,10 @@
 
 @mail-header-photo-height:              4rem;
 
+// Scrollbars
+@scrollbar-width:       auto; // 'auto' or 'thin'
+@scrollbar-dark-width:  thin; // 'auto' or 'thin'
+
 // Additional icons
 @icon-resize-corner:    data-uri("image/svg+xml;charset=utf-8", "../images/corner-handle.svg"); // size: 16x16
 @icon-file-drop:        data-uri("image/svg+xml;charset=utf-8", "../images/download.svg");

--- a/skins/elastic/styles/widgets/common.less
+++ b/skins/elastic/styles/widgets/common.less
@@ -239,6 +239,20 @@ fieldset.image-attachment {
     bottom: @layout-header-height;
 }
 
+textarea,
+select,
+.popover-body,
+.popupmenu,
+.ui-dialog-content,
+.frame-content,
+.formcontent,
+.table-responsive,
+.table-responsive-sm,
+.scroller {
+    // Firefox does not inherit scrollbar size from the html element
+    scrollbar-width: @scrollbar-width;
+}
+
 // iOS: Fix scrolling of iframe, display scrollbars on scrollable elements
 .ios-scroll {
     padding: 0;

--- a/skins/elastic/styles/widgets/editor.less
+++ b/skins/elastic/styles/widgets/editor.less
@@ -82,6 +82,12 @@ div.tox {
         background-color: @color-dialog-overlay-background;
     }
 
+    .tox-menu,
+    .tox-dialog__body-nav,
+    .tox-collection__group {
+        scrollbar-width: @scrollbar-width;
+    }
+
     .tox-dialog__header {
         height: (@layout-header-height - 1px);
         border-bottom: 1px solid @color-dialog-header-border;

--- a/skins/elastic/styles/widgets/jqueryui.less
+++ b/skins/elastic/styles/widgets/jqueryui.less
@@ -33,6 +33,7 @@
     border-radius: .3rem;
     z-index: 240;
     position: absolute;
+    scrollbar-width: @scrollbar-width;
 
    .ui-state-active {
         border: 0 !important;


### PR DESCRIPTION
possible solution for #8309 rather than adding any new settings the `scrollbar-width` CSS value could be moved to a Less variable `@scrollbar-dark-width` and then it can be overridden/customized like any other for specific requirements.

while I was there I added scrollbar styles into light mode so they can be customized in the same way. Tested in Firefox and Edge.