### PR TITLE
Pass port 0 as integer to Redis::connect() with unix socket

### DIFF
--- a/program/lib/Roundcube/cache/redis.php
+++ b/program/lib/Roundcube/cache/redis.php
@@ -110,7 +110,7 @@ class rcube_cache_redis extends rcube_cache
 
             if (substr($redis_host, 0, 7) === 'unix://') {
                 $host = substr($port, 2);
-                $port = null;
+                $port = 0;
             }
             else {
                 // set default values if not set


### PR DESCRIPTION
The second parameter to Redis::connect() is an int parameter. Passing null for it will trigger a PHP deprecation notice with PHP 8.1.

The Redis::connect() documentation shows that a 0 is used for the port parameter in the examples with unix sockets where parameters beyond the second parameter are set.