### PR TITLE
Fix erroneous stripping of non-Latin trailing letter from recipient addresses

### DIFF
--- a/program/include/rcmail_sendmail.php
+++ b/program/include/rcmail_sendmail.php
@@ -769,7 +769,7 @@ class rcmail_sendmail
             // address without brackets and without name (add brackets)
             else if (preg_match('/^'.$email_regexp.'$/', $item)) {
                 // Remove trailing non-letter characters (#7899)
-                $item     = preg_replace('/[^a-zA-Z]$/', '', $item);
+                $item     = preg_replace('/[^\p{L}0-9]$/u', '', $item);
                 $item     = rcube_utils::idn_to_ascii($item);
                 $result[] = $item;
             }


### PR DESCRIPTION
This PR fixes issue #8493, which was apparently closed for political reasons despite being a valid issue and a fix having been proposed in the issue thread.

This issue affects all addresses with IDN top-level domains, see [Internationalized ccTLDs](https://en.wikipedia.org/wiki/Country_code_top-level_domain#Internationalized_ccTLDs) for a complete list.

**Expected behavior:** email addresses with IDN ccTLDs (written in raw form without brackets) get parsed successfully.
**Actual behavior:** email addresses with IDN ccTLDs get silently discarded from the recipient list. If there are no more recipients left, the error message "No valid recipients" is displayed.

Problem introduced when fixing #7899 due to a regexp stripping non-Latin letter character from the end of the recipient address. The ```preg_replace``` call appears to treat the input UTF-8 string as ASCII, sees invalid data, and can corrupt the string as a result.

**Proposed solution:** Use [Unicode property escapes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Unicode_Property_Escapes) to scan for letters from all languages while removing the trailing character. Further research also indicates that [theoretically](https://stackoverflow.com/a/53875771), a digit can also be a part of a valid domain name, so a trailing digit, if present, should also not be stripped. Note that stripping the trailing character _after_ UTF-8 to Punycode conversion is not desirable due to the possibility of said character switching places.

I would also like to note that apparently, the original intent was to correct addresses containing trailing _dots_, but the original code (and hence this PR) does more than that (removes _any invalid trailing character_ instead of just the dot). Perhaps it would be best to change the regexp to scan only for dots instead, but I'll let the dev team be the judge of that. I'm just proposing a fix for the current algorithm, nothing more.

Additionally, it appears that bug #7899 has not been actually fixed (or has resurfaced again): if I enter "user@domain.com." into the recipient field, Roundcube tells me "Please enter at least one recipient" without actually performing any network requests. This indicates that the client-side JavaScript has likely not been updated to deal with this issue (as of 1.5.2; unstable builds not tested).