### PR TITLE
Wrap the mail date in a <time> tag

### DIFF
--- a/program/actions/mail/show.php
+++ b/program/actions/mail/show.php
@@ -473,8 +473,11 @@ class rcmail_action_mail_show extends rcmail_action_mail_index
             $header_value = null;
 
             if ($hkey == 'date') {
-                $header_value = $rcmail->format_date($value,
-                    self::$PRINT_MODE ? $rcmail->config->get('date_long', 'x') : null);
+                $header_value = html::time(
+                    ['datetime' => $rcmail->format_date($value, DATE_ATOM)],
+                    $rcmail->format_date($value, self::$PRINT_MODE ? $rcmail->config->get('date_long', 'x') : null)
+                );
+                $ishtml       = true;
             }
             else if ($hkey == 'priority') {
                 $header_value = html::span('prio' . $value, rcube::Q(self::localized_priority($value)));

--- a/program/lib/Roundcube/html.php
+++ b/program/lib/Roundcube/html.php
@@ -207,6 +207,24 @@ class html
     }
 
     /**
+     * Derived method for inline time tags
+     *
+     * @param string|array $attr Hash array with tag attributes or string with class name
+     * @param string       $cont Tag content
+     *
+     * @return string HTML code
+     * @see html::tag()
+     */
+    public static function time($attr, $cont)
+    {
+        if (is_string($attr)) {
+            $attr = ['class' => $attr];
+        }
+
+        return self::tag('time', $attr, $cont, ['datetime', 'title']);
+    }
+
+    /**
      * Derived method for form element labels
      *
      * @param string|array $attr Hash array with tag attributes or string with 'for' attrib


### PR DESCRIPTION
Some screen readers and other tools could benefit from a machine readable date.

- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time
- https://www.htmlgoodies.com/html5/its-time-for-an-html5-time-tag/
- https://css-tricks.com/time-element/

It's my first contribution here, so I may not be well polished about ways to code here


Note: adding a `title` attribute with some custom date format would allow a nice tooltip on the date for the user to see another representation of the date. I was initially thinking that browsers would do that but in fact no. So anyway I contribute this and hope you will like it. It's just more standard HTML for a date or time to be wrapped in such a tag