### PR TITLE
Add password driver for the gandi.net mail API

### DIFF
--- a/plugins/password/README
+++ b/plugins/password/README
@@ -53,6 +53,7 @@
  2.1.27. dovecot_passwdfile
  2.1.28. Mailcow
  2.1.29. LDAP Samba Active Directory (ldap_samba_ad)
+ 2.1.30  gandi (gandi.net mail-API)
  2.2.    Password Strength Drivers
  2.2.1.  Zxcvbn
  2.2.2.  Have I been pwned? (pwned)
@@ -425,6 +426,21 @@
 
  Password change via LDAP unicodePwd attribute supported by Active Directory.
  Uses configuration for other LDAP drivers.
+
+
+ 2.1.30 gandi
+ ---------------------------
+ 
+ Driver to change the user's password via gandi.net mail-API. A password driver is also
+ included that checks the password strength according to the official gandi.net documentation.
+ See https://api.gandi.net/docs/email/ for more information.
+
+ In order to work, the following configuration options must be set appropriately:
+ Password driver:
+    * password_username_format = %u
+    * password_algorithm = sha512-crypt
+ Password strength driver:
+    * password_minimum_score = 2
 
 
  2.2. Password Strength Drivers

--- a/plugins/password/README
+++ b/plugins/password/README
@@ -428,7 +428,7 @@
  Uses configuration for other LDAP drivers.
 
 
- 2.1.30 gandi
+ 2.1.30. gandi
  ---------------------------
  
  Driver to change the user's password via gandi.net mail-API. A password driver is also

--- a/plugins/password/README
+++ b/plugins/password/README
@@ -53,7 +53,7 @@
  2.1.27. dovecot_passwdfile
  2.1.28. Mailcow
  2.1.29. LDAP Samba Active Directory (ldap_samba_ad)
- 2.1.30  gandi (gandi.net mail-API)
+ 2.1.30. gandi (gandi.net mail-API)
  2.2.    Password Strength Drivers
  2.2.1.  Zxcvbn
  2.2.2.  Have I been pwned? (pwned)

--- a/plugins/password/config.inc.php.dist
+++ b/plugins/password/config.inc.php.dist
@@ -514,7 +514,7 @@ $config['password_dovecot_passwdfile_path'] = '/etc/mail/imap.passwd';
 $config['password_mailcow_api_host'] = 'localhost';
 $config['password_mailcow_api_token'] = '';
 
-<?php
+
 // GANDI-API Driver options
 // ------------------------
 // In order to work, the following configuration options must be set appropriately:
@@ -525,15 +525,14 @@ $config['password_mailcow_api_token'] = '';
 // Password strength driver:
 //   - password_minimum_score = 2
 //
-//
 // The domain-to-API key configuration required for authentication.
-// Can be either the absolute path to a JSON file, or an array which
-// contains the key-value mapping.
+// Can be either the absolute path to a JSON file, or an array
+// containing the key-value mapping.
 //
-// Examples: 
+// Examples:
 // (1) $config['password_gandi_apikeys'] = '/absolute/path/to/somewhere';
 // (2) $config['password_gandi_apikeys'] = array(
 //         'example.com' => 'first-api-key',
 //         'foo.com' => 'second-api-key',
-//     );
+// Note: For security reasons, it is recommended to use the first option.
 $config['password_gandi_apikeys'] = null;

--- a/plugins/password/config.inc.php.dist
+++ b/plugins/password/config.inc.php.dist
@@ -517,16 +517,16 @@ $config['password_mailcow_api_token'] = '';
 
 // GANDI-API Driver options
 // ------------------------
-// The domain-to-API key configuration required for authentication.
+// The domain-to-personal-access-token configuration required for authentication.
 // This can take various forms depending on your needs.
-//     (1) The raw API-key or an array containing the key-value mapping.
-//         $config['password_gandi_apikeys'] = 'your-api-key';
-//         $config['password_gandi_apikeys'] = array(
-//             'example.com' => 'first-api-key',
-//             'foo.com' => 'second-api-key',
+//     (1) The raw Personal Access Token (PAT) or an array containing the key-value mapping.
+//         $config['password_gandi_pats'] = 'your-pat';
+//         $config['password_gandi_pats'] = array(
+//             'example.com' => 'first-pat',
+//             'foo.com' => 'second-pat',
 //         );
-//     (2) The absolute path to a file containing either the raw API-key or a key-value mapping in JSON format.
-//         $config['password_gandi_apikeys'] = '/absolute/path/to/somewhere';
+//     (2) The absolute path to a file containing either the raw Personal Access Token (PAT) or a key-value mapping in JSON format.
+//         $config['password_gandi_pats'] = '/absolute/path/to/somewhere';
 //
 // Note: For security reasons, it is recommended to use the second option.
-$config['password_gandi_apikeys'] = null;
+$config['password_gandi_pats'] = null;

--- a/plugins/password/config.inc.php.dist
+++ b/plugins/password/config.inc.php.dist
@@ -518,14 +518,15 @@ $config['password_mailcow_api_token'] = '';
 // GANDI-API Driver options
 // ------------------------
 // The domain-to-API key configuration required for authentication.
-// Can be either the absolute path to a JSON file, or an array
-// containing the key-value mapping.
+// This can take various forms depending on your needs.
+//     (1) The raw API-key or an array containing the key-value mapping.
+//         $config['password_gandi_apikeys'] = 'your-api-key';
+//         $config['password_gandi_apikeys'] = array(
+//             'example.com' => 'first-api-key',
+//             'foo.com' => 'second-api-key',
+//         );
+//     (2) The absolute path to a file containing either the raw API-key or a key-value mapping in JSON format.
+//         $config['password_gandi_apikeys'] = '/absolute/path/to/somewhere';
 //
