### PR TITLE
Added link to logo image using $config['skin_logo']

### DIFF
--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -489,10 +489,12 @@ $config['blankpage_url'] = '/watermark.html';
 // is made up of (up to) 3 parts:
 // - skin name prefix (always with colon, can be replaced with *)
 // - template name (or * for all templates)
-// - logo type - it is used for logos used on multiple templates
-//   the available types include '[favicon]' for favicon, '[print]' for logo on all print
-//   templates (e.g. messageprint, contactprint) and '[small]' for small screen logo in supported skins
-//   '[dark]' and '[small-dark]' for dark mode logo in supported skins
+// - logo type - it is used for logos used on multiple templates and the available types include:
+//      '[favicon]' for favicon
+//      '[print]' for logo on all print templates (e.g. messageprint, contactprint)
+//      '[small]' for small screen logo in supported skins
+//      '[dark]' and '[small-dark]' for dark mode logo in supported skins
+//      '[link]' for adding a URL link to the logo image
 //
 // Example config for skin_logo
 /*
@@ -501,6 +503,12 @@ $config['blankpage_url'] = '/watermark.html';
      "elastic:login[small]" => "/images/logo_login_small.png",
      // show the image /images/logo_login.png for the Login screen in the Elastic skin
      "elastic:login" => "/images/logo_login.png",
+     // add a link to the logo on the Login screen in the Elastic skin
+     "elastic:login[link]" => "https://www.example.com",
+     // add a link to the logo on all screens in the Elastic skin
+     "elastic:*[link]" => "https://www.example.com",
+     // add a link to the logo on all screens for all skins
+     "[link]" => "https://www.example.com",
      // show the image /images/logo_small.png in the Elastic skin
      "elastic:*[small]" => "/images/logo_small.png",
      // show the image /images/larry.png in the Larry skin

--- a/program/include/rcmail_output_html.php
+++ b/program/include/rcmail_output_html.php
@@ -1501,6 +1501,11 @@ EOF;
                         $attrib['src'] = $template_logo;
                     }
 
+                    if (($link = $this->get_template_logo('link')) !== null) {
+                        $attrib['onclick'] = "location.href='$link';";
+                        $attrib['style'] = 'cursor:pointer;';
+                    }
+
                     $additional_logos = [];
                     $logo_types       = (array) $this->config->get('additional_logo_types');
 


### PR DESCRIPTION
Works by defining the `logo type` for $config['skin_logo'] as `[link]` for example:

    $config['skin_logo'] = ['elastic:*[link]' => 'https://www.example.com'];
    $config['skin_logo'] = ['[link]' => 'https://www.example.com'];

Same relative path rules apply as when you define location of logo image file.
Starting with `http://` or `https://` is absolute.
Starting with a slash `/page.html` is relative to the skin directory ie `example.com/skins/elastic/page.html`
Starting without a slash `page.html` is relative to the website root directory ie `example.com/page.html`
