### PR TITLE
Fix possibly incorrect usage of "break"

### DIFF
--- a/program/lib/Roundcube/rcube_imap.php
+++ b/program/lib/Roundcube/rcube_imap.php
@@ -157,7 +157,7 @@ class rcube_imap extends rcube_storage
             $data = $this->plugins->exec_hook('storage_connect', array_merge($this->options, $data));
 
             if ($attempt > 1 && !$data['retry']) {
-                $break;
+                break;
             }
 
             if (!empty($data['pass'])) {


### PR DESCRIPTION
Hi,

I stumbled upon this `$break;` statement and I can't figure out what it's supposed to do. I think this is an error and should be `break;` instead of `$break;`. The variable is never declared in the function itself and I can't seem to find any reference.

May have been introduced by #7844