-// Examples:
-// (1) $config['password_gandi_apikeys'] = '/absolute/path/to/somewhere';
-// (2) $config['password_gandi_apikeys'] = array(
-//         'example.com' => 'first-api-key',
-//         'foo.com' => 'second-api-key',
-//
-// Note: For security reasons, it is recommended to use the first option.
+// Note: For security reasons, it is recommended to use the second option.
 $config['password_gandi_apikeys'] = null;

--- a/plugins/password/config.inc.php.dist
+++ b/plugins/password/config.inc.php.dist
@@ -517,16 +517,16 @@ $config['password_mailcow_api_token'] = '';
 
 // GANDI-API Driver options
 // ------------------------
-// The domain-to-personal-access-token configuration required for authentication.
+// The domain-to-personal-access-token/domain-to-api-key configuration required for authentication.
 // This can take various forms depending on your needs.
-//     (1) The raw Personal Access Token (PAT) or an array containing the key-value mapping.
-//         $config['password_gandi_pats'] = 'your-pat';
-//         $config['password_gandi_pats'] = array(
-//             'example.com' => 'first-pat',
-//             'foo.com' => 'second-pat',
+//     (1) The raw Personal-Access-Token/API-key or an array containing the key-value mapping.
+//         $config['password_gandi_keys'] = 'your-personal-access-token-or-api-key';
+//         $config['password_gandi_keys'] = array(
+//             'example.com' => 'first-personal-access-token-or-api-key',
+//             'foo.com' => 'second-personal-access-token-or-api-key',
 //         );
-//     (2) The absolute path to a file containing either the raw Personal Access Token (PAT) or a key-value mapping in JSON format.
-//         $config['password_gandi_pats'] = '/absolute/path/to/somewhere';
+//     (2) The absolute path to a file containing either the raw Personal-Access-Token/API-key or a key-value mapping in JSON format.
+//         $config['password_gandi_keys'] = '/absolute/path/to/somewhere';
 //
 // Note: For security reasons, it is recommended to use the second option.
-$config['password_gandi_pats'] = null;
+$config['password_gandi_keys'] = null;

--- a/plugins/password/config.inc.php.dist
+++ b/plugins/password/config.inc.php.dist
@@ -520,7 +520,6 @@ $config['password_mailcow_api_token'] = '';
 // In order to work, the following configuration options must be set appropriately:
 // Password driver:
 //   - password_username_format = %u
-//   - password_minimum_length >= 8
 //   - password_algorithm = sha512-crypt
 // Password strength driver:
 //   - password_minimum_score = 2

--- a/plugins/password/config.inc.php.dist
+++ b/plugins/password/config.inc.php.dist
@@ -513,3 +513,27 @@ $config['password_dovecot_passwdfile_path'] = '/etc/mail/imap.passwd';
 // ----------------------
 $config['password_mailcow_api_host'] = 'localhost';
 $config['password_mailcow_api_token'] = '';
+
+<?php
+// GANDI-API Driver options
+// ------------------------
+// In order to work, the following configuration options must be set appropriately:
+// Password driver:
+//   - password_username_format = %u
+//   - password_minimum_length >= 8
+//   - password_algorithm = sha512-crypt
+// Password strength driver:
+//   - password_minimum_score = 2
+//
+//
+// The domain-to-API key configuration required for authentication.
+// Can be either the absolute path to a JSON file, or an array which
+// contains the key-value mapping.
+//
+// Examples: 
+// (1) $config['password_gandi_apikeys'] = '/absolute/path/to/somewhere';
+// (2) $config['password_gandi_apikeys'] = array(
+//         'example.com' => 'first-api-key',
+//         'foo.com' => 'second-api-key',
+//     );
+$config['password_gandi_apikeys'] = null;

--- a/plugins/password/config.inc.php.dist
+++ b/plugins/password/config.inc.php.dist
@@ -517,13 +517,6 @@ $config['password_mailcow_api_token'] = '';
 
 // GANDI-API Driver options
 // ------------------------
-// In order to work, the following configuration options must be set appropriately:
-// Password driver:
-//   - password_username_format = %u
-//   - password_algorithm = sha512-crypt
-// Password strength driver:
-//   - password_minimum_score = 2
-//
 // The domain-to-API key configuration required for authentication.
 // Can be either the absolute path to a JSON file, or an array
 // containing the key-value mapping.
@@ -533,5 +526,6 @@ $config['password_mailcow_api_token'] = '';
 // (2) $config['password_gandi_apikeys'] = array(
 //         'example.com' => 'first-api-key',
 //         'foo.com' => 'second-api-key',
+//
 // Note: For security reasons, it is recommended to use the first option.
 $config['password_gandi_apikeys'] = null;

--- a/plugins/password/drivers/gandi.php
+++ b/plugins/password/drivers/gandi.php
@@ -198,7 +198,7 @@ class rcube_gandi_password
                                                            'specialchars' => self::GANDI_PASS_AMOUNT_SCHARS,
                                                           ],
                                                ],
-                                       ); 
+                                       );
     }
 
 
@@ -229,7 +229,7 @@ class rcube_gandi_password
 
             // try to parse json
             $json = json_decode($file, true);
