### PR TITLE
Add option in initdb.sh to update schema if already exists

### DIFF
--- a/bin/initdb.sh
+++ b/bin/initdb.sh
@@ -25,6 +25,7 @@ require_once INSTALL_PATH . 'program/include/clisetup.php';
 // get arguments
 $opts = rcube_utils::get_opt([
     'd' => 'dir',
+    'u' => 'update'
 ]);
 
 if (empty($opts['dir'])) {
@@ -36,4 +37,11 @@ if (!file_exists($opts['dir'])) {
     rcube::raise_error("Specified database schema directory doesn't exist.", false, true);
 }
 
-rcmail_utils::db_init($opts['dir']);
+$db = rcmail_utils::db();
+
+if (!empty($opts['update']) && in_array($db->table_name('system'), (array)$db->list_tables())) {
+    echo "Checking for database schema updates..." . PHP_EOL;
+    rcmail_utils::db_update($opts['dir'], 'roundcube', null, ['errors' => true]);
+} else {
+    rcmail_utils::db_init($opts['dir']);
+}


### PR DESCRIPTION
This can be used by the Docker images where we don't know whether the configured database is already initialized or not.

New suggestion for #8419