### PR TITLE
contact_exists must call idn_to_utf8 to be consistent with contact_create

### DIFF
--- a/program/include/rcmail.php
+++ b/program/include/rcmail.php
@@ -1401,6 +1401,8 @@ class rcmail extends rcube
             return false;
         }
 
+        $email = rcube_utils::idn_to_utf8($email);
+
         // TODO: Support TYPE_READONLY filter
         $sources = [];
 


### PR DESCRIPTION
```rcmail::contact_create``` converts the input address to UTF-8 via ```rcube_utils::idn_to_utf8```, but ```rcmail::contact_exists``` doesn't. This can result in SQL errors in ```rcmail_sendmail::collect_recipients``` due to duplicate address insertion attempts when ```contact_exists``` erroneously returns false.