### PR TITLE
Purge messages from junk folder when delete_junk enabled

### DIFF
--- a/program/actions/mail/folder_purge.php
+++ b/program/actions/mail/folder_purge.php
@@ -35,13 +35,20 @@ class rcmail_action_mail_folder_purge extends rcmail_action_mail_index
         $mbox         = rcube_utils::get_input_string('_mbox', rcube_utils::INPUT_POST, true);
         $trash_mbox   = $rcmail->config->get('trash_mbox');
         $trash_regexp = '/^' . preg_quote($trash_mbox . $delimiter, '/') . '/';
+        $junk_mbox    = $rcmail->config->get('junk_mbox');
+        $junk_regexp  = '/^' . preg_quote($junk_mbox . $delimiter, '/') . '/';
+        $delete_junk  = $rcmail->config->get('delete_junk');
 
-        // we should only be purging trash (or their subfolders)
+        // purge directly if there is no trash, or we are operating on trash (or subfolders)
         if (!strlen($trash_mbox) || $mbox === $trash_mbox || preg_match($trash_regexp, $mbox)) {
             $success = $storage->delete_message('*', $mbox);
             $delete  = true;
+        } // also purge directly if delete_junk is on, and folder is junk (or subfolders)
+        else if ($delete_junk === true && ($mbox === $junk_mbox || preg_match($junk_regexp, $mbox))) {
+           $success = $storage->delete_message('*', $mbox);
+           $delete = true;
         }
-        // move to Trash
+        // otherwise move to Trash
         else {
             $success = $storage->move_message('1:*', $trash_mbox, $mbox);
             $delete  = false;


### PR DESCRIPTION
If delete_junk is on, end user expectation is that both single message delete as well as 'empty folder' operations should immediately delete messages from junk and bypass trash.