-            
+
             // try to assign the api-key appropriately and return on failure
             if (json_last_error() === JSON_ERROR_NONE && is_array($json)) {
                 $apikey = $json[$domain];

--- a/plugins/password/drivers/gandi.php
+++ b/plugins/password/drivers/gandi.php
@@ -57,17 +57,15 @@ class rcube_gandi_password
     {
         // get configuration
         $passformat = rcmail::get_instance()->config->get('password_username_format');
-        $minpasslength = rcmail::get_instance()->config->get('password_minimum_length');
         $passalgo = rcmail::get_instance()->config->get('password_algorithm');
         $apikey = rcmail::get_instance()->config->get('password_gandi_apikeys');
         $userdom = explode('@', $username);
 
         // log error and return if config is invalid
-        if (strcmp($passformat, '%u') !== 0 || is_int($minpasslength) === false || $minpasslength < self::GANDI_MIN_PASS_LENGTH
-         || $minpasslength > (self::GANDI_MAX_PASS_LENGTH - self::GANDI_MIN_PASS_LENGTH) || strcasecmp($passalgo, self::PASSWORD_ALGO) !== 0 || empty($apikey)) {
+        if (strcmp($passformat, '%u') !== 0 || strcasecmp($passalgo, self::PASSWORD_ALGO) !== 0 || empty($apikey)) {
             rcube::raise_error([
                     'code' => 600, 'file' => __FILE__, 'line' => __LINE__,
-                    'message' => "Password plugin: Invalid configuration option for 'password_username_format', 'password_minimum_length', 'password_algorithm' or 'password_gandi_apikeys'. Refer to the README for more information.",
+                    'message' => "Password plugin: Invalid configuration option for 'password_username_format', 'password_algorithm' or 'password_gandi_apikeys'. Refer to the README for more information.",
                 ],
                 true, false
             );
@@ -257,16 +255,20 @@ class rcube_gandi_password
             ),
         ));
 
-        // read and parse response
+        // read response
         $response = curl_exec($curl);
         $err = curl_error($curl);
-        $json = json_decode(trim($response, '[]'), true);
 
         // return if failed
         if ($err) {
             return array('code' => PASSWORD_CONNECT_ERROR, 'msg' => $err);
         }
-        else if (json_last_error() !== JSON_ERROR_NONE) {
+
+        // try to parse JSON
+        $json = json_decode(trim($response, '[]'), true);
+
+        // return if failed
+        if (json_last_error() !== JSON_ERROR_NONE) {
             return array('code' => PASSWORD_ERROR, 'msg' => 'Failed to parse JSON.');
         }
         else if (empty($json['id'])) {
@@ -301,16 +303,20 @@ class rcube_gandi_password
             ),
         ));
 
-        // read and parse response
+        // read response
         $response = curl_exec($curl);
         $err = curl_error($curl);
-        $json = json_decode(trim($response, '[]'), true);
 
         // return if failed
         if ($err) {
             return array('code' => PASSWORD_CONNECT_ERROR, 'msg' => $err);
         }
-        else if (json_last_error() !== JSON_ERROR_NONE) {
+
+        // try to parse JSON
+        $json = json_decode(trim($response, '[]'), true);
+
+        // return if failed
+        if (json_last_error() !== JSON_ERROR_NONE) {
             return array('code' => PASSWORD_ERROR, 'msg' => 'Failed to parse JSON.');
         }
         else if (empty($json['message']) || stripos($json['message'], self::GANDI_API_SUCCESS_MSG) === false) {

--- a/plugins/password/drivers/gandi.php
+++ b/plugins/password/drivers/gandi.php
@@ -279,7 +279,7 @@ class rcube_gandi_password
             CURLOPT_CUSTOMREQUEST => 'GET',
             CURLOPT_POSTFIELDS => "",
             CURLOPT_HTTPHEADER => array(
-                "authorization: Apikey ".$pat,
+                "authorization: Bearer ".$pat,
             ),
         ));
 

--- a/plugins/password/drivers/gandi.php
+++ b/plugins/password/drivers/gandi.php
@@ -132,7 +132,7 @@ class rcube_gandi_password
         curl_close($curl);
 
         // return result
