### PR TITLE
Use json_decode to prevent exception

### DIFF
--- a/program/include/rcmail_oauth.php
+++ b/program/include/rcmail_oauth.php
@@ -234,7 +234,7 @@ class rcmail_oauth
                         ],
                 ]);
 
-                $data = \GuzzleHttp\json_decode($response->getBody(), true);
+                $data = json_decode($response->getBody(), true);
 
                 // auth success
                 if (!empty($data['access_token'])) {
@@ -272,7 +272,7 @@ class rcmail_oauth
                                 ],
                         ]);
 
-                        $identity = \GuzzleHttp\json_decode($identity_response->getBody(), true);
+                        $identity = json_decode($identity_response->getBody(), true);
 
                         foreach ($this->options['identity_fields'] as $field) {
                             if (isset($identity[$field])) {
@@ -378,7 +378,7 @@ class rcmail_oauth
                         'grant_type'    => 'refresh_token',
                     ],
             ]);
-            $data = \GuzzleHttp\json_decode($response->getBody(), true);
+            $data = json_decode($response->getBody(), true);
 
             // auth success
             if (!empty($data['access_token'])) {


### PR DESCRIPTION
On our install ( Debian testing with rouncube 1.6.0+dfsg-1.1 ) we get:
```
PHP Fatal error:  Uncaught Error: Call to undefined function GuzzleHttp\json_decode() in /usr/share/roundcube/program/include/rcmail_oauth.php:237
```
 changing the function call from `\GuzzleHttp\json_decode` to `json_decode` fixes it and works fine
