### PR TITLE
Update 2020122900.sql

### DIFF
--- a/SQL/mysql/2020122900.sql
+++ b/SQL/mysql/2020122900.sql
@@ -1,1 +1,1 @@
---empty
+-- empty


### PR DESCRIPTION
Fix incorrect (comment) syntax.

Error:

> ERROR 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '--empty' at line 1