### PR TITLE
Add public_html to list of updated directories

### DIFF
--- a/bin/installto.sh
+++ b/bin/installto.sh
@@ -58,7 +58,7 @@ if (strtolower($input) == 'y') {
     echo "Copying files to target location...";
 
     $adds = [];
-    $dirs = ['bin','SQL','plugins','skins','program'];
+    $dirs = ['bin','SQL','plugins','skins','program','public_html'];
 
     if (is_dir(INSTALL_PATH . 'vendor') && !is_file("$target_dir/composer.json")) {
         $dirs[] = 'vendor';


### PR DESCRIPTION
This ensures that older installations get the `public_html` folder on update and that it is kept up-to-date.