### PR TITLE
Fix regression in showing attachments (#8425).

### DIFF
--- a/program/lib/Roundcube/rcube_message.php
+++ b/program/lib/Roundcube/rcube_message.php
@@ -979,7 +979,7 @@ class rcube_message
                         // MS Outlook sends sometimes non-related attachments as related
                         // In this case multipart/related message has only one text part
                         // We'll add all such attachments to the attachments list
-                        if (!isset($this->got_html_part)) {
+                        if ($this->got_html_part === false) {
                             $this->add_part($inline_object, 'attachment');
                         }
                         // MS Outlook sometimes also adds non-image attachments as related


### PR DESCRIPTION
a5c2b4360c731aa7cdd8ddbfc866953cf366d5f3 started initializing
$this->got_html_part always but this check wasn't updated.

Fixes https://github.com/roundcube/roundcubemail/issues/8425