### PR TITLE
Composer allow plugins - backport 5d7acdd12 to release-1.4

### DIFF
--- a/composer.json-dist
+++ b/composer.json-dist
@@ -27,5 +27,10 @@
     "suggest": {
         "kolab/net_ldap3": "~1.1.1 required for connecting to LDAP",
         "mkopinsky/zxcvbn-php": "^4.4.2 required for Zxcvbn password strength driver"
+    },
+    "config": {
+        "allow-plugins": {
+            "roundcube/plugin-installer": true
+        }
     }
 }


### PR DESCRIPTION
Add plugin-installer to allowed-plugins

So we skip the confirmaton question with new composer versions.

(cherry picked from commit 8bd31c54218971da24e6e9ba268dfb16feef1829)