-        return array('code' => $result['code'], message => $result['msg']);
+        return array('code' => $result['code'], 'message' => $result['msg']);
     }
 
     /**

--- a/plugins/password/drivers/gandi.php
+++ b/plugins/password/drivers/gandi.php
@@ -1,0 +1,322 @@
+<?php
+
+/**
+ * Roundcube password driver for gandi mail.
+ *
+ * This driver changes the e-mail password via the gandi mail API.
+ *
+ * @author Aaron Hermann
+ *
+ * Copyright (C) The Roundcube Dev Team
+ *
+ * Configuration can either be the absolute path to a JSON file,
+ * or an array which contains the key-value mapping:
+ * $config['password_gandi_apikeys'] = '/absolute/path/to/somewhere';
+ * $config['password_gandi_apikeys'] = array(
+ *     'example.com' => 'first-api-key',
+ *     'foo.com' => 'second-api-key',
+ * );
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+
+class rcube_gandi_password
+{
+    // constants
+    private const GANDI_MIN_PASS_LENGTH = 8;
+    private const GANDI_MAX_PASS_LENGTH = 200;
+    private const GANDI_MIN_PASS_NUMS = 3;
+    private const GANDI_API_URL = 'https://api.gandi.net/v5';
+    private const GANDI_API_SUCCESS_MSG = 'The email mailbox is being updated.';
+    private const PASSWORD_ALGO = 'sha512-crypt';
+
+    /**
+     * This method is called from roundcube to change the password
+     *
+     * roundcube already validated the old password so we just need to change it at this point
+     *
+     * @param string $curpass  Current password
+     * @param string $newpass  New password
+     * @param string $username The username
+     *
+     * @return int PASSWORD_SUCCESS|PASSWORD_ERROR|PASSWORD_CONNECT_ERROR
+     */
+    public function save($curpass, $newpass, $username)
+    {
+        // get configuration
+        $passformat = rcmail::get_instance()->config->get('password_username_format');
+        $minpasslength = rcmail::get_instance()->config->get('password_minimum_length');
+        $passalgo = rcmail::get_instance()->config->get('password_algorithm');
+        $apikey = rcmail::get_instance()->config->get('password_gandi_apikeys');
+        $userdom = explode('@', $username);
+
+        // log error and return if config is invalid
+        if (strcmp($passformat, '%u') !== 0 || is_int($minpasslength) === false || $minpasslength < self::GANDI_MIN_PASS_LENGTH
+         || strcasecmp($passalgo, self::PASSWORD_ALGO) !== 0 || empty($apikey)) {
+            rcube::raise_error([
+                    'code' => 600, 'file' => __FILE__, 'line' => __LINE__,
+                    'message' => "Password plugin: Invalid configuration option for 'password_username_format', 'password_minimum_length', 'password_algorithm' or 'password_gandi_apikeys'. Refer to the README for more information.",
+                ],
+                true, false
+            );
+            return array('code' => PASSWORD_ERROR, 'message' => 'Invalid configuration');
+        }
+
+        // try to get the api-key and log error & return on failure
+        $result = $this->getApiKey($apikey, $userdom[1]);
+        if ($result['result'] === false) {
+            if (empty($result['msg']) === false) {
+                rcube::raise_error([
+                        'code' => 600, 'file' => __FILE__, 'line' => __LINE__,
+                        'message' => "Password plugin: Problem with configuration option 'password_gandi_apikeys': ".$result['msg'],
+                    ],
+                    true, false
+                );
+            }
+            return array('code' => PASSWORD_ERROR, 'message' => $result['msg']);
+        }
+
+        // assign api-key and initialize curl
+        $apikey = $result['msg'];
+        $curl = curl_init();
+
+        // set curl options
+        curl_setopt_array($curl, array(
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_ENCODING => '',
+            CURLOPT_MAXREDIRS => 10,
+            CURLOPT_TIMEOUT => 30,
+            CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+        ));
+
+        // try to get the mailbox id
+        $result = $this->reqMailboxId($curl, $userdom[0], $userdom[1], $apikey);
+
+        // log error and cleanup if required
+        if ($result['code'] !== PASSWORD_SUCCESS) {
+            rcube::raise_error([
+                    'code' => 600, 'file' => __FILE__, 'line' => __LINE__,
+                    'message' => "Password plugin: Failed to get the mailbox id of '".$username."': ".$result['msg'],
+                ],
+                true, false
+            );
+            goto cleanup;
+        }
+
+        // hash password and try to apply it
+        $hashedpass = password::hash_password($newpass);
+        $result = $this->tellPassword($curl, $userdom[1], $hashedpass, $result['msg'], $apikey);
+
+        // log error if required
+        if ($result['code'] !== PASSWORD_SUCCESS) {
+            rcube::raise_error([
+                    'code' => 600, 'file' => __FILE__, 'line' => __LINE__,
+                    'message' => "Password plugin: Failed to set new password for '".$username."': ".$result['msg'],
+                ],
+                true, false
+            );
+        }
+
+        // cleanup curl handle
+        cleanup:
+        curl_close($curl);
+
+        // return result
+        return array('code' => $result['code'], $result['msg']);
+    }
+
+    /**
+     * Password strength check.
+     * Return values:
+     *     1 - if password is to weak.
+     *     2 - if password is strong enough.
+     *
+     * @param string $passwd Password
+     *
+     * @return array password score (1 to 2) and (optional) reason message
+     */
+    public function check_strength($newpass)
+    {
+        // variables
+        $passminscore = rcmail::get_instance()->config->get('password_minimum_score');
+        $passlenght = strlen($newpass);
+
+        // log and return if config invalid
+        if (is_numeric($passminscore) === false || $passminscore !== 2) {
+            rcube::raise_error([
+                    'code' => 600, 'file' => __FILE__, 'line' => __LINE__,
+                    'message' => "Password plugin: Invalid configuration option for 'password_minimum_score'. Refer to the README for more inform>                ],
+                true, false
+            );
+            return [1, 'Invalid configuration'];
+        }
+
+        // get password properties
+        $uppercase = preg_match('@[A-Z]@', $newpass);
+        $numbers = preg_match_all('@[0-9]@', $newpass);
+        $specialChars = preg_match('@[^\w]@', $newpass);
+		
+        // return if password is not strong enough
+        if($passlenght < self::GANDI_MIN_PASS_LENGTH || $passlenght > self::GANDI_MAX_PASS_LENGTH
+        || !$uppercase || $numbers < self::GANDI_MIN_PASS_NUMS || !$specialChars) {
+            return [1, $this->strength_rules()];
+        }
+
+        // success
+        return [2, ''];
+    }
+
+    /**
+     * Password strength rules.
+     *
+     * @return string The strenght rules
+     */
+    public function strength_rules()
+    {
+        // return message
+        return sprintf("Password must contain between %s and %s characters and contain at least 1 upper-case letter, %d numbers,
+                        and a special character.", self::GANDI_MIN_PASS_LENGTH, self::GANDI_MAX_PASS_LENGTH, self::GANDI_MIN_PASS_NUMS);
+    }
+
+
+    /**
+     * Get the users api-key
+     *
+     * @param string $apikey The API-key field of the config
+     * @param string $domain The domain name
+     *
+     * @return array ['result' => true/false, 'msg' => 'api_key_or_error_message']
+     */
+    private function getApiKey($apikey, $domain)
+    {
+        // check if API-keys are stored in file
+        if (is_array($apikey) === false)
+        {
+            // read file and return on failure
+            $json = file_get_contents($apikey);
+            if ($json === false) {
+                return array('result' => false, 'msg' => "Failed to open file '".$apikey."'");
+            }
+
+            // parse json and return on failure
+            $json = json_decode($json, true);
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                return array('result' => false, 'msg' => "Failed to parse json");
+            }
+
+            // assign api-key
+            $apikey = $json[$domain];
+        }
+        // API-keys are stored in an array => assign api-key directly
+        else {
+            $apikey = $apikey[$domain];
+        }
+
+        // return if api-key invalid
+        if (empty($apikey)) {
+            return array('result' => false, 'msg' => '');
+        }
+
+        // return result
+        return array('result' => true, 'msg' => $apikey);
+    }
+
+    /**
+     * Request the users mailbox id from the server
+     *
+     * @param int    $curl     The curl handle
+     * @param string $username The username
+     * @param string $domain   The domain name
+     * @param string $apikey   The api-key
+     *
+     * @return array ['code' => 'result_code', 'msg' => 'id_or_error_message']
+     */
+    private function reqMailboxId($curl, $username, $domain, $apikey)
+    {
+        // add curl options
+        curl_setopt_array($curl, array(
+            CURLOPT_URL => sprintf("%s/email/mailboxes/%s", self::GANDI_API_URL, $domain),
+            CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+            CURLOPT_CUSTOMREQUEST => 'GET',
+            CURLOPT_POSTFIELDS => "login=".$username,
+            CURLOPT_HTTPHEADER => array(
+                "authorization: Apikey ".$apikey,
+            ),
+        ));
+
+        // read and parse response
+        $response = curl_exec($curl);
+        $json = json_decode(trim($response, '[]'), true);
+        $err = curl_error($curl);
+
+        // return if failed
+        if ($err) {
+            return array('code' => PASSWORD_CONNECT_ERROR, 'msg' => $err);
+        }
+        else if (json_last_error() !== JSON_ERROR_NONE) {
+            return array('code' => PASSWORD_ERROR, 'msg' => (empty($response) ? 'Failed to parse json' : $response));
+        }
+        else if (empty($json['id'])) {
+            return array('code' => PASSWORD_ERROR, 'msg' => (empty($json['message']) ? 'unknown' : $json['message']));
+        }
+
+        // return result
+        return array('code' => PASSWORD_SUCCESS, 'msg' => $json['id']);
+    }
+
+    /**
+     * Send the new password to the server
+     *
+     * @param int    $curl      The curl handle
+     * @param string $domain    The domain name
+     * @param string $newpass   The new password
+     * @param string $mailboxid The mailbox id of the users mailbox
+     * @param string $apikey    The api-key
+     *
+     * @return array ['code' => 'result_code', 'msg' => 'error_message']
+     */
+    private function tellPassword($curl, $domain, $newpass, $mailboxid, $apikey)
+    {
+        // overrride curl options
+        curl_setopt_array($curl, array(
+            CURLOPT_URL => sprintf("%s/email/mailboxes/%s/%s", self::GANDI_API_URL, $domain, $mailboxid),
+            CURLOPT_CUSTOMREQUEST => 'PATCH',
+            CURLOPT_POSTFIELDS => "{\"password\":\"".$newpass."\"}",
+            CURLOPT_HTTPHEADER => array(
+                "authorization: Apikey ".$apikey,
+                "content-type: application/json"
+            ),
+        ));
+
+        // read and parse response
+        $response = curl_exec($curl);
+        $json = json_decode(trim($response, '[]'), true);
+        $err = curl_error($curl);
+
+        // return if failed
+        if ($err) {
+            return array('code' => PASSWORD_CONNECT_ERROR, 'msg' => $err);
+        }
+        else if (json_last_error() !== JSON_ERROR_NONE) {
+            return array('code' => PASSWORD_ERROR, 'msg' => (empty($response) ? 'Failed to parse json' : $response));
+        }
+        else if (empty($json['message']) || stripos($json['message'], self::GANDI_API_SUCCESS_MSG) === false) {
+            return array('code' => PASSWORD_ERROR, 'msg' => (empty($json['message']) ? 'unknown' : $json['message']));
+        }
+
+        // success
+        return array('code' => PASSWORD_SUCCESS, 'msg' => '');
+    }
+}

