### PR TITLE
Allow to set HTML Content-Transfer-Encoding based on UseMIMEfor 8bit

### DIFF
--- a/program/include/rcmail_sendmail.php
+++ b/program/include/rcmail_sendmail.php
@@ -279,7 +279,7 @@ class rcmail_sendmail
 
         // encoding settings for mail composing
         $message->setParam('text_encoding', $transfer_encoding);
-        $message->setParam('html_encoding', 'quoted-printable');
+        $message->setParam('html_encoding', $transfer_encoding);
         $message->setParam('head_encoding', $head_encoding);
         $message->setParam('head_charset', $this->options['charset']);
         $message->setParam('html_charset', $this->options['charset']);


### PR DESCRIPTION
[Original name "Allow to set HTML Content-Transfer-Encoding  by  "Use MIME for 8bit config setting]

I modified Content-Transfer-Encoding for HTML parts.   Previously it was hardcoded quoted-printable. Now it  is determined in same manner as for Text part.

**Is there any caveat in it?** I have Settings-Composing-Advanced:Use MIME for 8bit obviously off so it is effectively 8bit.


Allows to set Content-Transfer-Encoding for HTML part in similiar way as for Text part. (Based on Settings-Writing-Use MIME for 8bit)
If it is intentional (bugs in user agents...), please explain. According to my observations nearly everyone uses it and I think I should not be problematic, but I am not sure totally.