### PR TITLE
Initialize HTTP client using get_http_client() for OAuth requests

### DIFF
--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -358,6 +358,9 @@ $config['oauth_token_uri'] = null;
 // Optional: Endpoint to query user identity if not provided in auth response
 $config['oauth_identity_uri'] = null;
 
+// Optional: timeout for HTTP requests to OAuth server
+$config['oauth_timeout'] = 10;
+
 // Optional: disable SSL certificate check on HTTP requests to OAuth server
 // See http://docs.guzzlephp.org/en/stable/request-options.html#verify for possible values
 $config['oauth_verify_peer'] = true;

--- a/program/include/rcmail_oauth.php
+++ b/program/include/rcmail_oauth.php
@@ -17,7 +17,6 @@
  +-----------------------------------------------------------------------+
 */
 
-use GuzzleHttp\Client;
 use GuzzleHttp\MessageFormatter;
 use GuzzleHttp\Exception\RequestException;
 
@@ -219,8 +218,7 @@ class rcmail_oauth
                 }
 
                 // send token request to get a real access token for the given auth code
-                $client = new Client([
-                    'timeout' => 10.0,
+                $client = rcube::get_instance()->get_http_client([
                     'verify' => $this->options['verify_peer'],
                 ]);
 
@@ -366,8 +364,7 @@ class rcmail_oauth
 
         // send token request to get a real access token for the given auth code
         try {
-            $client = new Client([
-                'timeout' => 10.0,
+            $client = rcube::get_instance()->get_http_client([
                 'verify' => $this->options['verify_peer'],
             ]);
             $response = $client->post($oauth_token_uri, [

--- a/program/include/rcmail_oauth.php
+++ b/program/include/rcmail_oauth.php
@@ -75,6 +75,7 @@ class rcmail_oauth
             'identity_uri'    => $this->rcmail->config->get('oauth_identity_uri'),
             'identity_fields' => $this->rcmail->config->get('oauth_identity_fields', ['email']),
             'scope'           => $this->rcmail->config->get('oauth_scope'),
+            'timeout'     => $this->rcmail->config->get('oauth_timeout', 10),
             'verify_peer'     => $this->rcmail->config->get('oauth_verify_peer', true),
             'auth_parameters' => $this->rcmail->config->get('oauth_auth_parameters', []),
             'login_redirect'  => $this->rcmail->config->get('oauth_login_redirect', false),
@@ -219,6 +220,7 @@ class rcmail_oauth
 
                 // send token request to get a real access token for the given auth code
                 $client = rcube::get_instance()->get_http_client([
+                    'timeout' => $this->options['timeout'],
                     'verify' => $this->options['verify_peer'],
                 ]);
 
@@ -365,6 +367,7 @@ class rcmail_oauth
         // send token request to get a real access token for the given auth code
         try {
             $client = rcube::get_instance()->get_http_client([
+                'timeout' => $this->options['timeout'],
                 'verify' => $this->options['verify_peer'],
             ]);
             $response = $client->post($oauth_token_uri, [


### PR DESCRIPTION
Hi, I noticed OAuth outgoing requests are not using the `get_http_client()` helper method, which means any options defined in `$config['http_client']` are not honored (e.g. custom proxy).

This PR switches from initializing a `GuzzleHttp\Client` from scratch to using the aforementioned method when dealing with OAuth requests.