--- a/plugins/password/drivers/gandi.php
+++ b/plugins/password/drivers/gandi.php
@@ -258,7 +258,7 @@ class rcube_gandi_password
      * @return array [
      *                'code' => (int) PASSWORD_SUCCESS|PASSWORD_ERROR|PASSWORD_CONNECT_ERROR
      *                'msg'  => (int|string) Mailbox id or error message if 'code' is not equal to 'PASSWORD_SUCCESS'.
-     *                 ]
+     *               ]
      */
     private function reqMailboxId($curl, $username, $domain, $apikey)
     {
@@ -309,7 +309,7 @@ class rcube_gandi_password
      * @return array [
      *                'code' => (int) PASSWORD_SUCCESS|PASSWORD_ERROR|PASSWORD_CONNECT_ERROR
      *                'msg'  => (string) Optional error message.
-     *                 ]
+     *               ]
      */
     private function tellPassword($curl, $domain, $newpass, $mailboxid, $apikey)
     {

--- a/plugins/password/drivers/gandi.php
+++ b/plugins/password/drivers/gandi.php
@@ -274,10 +274,10 @@ class rcube_gandi_password
     {
         // add curl options
         curl_setopt_array($curl, array(
-            CURLOPT_URL => sprintf('%s/email/mailboxes/%s', self::GANDI_API_URL, $domain),
+            CURLOPT_URL => sprintf('%s/email/mailboxes/%s?login=%s', self::GANDI_API_URL, $domain, $username),
             CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
             CURLOPT_CUSTOMREQUEST => 'GET',
-            CURLOPT_POSTFIELDS => "login=".$username,
+            CURLOPT_POSTFIELDS => "",
             CURLOPT_HTTPHEADER => array(
                 "authorization: Apikey ".$apikey,
             ),

--- a/plugins/password/drivers/gandi.php
+++ b/plugins/password/drivers/gandi.php
@@ -259,7 +259,7 @@ class rcube_gandi_password
 
         // read and parse response
         $response = curl_exec($curl);
-		$err = curl_error($curl);
+        $err = curl_error($curl);
         $json = json_decode(trim($response, '[]'), true);
 
         // return if failed
@@ -303,7 +303,7 @@ class rcube_gandi_password
 
         // read and parse response
         $response = curl_exec($curl);
-		$err = curl_error($curl);
+        $err = curl_error($curl);
         $json = json_decode(trim($response, '[]'), true);
 
         // return if failed

--- a/plugins/password/drivers/gandi.php
+++ b/plugins/password/drivers/gandi.php
@@ -221,24 +221,30 @@ class rcube_gandi_password
         }
         // check if api-keys are stored in file
         else if (strpos($apikey, '/') !== false) {
-            // read file and return on failure
+            // try to read file
             $file = @file_get_contents($apikey);
+
+            // return if the file could not be opened or is empty
             if ($file === false) {
-                return array('result' => false, 'msg' => 'The API key file could not be opened.');
+                return array('result' => false, 'msg' => 'The API-key file could not be opened.');
+            }
+            else if (empty($file)) {
+                return array('result' => false, 'msg' => "No mapping was found for '".$domain."'.");
             }
 
-            // try to parse json
+            // remove all newlines and try to parse json
+            $file = str_replace("\n", '', $file);
             $json = json_decode($file, true);
 
             // try to assign the api-key appropriately and return on failure
             if (json_last_error() === JSON_ERROR_NONE && is_array($json)) {
                 $apikey = $json[$domain];
             }
-            else if (strpos($apikey, '\n') === false) {
+            else if (preg_match('@"|\\\\|[[:cntrl:]]@', $file) === 0) {
                 $apikey = $file;
             }
             else {
-                return array('result' => false, 'msg' => 'The API key file could not be interpreted.');
+                return array('result' => false, 'msg' => 'The API-key file could not be interpreted.');
             }
         }
 

--- a/plugins/password/drivers/gandi.php
+++ b/plugins/password/drivers/gandi.php
@@ -40,7 +40,7 @@ class rcube_gandi_password
     // constants
     private const PASSWORD_ALGO = 'sha512-crypt';
     private const GANDI_API_URL = 'https://api.gandi.net/v5';
-    private const GANDI_API_SUCCESS_MSG = 'The email mailbox is being updated.';
+    private const GANDI_API_SUCCESS_MSG = 'Mailbox updated.';
     private const GANDI_PASS_MIN_LENGTH = 8;
     private const GANDI_PASS_MAX_LENGTH = 200;
     private const GANDI_PASS_AMOUNT_UCASE = 1;

--- a/plugins/password/drivers/gandi.php
+++ b/plugins/password/drivers/gandi.php
@@ -142,7 +142,7 @@ class rcube_gandi_password
     /**
      * Password strength check.
      * Return values:
-     *     1 - f password is to weak.
+     *     1 - if password is to weak.
      *     2 - if password is strong enough.
      *
      * @param string $passwd Password

--- a/plugins/password/drivers/gandi.php
+++ b/plugins/password/drivers/gandi.php
@@ -180,7 +180,7 @@ class rcube_gandi_password
     /**
      * Password strength rules.
      *
-     * @return string The strenght rules
+     * @return string The strength rules
      */
     public function strength_rules()
     {

--- a/plugins/password/localization/ar.inc
+++ b/plugins/password/localization/ar.inc
@@ -34,4 +34,4 @@ $messages['samepasswd'] = 'يجب أن تكون كلمة السر الجديدة
 $messages['passwdexpirewarning'] = 'تنبيه ! إنّ مدة صلاحية كلمتك السرية سوف تنقضي قريبا، يُرجى تغييرها قبل $expirationdatetime.';
 $messages['passwdexpired'] = 'لقد إنتهت مدة صلاحية كلمتك السرية، يجب عليك تغييرها الآن !';
 $messages['passwdconstraintviolation'] = 'تحتوي كلمة المرور على خروقات. ربما كلمة المرور ضعيفة جدا.';
-$messages['gandi_strengthrules'] = 'يجب أن تحتوي كلمة المرور بين $minlen و $maxlen أحرف وأن تحتوي على الأقل $uppercase على حرف (أحرف) كبيرة ، $nums رقم (أرقام) ، و $specialchars حرف (أحرف) خاص.'
+$messages['gandi_strengthrules'] = 'يجب أن تحتوي كلمة المرور بين $minlen و $maxlen أحرف وأن تحتوي على الأقل $uppercase على حرف (أحرف) كبيرة ، $nums رقم (أرقام) ، و $specialchars حرف (أحرف) خاص.';

--- a/plugins/password/localization/ar.inc
+++ b/plugins/password/localization/ar.inc
@@ -34,3 +34,4 @@ $messages['samepasswd'] = 'يجب أن تكون كلمة السر الجديدة
 $messages['passwdexpirewarning'] = 'تنبيه ! إنّ مدة صلاحية كلمتك السرية سوف تنقضي قريبا، يُرجى تغييرها قبل $expirationdatetime.';
 $messages['passwdexpired'] = 'لقد إنتهت مدة صلاحية كلمتك السرية، يجب عليك تغييرها الآن !';
 $messages['passwdconstraintviolation'] = 'تحتوي كلمة المرور على خروقات. ربما كلمة المرور ضعيفة جدا.';
+$messages['gandi_strengthrules'] = 'يجب أن تحتوي كلمة المرور بين $minlen و $maxlen أحرف وأن تحتوي على الأقل $uppercase على حرف (أحرف) كبيرة ، $nums رقم (أرقام) ، و $specialchars حرف (أحرف) خاص.'

--- a/plugins/password/localization/ast.inc
+++ b/plugins/password/localization/ast.inc
@@ -28,3 +28,4 @@ $messages['passwordshort'] = 'La contraseña tien de tener polo menos $length ca
 $messages['passwordweak'] = 'La contraseña tien de tener polo menos un númberu y un signu de puntuación.';
 $messages['passwordforbidden'] = 'La contraseña contien caráuteres prohibíos.';
 $messages['firstloginchange'] = 'Esti ye\'l to primer aniciu sesión. Por favor, camuda la to contraseña.';
+$messages['gandi_strengthrules'] = 'La contraseña debe contener entre $minlen y $maxlen caracteres y contener al menos $uppercase letra(s) mayúscula(s), $nums número(s) y $specialchars carácter(es) especial(es).';

--- a/plugins/password/localization/az_AZ.inc
+++ b/plugins/password/localization/az_AZ.inc
@@ -27,3 +27,4 @@ $messages['internalerror'] = 'Yeni şifrənin saxlanılması mümkün olmadı.';
 $messages['passwordshort'] = 'Yeni şifrə $length simvoldan uzun olmalıdır.';
 $messages['passwordweak'] = 'Şifrədə heç olmasa minimum bir rəqəm və simvol olmalıdır.';
 $messages['passwordforbidden'] = 'Şifrədə icazə verilməyən simvollar vardır.';
+$messages['gandi_strengthrules'] = 'Parolda $minlen və $maxlen simvolları olmalıdır və ən azı $uppercase böyük hərf(lər), $nums nömrə(lər) və $specialchars xüsusi simvol(lar)dan ibarət olmalıdır.';

--- a/plugins/password/localization/be_BE.inc
+++ b/plugins/password/localization/be_BE.inc
@@ -29,3 +29,4 @@ $messages['passwordshort'] = 'Пароль мусіць быць мінімум 
 $messages['passwordweak'] = 'Пароль мусіць утрымліваць мінімум адну лічбу і адзін знак пунктуацыі.';
 $messages['passwordforbidden'] = 'Пароль утрымлівае забароненыя знакі.';
 $messages['firstloginchange'] = 'Гэта ваш першы ўваход. Трэба змяніць пароль.';
+$messages['gandi_strengthrules'] = 'Пароль павінен змяшчаць сімвалы ад $minlen да $maxlen і змяшчаць як мінімум $uppercase вялікія літары, $nums нумар(ы) і $specialchars спецыяльны сімвал(ы).';

--- a/plugins/password/localization/bg_BG.inc
+++ b/plugins/password/localization/bg_BG.inc
@@ -41,3 +41,4 @@ $messages['passwdconstraintviolation'] = 'Нарушение на изисква
 $messages['pwned_mustnotbedisclosed'] = 'Паролата не трябва да бъде <a href="$href" target="_blank">общоизвестна</a>.';
 $messages['pwned_isdisclosed'] = 'Тази парола е общоизвестна.';
 $messages['pwned_fetcherror'] = 'Неуспешна проверка на силата на паролата.';
+$messages['gandi_strengthrules'] = 'Паролата трябва да съдържа между $minlen и $maxlen знаци и да съдържа поне $uppercase главни букви, $nums числа и $specialchars специални знаци.';

--- a/plugins/password/localization/de_CH.inc
+++ b/plugins/password/localization/de_CH.inc
@@ -41,3 +41,4 @@ $messages['passwdconstraintviolation'] = 'Passwortrichtlinien nicht erfüllt. Da
 $messages['pwned_mustnotbedisclosed'] = 'Das Passwort darf nicht <a href="$href" target="_blank">allgemein bekannt sein</a>.';
 $messages['pwned_isdisclosed'] = 'Dieses Passwort ist allgemein bekannt.';
 $messages['pwned_fetcherror'] = 'Die Überprüfung der Passwortstärke ist fehlgeschlagen.';
+$messages['gandi_strengthrules'] = 'Das Passwort muss zwischen $minlen und $maxlen Zeichen und mindestens $uppercase Großbuchstaben, $nums Zahl(en) und $specialchars Sonderzeichen enthalten.';

--- a/plugins/password/localization/de_DE.inc
+++ b/plugins/password/localization/de_DE.inc
@@ -40,4 +40,4 @@ $messages['passwdexpired'] = 'Ihr Passwort ist abgelaufen, ändern Sie es jetzt!
 $messages['passwdconstraintviolation'] = 'Passwortbeschränkungsverletzung. Passwort wahrscheinlich zu schwach.';
 $messages['pwned_isdisclosed'] = 'Dieses Passwort ist allgemein bekannt.';
 $messages['pwned_fetcherror'] = 'Die Überprüfung der Passwortstärke ist fehlgeschlagen.';
-$messages['gandi_strengthrules'] = 'Das Passwort muss zwischen $minlen und $maxlen Zeichen und mindestens $uppercase Großbuchstaben, $nums Zahl(en) und $specialchars Sonderzeichen enthalten.'
+$messages['gandi_strengthrules'] = 'Das Passwort muss zwischen $minlen und $maxlen Zeichen und mindestens $uppercase Großbuchstaben, $nums Zahl(en) und $specialchars Sonderzeichen enthalten.';

--- a/plugins/password/localization/de_DE.inc
+++ b/plugins/password/localization/de_DE.inc
@@ -40,3 +40,4 @@ $messages['passwdexpired'] = 'Ihr Passwort ist abgelaufen, ändern Sie es jetzt!
 $messages['passwdconstraintviolation'] = 'Passwortbeschränkungsverletzung. Passwort wahrscheinlich zu schwach.';
 $messages['pwned_isdisclosed'] = 'Dieses Passwort ist allgemein bekannt.';
 $messages['pwned_fetcherror'] = 'Die Überprüfung der Passwortstärke ist fehlgeschlagen.';
+$messages['gandi_strengthrules'] = 'Das Passwort muss zwischen $minlen und $maxlen Zeichen und mindestens $uppercase Großbuchstaben, $nums Zahl(en) und $specialchars Sonderzeichen enthalten.'

--- a/plugins/password/localization/en_CA.inc
+++ b/plugins/password/localization/en_CA.inc
@@ -27,3 +27,4 @@ $messages['internalerror'] = 'Could not save new password.';
 $messages['passwordshort'] = 'Password must be at least $length characters long.';
 $messages['passwordweak'] = 'Password must include at least one number and one punctuation character.';
 $messages['passwordforbidden'] = 'Password contains forbidden characters.';
+$messages['gandi_strengthrules'] = 'Password must contain between $minlen and $maxlen characters and contain at least $uppercase upper-case letter(s), $nums number(s), and $specialchars special character(s).';

--- a/plugins/password/localization/en_GB.inc
+++ b/plugins/password/localization/en_GB.inc
@@ -41,3 +41,4 @@ $messages['passwdconstraintviolation'] = 'Password constraint violation. Passwor
 $messages['pwned_mustnotbedisclosed'] = 'Password must not be <a href="$href" target="_blank">commonly known</a>.';
 $messages['pwned_isdisclosed'] = 'This password is commonly known.';
 $messages['pwned_fetcherror'] = 'Failed to verify the password strength.';
+$messages['gandi_strengthrules'] = 'Password must contain between $minlen and $maxlen characters and contain at least $uppercase upper-case letter(s), $nums number(s), and $specialchars special character(s).';

--- a/plugins/password/localization/en_US.inc
+++ b/plugins/password/localization/en_US.inc
@@ -42,4 +42,4 @@ $messages['passwdconstraintviolation'] = 'Password constraint violation. Passwor
 $messages['pwned_mustnotbedisclosed'] = 'Password must not be <a href="$href" target="_blank">commonly known</a>.';
 $messages['pwned_isdisclosed'] = 'This password is commonly known.';
 $messages['pwned_fetcherror'] = 'Failed to verify the password strength.';
-$messages['gandi_strengthrules'] = 'Password must contain between $minlen and $maxlen characters and contain at least $uppercase upper-case letter(s), $nums number(s), and $specialchars special character(s).'
+$messages['gandi_strengthrules'] = 'Password must contain between $minlen and $maxlen characters and contain at least $uppercase upper-case letter(s), $nums number(s), and $specialchars special character(s).';

--- a/plugins/password/localization/en_US.inc
+++ b/plugins/password/localization/en_US.inc
@@ -42,3 +42,4 @@ $messages['passwdconstraintviolation'] = 'Password constraint violation. Passwor
 $messages['pwned_mustnotbedisclosed'] = 'Password must not be <a href="$href" target="_blank">commonly known</a>.';
 $messages['pwned_isdisclosed'] = 'This password is commonly known.';
 $messages['pwned_fetcherror'] = 'Failed to verify the password strength.';
+$messages['gandi_strengthrules'] = 'Password must contain between $minlen and $maxlen characters and contain at least $uppercase upper-case letter(s), $nums number(s), and $specialchars special character(s).'

--- a/plugins/password/localization/fr_FR.inc
+++ b/plugins/password/localization/fr_FR.inc
@@ -41,3 +41,4 @@ $messages['passwdconstraintviolation'] = 'Contrainte non respectée. Le mot de p
 $messages['pwned_mustnotbedisclosed'] = 'Le mot de passe ne doit pas être <a href="$href" target="_blank">notoire</a>.';
 $messages['pwned_isdisclosed'] = 'Ce mot de passe est connu par ailleurs.';
 $messages['pwned_fetcherror'] = 'Échec de vérification de la robustesse du mot de passe.';
+$messages['gandi_strengthrules'] = 'Le mot de passe doit contenir entre $minlen et $maxlen caractères et contenir au moins $uppercase lettre(s) majuscule(s), $nums nombre(s) et $specialchars caractère(s) spécial(s).';


### PR DESCRIPTION
I recently switched to Roundcube and was surprised to see how well designed this app is.
However, when setting up the password plugin, I noticed that there is no password driver for my provider.
So I did the only reasonable thing and coded one myself.

The driver uses the gandi.net mail API (https://api.gandi.net/docs/email/) to update the user password. It also includes a strength driver that conforms to the gandi.net rules for changing passwords, and of course some translations and documentation. It has been tested with PHP 7.4 on Roundcube 1.6.

This took al lot of work and I would really appreciate it if you would look over it and consider a merge.