### PR TITLE
fix php 8.0 warning if db_dsnr is used

### DIFF
--- a/program/lib/Roundcube/rcube_db.php
+++ b/program/lib/Roundcube/rcube_db.php
@@ -290,9 +290,11 @@ class rcube_db
                 }
                 else if ($mode == 'r') {
                     // connected to db with the same or "higher" mode for this table
-                    $db_mode = $this->table_connections[$table];
-                    if ($db_mode == 'w' && empty($this->options['dsnw_noread'])) {
-                        $mode = $db_mode;
+                    if (isset($this->table_connections[$table])) {
+                        $db_mode = $this->table_connections[$table];
+                        if ($db_mode == 'w' && empty($this->options['dsnw_noread'])) {
+                            $mode = $db_mode;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Fixes the warnings in php 8.0

```
Warning: Undefined array key "contactgroups" in program/lib/Roundcube/rcube_db.php on line 291

Warning: Undefined array key "searches" in program/lib/Roundcube/rcube_db.php on line 291
```

on the contacts page (`?_task=addressbook&_source=0`) on roundcube 1.5.3

This only occurs if `db_dsnr` is used.