### PR TITLE
Restore support for UNIX domain socket connections

### DIFF
--- a/program/lib/Roundcube/rcube_utils.php
+++ b/program/lib/Roundcube/rcube_utils.php
@@ -745,6 +745,10 @@ class rcube_utils
         $port   = $plain_port;
         $scheme = null;
 
+        if (!$url && str_starts_with($host, "unix://")) {
+            $port = -1;
+        }
+
         if (!empty($url['host'])) {
             $host   = $url['host'];
             $scheme = $url['scheme'] ?? null;


### PR DESCRIPTION
In <=1.5.x, it was possible to make Roundcube connect to UNIX
domain sockets by setting the host configuration options to, for
example, "unix:///var/run/dovecot/imap" and the port to -1.
https://github.com/roundcube/roundcubemail/commit/893216cb297268d222ae49099e6654a304b72e3f
introduced a new format for the connection string that includes the
port in the URL.  This broke support for domain sockets, however,
because the PHP parse_url() function cannot handle domain socket
URLs and returns false, which causes the default port (143) to be
used when it is necessary for port -1 to be used for domain
sockets.  To fix this, check to see if the result of parse_url() is
false and the URL starts with "unix://".  If both of those
conditions are true, set the port to -1.