### PR TITLE
Disable `gc_temp` in favor of an external gc

### DIFF
--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -558,6 +558,11 @@ $config['temp_dir'] = RCUBE_INSTALL_PATH . 'temp/';
 // possible units: s, m, h, d, w
 $config['temp_dir_ttl'] = '48h';
 
+// Use an external garbage collector to clean up the temp_dir
+// Useful to avoid readdir over large directories on network shares
+// Example: find /mnt/rc_temp -type f -mtime 2 -not -name 'RCMTEMP*' -exec rm -l {} \;'
+$config['external_gc_temp'] = false;
+
 // Enforce connections over https
 // With this option enabled, all non-secure connections will be redirected.
 // It can be also a port number, hostname or hostname:port if they are

--- a/program/lib/Roundcube/rcube.php
+++ b/program/lib/Roundcube/rcube.php
@@ -502,7 +502,9 @@ class rcube
     {
         rcube_cache::gc();
         $this->get_storage()->cache_gc();
-        $this->gc_temp();
+
+        if ($this->config->get('external_gc_temp', false) == false)
+            $this->gc_temp();
     }
 
     /**


### PR DESCRIPTION
Use an external garbage collector to clean up the `temp_dir`.
Useful to avoid `readdir` over large directories on network shares
