### PR TITLE
Fix SIGBUS raised in ImageMagick extension

### DIFF
--- a/program/actions/mail/get.php
+++ b/program/actions/mail/get.php
@@ -95,7 +95,7 @@ class rcmail_action_mail_get extends rcmail_action_mail_index
             $cache_file     = rcube_utils::temp_filename($thumb_name, false, false);
 
             // render thumbnail image if not done yet
-            if (!is_file($cache_file) && $attachment->body_to_file($orig_name = $cache_file . '.tmp')) {
+            if (!is_file($cache_file) && $attachment->body_to_file($orig_name = rcube_utils::temp_filename('attmnt'))) {
                 $image = new rcube_image($orig_name);
 
                 if ($imgtype = $image->resize($thumbnail_size, $cache_file, true)) {


### PR DESCRIPTION
When several processess try to render JPG image thumbnail simultaneously, there is propability for one of them to get killed with SIGBUS signal. I noticed following messages in apache error log and investigated a problem:

[Wed Mar 30 11:04:35.341295 2022] [core:notice] [pid 380:tid 139845588080576] AH00052: child pid 20333 exit signal Bus error (7)
[Wed Mar 30 11:04:56.364609 2022] [core:notice] [pid 380:tid 139845588080576] AH00052: child pid 20343 exit signal Bus error (7)
[Tue Mar 29 12:16:35.320405 2022] [core:notice] [pid 380:tid 139845588080576] AH00052: child pid 20639 exit signal Bus error (7)
[Tue Mar 29 10:11:27.187306 2022] [core:notice] [pid 380:tid 139845588080576] AH00052: child pid 20640 exit signal Bus error (7)

Signal was raised in function rcube_image->resize, while is was constructing Imagick object. Function was called from rcmail_action_mail_get->run. Problem appears when imagick tries to read source image from temporary file, while it is being overwritten by another process, doing same thing. This is possible when thumbnail is already being generated, but thumbnail file still doesn't exists. I encountered such behaviour only dealing with JPG images, but other formats may also be affected. 

Using unique filename for temporary file eliminates this issue.