### PR TITLE
Update rcube_smtp.php : no more smtp authentification with CONFIG smtp_user smtp_pass values (issue #8507)

### DIFF
--- a/program/lib/Roundcube/rcube_smtp.php
+++ b/program/lib/Roundcube/rcube_smtp.php
@@ -179,10 +179,16 @@ class rcube_smtp
 
         if ($CONFIG['smtp_user'] == '%u') {
             $smtp_user = (string) $rcube->get_user_name();
+        } else {
+            $smtp_user = $CONFIG['smtp_user'];
         }
+
         if ($CONFIG['smtp_pass'] == '%p') {
             $smtp_pass = (string) $rcube->get_user_password();
+        } else {
+            $smtp_pass = $CONFIG['smtp_pass'];
         }
+
         $smtp_auth_type = $CONFIG['smtp_auth_type'] ?: null;
         $smtp_authz     = null;
 


### PR DESCRIPTION
Correction on the issue explain here : https://github.com/roundcube/roundcubemail/issues/8507

This is a big issue after the commit https://github.com/roundcube/roundcubemail/issues/8435 on file program/lib/Roundcube/rcube_smtp.php

No more smtp authentification when $CONFIG['smtp_user']) and $CONFIG['smtp_pass']) have user and pass value.

My analyze:
$smtp_user and $smtp_pass was never set again to $CONFIG['smtp_user']) and $CONFIG['smtp_pass']) if value is not %u or %p

Thanks.