### PR TITLE
darkmode blockquote patch

### DIFF
--- a/skins/elastic/styles/colors.less
+++ b/skins/elastic/styles/colors.less
@@ -222,15 +222,16 @@
 
 
 // Dark mode colors
-@color-dark-main:           darken(@color-main, 30%);
-@color-dark-background:     #21292c;
-@color-dark-font:           #c5d1d3;
-@color-dark-border:         #4d6066;
-@color-dark-hint:           darken(@color-dark-font, 20%);
-@color-dark-information:    shade(@color-main, 40%);
-@color-dark-success:        shade(@color-success, 40%);
-@color-dark-warning:        shade(@color-warning, 40%);
-@color-dark-error:          shade(@color-error, 40%);
+@color-dark-main:                   darken(@color-main, 30%);
+@color-dark-background:             #21292c;
+@color-dark-blockquote-background:  #f8f9f9;
+@color-dark-font:                   #c5d1d3;
+@color-dark-border:                 #4d6066;
+@color-dark-hint:                   darken(@color-dark-font, 20%);
+@color-dark-information:            shade(@color-main, 40%);
+@color-dark-success:                shade(@color-success, 40%);
+@color-dark-warning:                shade(@color-warning, 40%);
+@color-dark-error:                  shade(@color-error, 40%);
 
 @color-dark-list-selected:              @color-main;
 @color-dark-list-selected-background:   #374549;

--- a/skins/elastic/styles/dark.less
+++ b/skins/elastic/styles/dark.less
@@ -797,7 +797,7 @@ html.dark-mode {
         border-color: @color-dark-border;
 
         blockquote {
-            background-color: @color-dark-blockquote-background:;
+            background-color: @color-dark-blockquote-background;
             border-color: @color-dark-blockquote-0-border;
             color: @color-dark-blockquote-0;
 

--- a/skins/elastic/styles/dark.less
+++ b/skins/elastic/styles/dark.less
@@ -797,7 +797,7 @@ html.dark-mode {
         border-color: @color-dark-border;
 
         blockquote {
-            background-color: @color-dark-background;
+            background-color: @color-dark-blockquote-background:;
             border-color: @color-dark-blockquote-0-border;
             color: @color-dark-blockquote-0;
 


### PR DESCRIPTION
Currently in dark mode, a blockquote in an email message content appears as a dark background with dark grey text. This makes reading blockquotes in message content nearly impossible without switching to light mode.
I have added a new color: `@color-dark-blockquote-background: #f8f9f9;` which matches the lightmode blockquote background and applied this color to blockquotes in the dark.less file.
This should make blockquotes appear readable within the rest of the email content.