### PR TITLE
Added %u, %d and %l as variables in additional_message_headers

### DIFF
--- a/plugins/additional_message_headers/additional_message_headers.php
+++ b/plugins/additional_message_headers/additional_message_headers.php
@@ -39,6 +39,23 @@ class additional_message_headers extends rcube_plugin
         $additional_headers = $rcube->config->get('additional_message_headers', []);
 
         if (!empty($additional_headers)) {
+
+	    // Expand the % config variables
+	    $search = array(
+                '/(^|[^%])%u/',
+                '/(^|[^%])%l/',
+                '/(^|[^%])%d/'
+	    );
+	    $replace = array(
+                '${1}'.$rcube->get_user_name(),
+                '${1}'.$rcube->user->get_username('local'),
+                '${1}'.$rcube->user->get_username('domain')
+	    );
+	    $additional_headers = preg_replace($search, $replace, $additional_headers);
+	
+	    // replace %%<variable> with %<variable>
+	    $additional_headers = preg_replace( '/%(%[uld])/', '${1}', $additional_headers);
+
             $args['message']->headers($additional_headers, true);
         }
 


### PR DESCRIPTION
Now you can configure something like

`$config['additional_message_headers']['X-RC-Auth-Username']  = '%u';`

If you need a '%u' in your message header, pleas use %%u.

