### PR TITLE
Fix bug where addresses array in managesieve plugin is assumed to be string

### DIFF
--- a/plugins/managesieve/lib/Roundcube/rcube_sieve_vacation.php
+++ b/plugins/managesieve/lib/Roundcube/rcube_sieve_vacation.php
@@ -188,7 +188,7 @@ class rcube_sieve_vacation extends rcube_sieve_engine
         $from          = rcube_utils::get_input_string('vacation_from', rcube_utils::INPUT_POST, true);
         $subject       = rcube_utils::get_input_string('vacation_subject', rcube_utils::INPUT_POST, true);
         $reason        = rcube_utils::get_input_string('vacation_reason', rcube_utils::INPUT_POST, true);
-        $addresses     = rcube_utils::get_input_array('vacation_addresses', rcube_utils::INPUT_POST, true);
+        $addresses     = rcube_utils::get_input_value('vacation_addresses', rcube_utils::INPUT_POST, true);
         $interval      = rcube_utils::get_input_string('vacation_interval', rcube_utils::INPUT_POST);
         $interval_type = rcube_utils::get_input_string('vacation_interval_type', rcube_utils::INPUT_POST);
         $date_from     = rcube_utils::get_input_string('vacation_datefrom', rcube_utils::INPUT_POST);

--- a/plugins/managesieve/lib/Roundcube/rcube_sieve_vacation.php
+++ b/plugins/managesieve/lib/Roundcube/rcube_sieve_vacation.php
@@ -188,7 +188,7 @@ class rcube_sieve_vacation extends rcube_sieve_engine
         $from          = rcube_utils::get_input_string('vacation_from', rcube_utils::INPUT_POST, true);
         $subject       = rcube_utils::get_input_string('vacation_subject', rcube_utils::INPUT_POST, true);
         $reason        = rcube_utils::get_input_string('vacation_reason', rcube_utils::INPUT_POST, true);
-        $addresses     = rcube_utils::get_input_string('vacation_addresses', rcube_utils::INPUT_POST, true);
+        $addresses     = rcube_utils::get_input_array('vacation_addresses', rcube_utils::INPUT_POST, true);
         $interval      = rcube_utils::get_input_string('vacation_interval', rcube_utils::INPUT_POST);
         $interval_type = rcube_utils::get_input_string('vacation_interval_type', rcube_utils::INPUT_POST);
         $date_from     = rcube_utils::get_input_string('vacation_datefrom', rcube_utils::INPUT_POST);

--- a/program/lib/Roundcube/rcube_utils.php
+++ b/program/lib/Roundcube/rcube_utils.php
@@ -286,24 +286,6 @@ class rcube_utils
     }
 
     /**
-     * Read input value and make sure it is an array.
-     *
-     * @param string $fname      Field name to read
-     * @param int    $source     Source to get value from (see self::INPUT_*)
-     * @param bool   $allow_html Allow HTML tags in field value
-     * @param string $charset    Charset to convert into
-     *
-     * @return array Request parameter value
-     * @see self::get_input_value()
-     */
-    public static function get_input_array($fname, $source, $allow_html = false, $charset = null)
-    {
-        $value = self::get_input_value($fname, $source, $allow_html, $charset);
-
-        return is_array($value) ? $value : '';
-    }
-
-    /**
      * Read request parameter value and convert it for internal use
      * Performs stripslashes() and charset conversion if necessary
      *

--- a/program/lib/Roundcube/rcube_utils.php
+++ b/program/lib/Roundcube/rcube_utils.php
@@ -286,6 +286,24 @@ class rcube_utils
     }
 
     /**
+     * Read input value and make sure it is an array.
+     *
+     * @param string $fname      Field name to read
+     * @param int    $source     Source to get value from (see self::INPUT_*)
+     * @param bool   $allow_html Allow HTML tags in field value
+     * @param string $charset    Charset to convert into
+     *
+     * @return array Request parameter value
+     * @see self::get_input_value()
+     */
+    public static function get_input_array($fname, $source, $allow_html = false, $charset = null)
+    {
+        $value = self::get_input_value($fname, $source, $allow_html, $charset);
+
+        return is_array($value) ? $value : '';
+    }
+
+    /**
      * Read request parameter value and convert it for internal use
      * Performs stripslashes() and charset conversion if necessary
      *


### PR DESCRIPTION
When submitting the form for a vacation message in the managesieve plugin, the $addresses variable is an array (name="vacation_addresses[]" in the html) but is erroneously assumed to be a string and run through get_input_string(). This will always fail and return an empty string instead of the expected array.

This PR adds a get_input_array() function to rcube_utils.php and changes rcube_sieve_vacation.php to use the new function.