### PR TITLE
Clean duplicates in autocomplete list

### DIFF
--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -1230,6 +1230,9 @@ $config['autocomplete_threads'] = 0;
 // Max. number of entries in autocomplete popup. Default: 15.
 $config['autocomplete_max'] = 15;
 
+// Clean duplicates in automcomplete list. Default: false
+$config['autocomplete_clean_duplicates'] = true;
+
 // show address fields in this order
 // available placeholders: {street}, {locality}, {zipcode}, {country}, {region}
 $config['address_template'] = '{street}<br/>{locality} {zipcode}<br/>{country} {region}';

--- a/plugins/acl/acl.php
+++ b/plugins/acl/acl.php
@@ -207,6 +207,7 @@ class acl extends rcube_plugin
 
         $this->rc->output->set_env('autocomplete_max', (int) $this->rc->config->get('autocomplete_max', 15));
         $this->rc->output->set_env('autocomplete_min_length', $this->rc->config->get('autocomplete_min_length'));
+        $this->rc->output->set_env('autocomplete_clean_duplicates', (bool) $this->rc->config->get('autocomplete_clean_duplicates', false));
         $this->rc->output->add_label('autocompletechars', 'autocompletemore');
 
         $args['form']['sharing'] = [

--- a/program/include/rcmail_action.php
+++ b/program/include/rcmail_action.php
@@ -666,6 +666,7 @@ abstract class rcmail_action
 
         $rcmail->output->set_env('autocomplete_max', (int) $rcmail->config->get('autocomplete_max', 15));
         $rcmail->output->set_env('autocomplete_min_length', $rcmail->config->get('autocomplete_min_length'));
+        $rcmail->output->set_env('autocomplete_clean_duplicates', (bool) $rcmail->config->get('autocomplete_clean_duplicates', false));
         $rcmail->output->add_label('autocompletechars', 'autocompletemore');
     }
 

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -6033,6 +6033,11 @@ function rcube_webmail()
         text = typeof results[i] === 'object' ? (results[i].display || results[i].name) : results[i];
         type = typeof results[i] === 'object' ? results[i].type : '';
         id = i + this.env.contacts.length;
+        if (this.env.contacts.length && this.env.autocomplete_clean_duplicates) {
+          if (this.env.contacts.find(contact => contact.name == text)) {
+            continue;
+          }
+        }
         $('<li>').attr({id: 'rcmkSearchItem' + id, role: 'option'})
           .html('<i class="icon"></i>' + this.quote_html(text.replace(new RegExp('('+RegExp.escape(value)+')', 'ig'), '##$1%%')).replace(/##([^%]+)%%/g, '<b>$1</b>'))
           .addClass(type || '')


### PR DESCRIPTION
When a contact is displayed multiple time in the autocompletion list, this will clean the list to display this user only once.
There is an 'autocomplete_clean_duplicates' (false by default) parameter to activate this function in the configs.