### PR TITLE
rcmail.php: Machine-readable Login Log (Security)

### DIFF
--- a/program/include/rcmail.php
+++ b/program/include/rcmail.php
@@ -1499,9 +1499,13 @@ class rcmail extends rcube
             if (strlen($user) > 256) {
                 $user = substr($user, 0, 256) . '...';
             }
-
-            $message = sprintf('Failed login for %s from %s in session %s (error: %d)',
-                $user, rcube_utils::remote_ip(), $session_id, $error_code);
+         
+            $message = sprintf("RC_LOGIN:FAILURE: %s", json_encode([
+                'user' => $user,
+                'ip' => rcube_utils::remote_ip(),
+                'error' => $error_code,
+                'sess' => $session_id
+            ]));
         }
         // successful login
         else {
@@ -1512,8 +1516,12 @@ class rcmail extends rcube
                 return;
             }
 
-            $message = sprintf('Successful login for %s (ID: %d) from %s in session %s',
-                $user_name, $user_id, rcube_utils::remote_ip(), $session_id);
+            $message = sprintf("RC_LOGIN:SUCCESS: %s", json_encode([
+                'user' => $user,
+                'ip' => rcube_utils::remote_ip(),
+                'user_id' => $user_id,
+                'sess' => $session_id
+            ]));
         }
 
         // log login


### PR DESCRIPTION
Proposal: Log the Login Success/Failure Log Messages in a JSON-readable fashion.

Rationale: fail2ban most likely never bans localhost. Localhost is trusted. However, in many installations, Dovecot (or another userauth subsystem) will log Roundcube logins as originating from the machine Roundcube runs on, probably localhost. Failed logins thru Roundcube thus result in being mistakenly considered as originating from "localhost" — which of course is not true, considering only Roundcube itself knows the true origin of the failed login attempt (`rcube_utils::remote_ip()`).

This change request patches rcmail.php to write more `grep` and other  machine-parse-friendly log messages, allowing for simpler extension of whatever fail2ban-like attack counter measures are in place. With this, one could even configure rsyslog to create own log files for Roundcube auth failures, based on the simple yet quite unique string `RC_LOGIN:FAILURE:` introduced here, again making it much easier for fail2ban to look in the right places.

{EDIT 2022-02-26 17:50 UTC} Test case with some problematic strings on PHP 5.5.21 (released 2015-01-22):
```php
<?php
$strings = [
    "test@moidrug.net",
    "test\x02@moidrug.net",
    "test\x02äöü@moidrug.net",
    "test\x02äöüƒ‚∂“¶“上海/虹桥≤@moidrug.net",
    "test\x02äöüƒ‚∂“🤩¶“≤上@moidrug.☣️"
];

foreach ($strings as $string) {
    printf("> %s\n", json_encode($string));
}
```
```
### OUTPUT:
> "test@moidrug.net"
> "test\u0002@moidrug.net"
> "test\u0002\u00e4\u00f6\u00fc@moidrug.net"
> "test\u0002\u00e4\u00f6\u00fc\u0192\u201a\u2202\u201c\u00b6\u201c\u4e0a\u6d77\/\u8679\u6865\u2264@moidrug.net"
> "test\u0002\u00e4\u00f6\u00fc\u0192\u201a\u2202\u201c\ud83e\udd29\u00b6\u201c\u2264\u4e0a@moidrug.\u2623\ufe0f"
```
 {/EDIT}

Example rsyslog config snippet (of course, RC needs to be configured to log to syslog):

```
if $programname contains 'roundcube' then {
    if $msg contains 'RC_LOGIN:FAILURE:' then {
        -/var/log/mail.err
        & stop
    }
}
```