### PR TITLE
Address most common warnings in PHP >= 8.0.0

### DIFF
--- a/program/actions/mail/check_recent.php
+++ b/program/actions/mail/check_recent.php
@@ -52,7 +52,7 @@ class rcmail_action_mail_check_recent extends rcmail_action_mail_index
         if ($check_all) {
             $a_mailboxes = $rcmail->storage->list_folders_subscribed('', '*', 'mail');
         }
-        else if ($search_request && is_object($_SESSION['search'][1])) {
+        else if ($search_request && isset($_SESSION['search'][1]) && is_object($_SESSION['search'][1])) {
             $a_mailboxes = (array) $_SESSION['search'][1]->get_parameters('MAILBOX');
         }
         else {
@@ -74,6 +74,7 @@ class rcmail_action_mail_check_recent extends rcmail_action_mail_index
             $is_current = $mbox_name == $current
                 || (
                     !empty($search_request)
+                    && isset($_SESSION['search'][1])
                     && is_object($_SESSION['search'][1])
                     && in_array($mbox_name, (array)$_SESSION['search'][1]->get_parameters('MAILBOX'))
                 );

--- a/program/actions/mail/compose.php
+++ b/program/actions/mail/compose.php
@@ -1093,7 +1093,7 @@ class rcmail_action_mail_compose extends rcmail_action_mail_index
                         continue;
                     }
 
-                    $idx = $part->content_id ? ('cid:' . $part->content_id) : $part->content_location;
+                    $idx = $part->content_id ? ('cid:' . $part->content_id) : $part->content_location ?? null;
 
                     if ($idx && isset(self::$CID_MAP[$idx]) && strpos($message_body, self::$CID_MAP[$idx]) !== false) {
                         $replace = self::$CID_MAP[$idx];

--- a/program/actions/mail/mark.php
+++ b/program/actions/mail/mark.php
@@ -46,10 +46,9 @@ class rcmail_action_mail_mark extends rcmail_action_mail_index
         $flag         = self::imap_flag($flag);
         $old_count    = 0;
 
-        if ($flag == 'DELETED' && $skip_deleted && $_POST['_from'] != 'show') {
+        if ($flag == 'DELETED' && $skip_deleted && (!isset($_POST['_from']) || $_POST['_from'] != 'show')) {
             // count messages before changing anything
             $old_count = $rcmail->storage->count(null, $threading ? 'THREADS' : 'ALL');
-            $old_pages = ceil($old_count / $rcmail->storage->get_pagesize());
         }
 
         if ($folders == 'all') {


### PR DESCRIPTION
After updating to the latest RoundCube version and also updating to the latest PHP 8.0 release, some warnings began to appear in our logs.

This PR addresses the most common ones that haven't been solved yet: 

Warning: Trying to access array offset on value of type null
`program/actions/mail/check_recent.php` in `rcmail_action_mail_check_recent::run` at line 55

Warning: Trying to access array offset on value of type null
`program/actions/mail/check_recent.php` in `rcmail_action_mail_check_recent::run` at line 77

Warning: Undefined property: rcube_message_part::$content_location
`program/actions/mail/compose.php` in `rcmail_action_mail_compose::write_compose_attachments` at line 1105

Warning: Undefined array key "_from"
`program/actions/mail/mark.php` in `rcmail_action_mail_mark::run` at line 49

I also took the liberty of deleting a non-used variable `$old_pages` in `rcmail_action_mail_mark::run`