### PR TITLE
fix PHP8 warning: don't return undefined $_SESSION['secure_token']

### DIFF
--- a/program/lib/Roundcube/rcube.php
+++ b/program/lib/Roundcube/rcube.php
@@ -996,7 +996,9 @@ class rcube
                 $_SESSION['secure_token'] = $plugin['value'];
             }
 
-            return $_SESSION['secure_token'];
+            if (!empty($_SESSION['secure_token'])) {
+                return $_SESSION['secure_token'];
+            }
         }
 
         return false;


### PR DESCRIPTION
Avoid `PHP Warning: Undefined array key "secure_token" in /roundcubemail/program/lib/Roundcube/rcube.php on line 1002` seen with PHP 8 and secure_urls enabled.