### PR TITLE
Restore support for ManageSieve over implicit SSL

### DIFF
--- a/plugins/managesieve/config.inc.php.dist
+++ b/plugins/managesieve/config.inc.php.dist
@@ -8,7 +8,8 @@
 // For example %n = mail.domain.tld, %d = domain.tld
 // If port is omitted it will be determined automatically using getservbyname()
 // function, with 4190 as a fallback.
-// Note: Add tls:// prefix to enable TLS
+// Note: Add tls:// prefix to enable explicit STARTTLS
+// or add ssl:// prefix to enable implicit SSL.
 $config['managesieve_host'] = 'localhost';
 
 // authentication method. Can be CRAM-MD5, DIGEST-MD5, PLAIN, LOGIN, EXTERNAL

--- a/plugins/managesieve/lib/Roundcube/rcube_sieve_engine.php
+++ b/plugins/managesieve/lib/Roundcube/rcube_sieve_engine.php
@@ -184,7 +184,13 @@ class rcube_sieve_engine
 
         list($host, $scheme, $port) = rcube_utils::parse_host_uri($plugin['host']);
 
+        // Support explicit STARTTLS by establishing an unencrypted TCP connection, then instructing Net_Sieve to send the `STARTTLS` command.
         $tls = $scheme === 'tls';
+
+        // Support implicit SSL by passing the URI scheme through to Net_Sieve -> Net_Socket -> stream_socket_client().
+        if ($scheme === 'ssl') {
+            $host = 'ssl://' . $host;
+        }
 
         if (empty($port)) {
             $port = getservbyname('sieve', 'tcp') ?: self::PORT;


### PR DESCRIPTION
Prior to #8310 (893216cb297268d222ae49099e6654a304b72e3f), it was possible to connect to ManageSieve over implicit SSL using a config like this:
```php
$config['managesieve_host'] = 'ssl://mail-0.local:4190';
```
(See https://github.com/roundcube/roundcubemail/issues/7127#issuecomment-568284068 for example.)

Roundcube's ManageSieve plugin would leave the host's `ssl://` prefix intact, and pass it through to `Net_Sieve`, to `Net_Socket`, and finally to PHP's `stream_socket_client()` `$address` argument.  But as of #8310 (893216cb297268d222ae49099e6654a304b72e3f), it now strips off the `ssl://` URI scheme, so `stream_socket_client()` doesn't know that it should implicitly perform the SSL handshake.

This PR restores support for implicit SSL connections by preserving the `ssl://` URI scheme, and mentions support for it in the example config.  I've tested this locally using Dovecot Pigeonhole.