### PR TITLE
Add config option for request uri field (#8738)

### DIFF
--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -817,6 +817,13 @@ $config['no_save_sent_messages'] = false;
 // Note: Use assets_path to not prevent the browser from caching assets
 $config['use_secure_urls'] = false;
 
+// Specify the $_SERVER field that contains the full path of the original HTTP request.
+// This might be changed when Roundcube runs behind a reverse proxy using a subpath.
+// The reverse proxy config can specify a custom header (e.g. X-Forwarded-Path) containing
+// the path under which Roundcube is exposed to the outside world (e.g. /rcube/).
+// This header vaue is then availbale in PHP with $_SERVER['HTTP_X_FORWARDED_PATH'].
+$config['request_uri_field'] = 'REQUEST_URI';
+
 // Allows to define separate server/path for image/js/css files
 // Warning: If the domain is different cross-domain access to some
 // resources need to be allowed

--- a/program/include/rcmail.php
+++ b/program/include/rcmail.php
@@ -1119,9 +1119,9 @@ class rcmail extends rcube
         }
 
         $base_path = '';
-        $server_var = $this->get_requesr_uri_field();
+        $server_var = $this->get_request_uri_field();
         if ($server_var && !empty($_SERVER[$server_var])) {
-            $base_path = preg_replace('/[?&].*$/', '', $_SERVER[$server_var]) ?: './';
+            $base_path = preg_replace('/[?&].*$/', '', $_SERVER[$server_var]);
         }
         else if (!empty($_SERVER['REDIRECT_SCRIPT_URL'])) {
             $base_path = $_SERVER['REDIRECT_SCRIPT_URL'];
@@ -1168,7 +1168,8 @@ class rcmail extends rcube
      * Get the 'request_uri_field' config option
      * with an additional check against the 'proxy_whitelist' config
      */
-    protected function get_requesr_uri_field() {
+    protected function get_request_uri_field()
+    {
         $server_var = $this->config->get('request_uri_field');
         if (!empty($server_var) && (strpos($server_var, 'HTTP_') !== 0 || rcube_utils::check_proxy_whitelist_ip())) {
             return $server_var;

--- a/program/include/rcmail.php
+++ b/program/include/rcmail.php
@@ -1119,7 +1119,11 @@ class rcmail extends rcube
         }
 
         $base_path = '';
-        if (!empty($_SERVER['REDIRECT_SCRIPT_URL'])) {
+        $server_var = $this->get_requesr_uri_field();
+        if ($server_var && !empty($_SERVER[$server_var])) {
+            $base_path = preg_replace('/[?&].*$/', '', $_SERVER[$server_var]) ?: './';
+        }
+        else if (!empty($_SERVER['REDIRECT_SCRIPT_URL'])) {
             $base_path = $_SERVER['REDIRECT_SCRIPT_URL'];
         }
         else if (!empty($_SERVER['SCRIPT_NAME'])) {
@@ -1154,16 +1158,22 @@ class rcmail extends rcube
             $prefix = rtrim($prefix, '/') . '/';
         }
         else {
-            $server_var = $this->config->get('request_uri_field');
-            if (isset($server_var) &&!empty($_SERVER[$server_var])) {
-                $prefix = preg_replace('/[?&].*$/', '', $_SERVER[$server_var]) ?: './';
-            }
-            else {
-                $prefix = './';
-            }
+            $prefix = $base_path ?: './';
         }
 
         return $prefix . $url;
+    }
+
+    /**
+     * Get the 'request_uri_field' config option
+     * with an additional check against the 'proxy_whitelist' config
+     */
+    protected function get_requesr_uri_field() {
+        $server_var = $this->config->get('request_uri_field');
+        if (!empty($server_var) && (strpos($server_var, 'HTTP_') !== 0 || rcube_utils::check_proxy_whitelist_ip())) {
+            return $server_var;
+        }
+        return null;
     }
 
     /**

--- a/program/include/rcmail.php
+++ b/program/include/rcmail.php
@@ -1154,8 +1154,9 @@ class rcmail extends rcube
             $prefix = rtrim($prefix, '/') . '/';
         }
         else {
-            if (isset($_SERVER['REQUEST_URI'])) {
-                $prefix = preg_replace('/[?&].*$/', '', $_SERVER['REQUEST_URI']) ?: './';
+            $server_var = $this->config->get('request_uri_field');
+            if (isset($server_var) &&!empty($_SERVER[$server_var])) {
+                $prefix = preg_replace('/[?&].*$/', '', $_SERVER[$server_var]) ?: './';
             }
             else {
                 $prefix = './';

--- a/program/lib/Roundcube/rcube_utils.php
+++ b/program/lib/Roundcube/rcube_utils.php
@@ -673,7 +673,7 @@ class rcube_utils
 
         if (!empty($_SERVER['HTTP_X_FORWARDED_PROTO'])
             && strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https'
-            && in_array($_SERVER['REMOTE_ADDR'], (array) rcube::get_instance()->config->get('proxy_whitelist', []))
+            && self::check_proxy_whitelist_ip()
         ) {
             return true;
         }
@@ -687,6 +687,13 @@ class rcube_utils
         }
 
         return false;
+    }
+
+    /**
+     * Check if the reported REMOTE_ADDR is in the 'proxy_whitelist' config option
+     */
+    public static function check_proxy_whitelist_ip() {
+        return in_array($_SERVER['REMOTE_ADDR'], (array) rcube::get_instance()->config->get('proxy_whitelist', []));
     }
 
     /**

--- a/tests/Rcmail/OutputHtml.php
+++ b/tests/Rcmail/OutputHtml.php
@@ -381,7 +381,7 @@ class Rcmail_RcmailOutputHtml extends PHPUnit\Framework\TestCase
         $rcmail = rcube::get_instance();
         $output = new rcmail_output_html();
 
-        $this->assertSame('<form action="./phpunit?_task=cli" method="get">test</form>', $output->form_tag([], 'test'));
+        $this->assertSame('<form action="vendor/bin/phpunit?_task=cli" method="get">test</form>', $output->form_tag([], 'test'));
     }
 
     /**
@@ -404,7 +404,7 @@ class Rcmail_RcmailOutputHtml extends PHPUnit\Framework\TestCase
         $output = new rcmail_output_html();
 
         $expected = '<form name="rcmqsearchform" onsubmit="rcmail.command(\'search\'); return false"'
-            . ' action="./phpunit?_task=cli" method="get"><label for="rcmqsearchbox" class="voice">Search terms</label>'
+            . ' action="vendor/bin/phpunit?_task=cli" method="get"><label for="rcmqsearchbox" class="voice">Search terms</label>'
             . '<input name="_q" class="no-bs" id="rcmqsearchbox" placeholder="Search..." type="text"></form>';
 
         $this->assertSame($expected, $output->search_form([]));


### PR DESCRIPTION
This can be used to read a custom header sent by a reverse proxy to resolve the absolute path to Roundcube.

Resolves issue #8738