### PR TITLE
Fix most common warnings RoundCube 1.6.1

### DIFF
--- a/program/actions/contacts/import.php
+++ b/program/actions/contacts/import.php
@@ -184,7 +184,7 @@ class rcmail_action_contacts_import extends rcmail_action_contacts_index
                     if (empty($a_record['name'])) {
                         $a_record['name'] = rcube_addressbook::compose_display_name($a_record, true);
                         // Reset it if equals to email address (from compose_display_name())
-                        if ($a_record['name'] == $a_record['email'][0]) {
+                        if ($a_record['name'] == ($a_record['email'][0] ?? null)) {
                             $a_record['name'] = '';
                         }
                     }

--- a/program/actions/mail/show.php
+++ b/program/actions/mail/show.php
@@ -320,8 +320,11 @@ class rcmail_action_mail_show extends rcmail_action_mail_index
         $dbox   = $rcmail->config->get('drafts_mbox');
 
         // the message is not a draft
-        if (self::$MESSAGE->context
-            || (self::$MESSAGE->folder != $dbox && strpos(self::$MESSAGE->folder, $dbox.$delim) !== 0)
+        if (!empty(self::$MESSAGE->context)
+            || (
+                !empty(self::$MESSAGE->folder)
+                && (self::$MESSAGE->folder != $dbox && strpos(self::$MESSAGE->folder, $dbox.$delim) !== 0)
+            )
         ) {
             return '';
         }
@@ -392,7 +395,7 @@ class rcmail_action_mail_show extends rcmail_action_mail_index
             $attrib['onerror'] = "this.onerror = null; this.src = '$placeholder';";
         }
 
-        if (self::$MESSAGE->sender) {
+        if (!empty(self::$MESSAGE->sender)) {
             $photo_img = $rcmail->url([
                     '_task'   => 'addressbook',
                     '_action' => 'photo',
@@ -642,7 +645,10 @@ class rcmail_action_mail_show extends rcmail_action_mail_index
      */
     public static function message_body($attrib)
     {
-        if (!is_array(self::$MESSAGE->parts) && empty(self::$MESSAGE->body)) {
+        if (
+            empty(self::$MESSAGE)
+            || (!is_array(self::$MESSAGE->parts) && empty(self::$MESSAGE->body))
+        ) {
             return '';
         }
 


### PR DESCRIPTION
This PR fixes some of the most common warnings found after updating to RoundCube 1.6.1

It fixes the following stack traces:

```
ErrorException: Warning: Attempt to read property "folder" on null
#10 /var/www/roundcube/program/actions/mail/show.php(324): rcmail_action_mail_show::message_buttons
#9 /var/www/roundcube/program/actions/mail/show.php(360): rcmail_action_mail_show::message_objects
#8 /var/www/roundcube/program/include/rcmail_output_html.php(1484): rcmail_output_html::xml_command
#7 [internal](0): preg_replace_callback
#6 /var/www/roundcube/program/include/rcmail_output_html.php(1322): rcmail_output_html::parse_xml
#5 /var/www/roundcube/program/include/rcmail_output_html.php(825): rcmail_output_html::parse
#4 /var/www/roundcube/program/include/rcmail_output_html.php(654): rcmail_output_html::send
#3 /var/www/roundcube/program/actions/mail/show.php(164): rcmail_action_mail_show::run
#2 /var/www/roundcube/program/include/rcmail.php(282): rcmail::action_handler
#1 /var/www/roundcube/index.php(278): include
#0 /index.php(26): null
```

```
ErrorException: Warning: Trying to access array offset on value of type null
#3 /var/www/roundcube/program/actions/contacts/import.php(187): rcmail_action_contacts_import::run
#2 /var/www/roundcube/program/include/rcmail.php(282): rcmail::action_handler
#1 /var/www/roundcube/index.php(278): include
#0 /index.php(26): null
```

```
ErrorException: Warning: Attempt to read property "sender" on null
#9 /var/www/roundcube/program/actions/mail/show.php(395): rcmail_action_mail_show::message_contactphoto
#8 /var/www/roundcube/program/include/rcmail_output_html.php(1484): rcmail_output_html::xml_command
#7 [internal](0): preg_replace_callback
#6 /var/www/roundcube/program/include/rcmail_output_html.php(1322): rcmail_output_html::parse_xml
#5 /var/www/roundcube/program/include/rcmail_output_html.php(825): rcmail_output_html::parse
#4 /var/www/roundcube/program/include/rcmail_output_html.php(654): rcmail_output_html::send
#3 /var/www/roundcube/program/actions/mail/show.php(164): rcmail_action_mail_show::run
#2 /var/www/roundcube/program/include/rcmail.php(282): rcmail::action_handler
#1 /var/www/roundcube/index.php(278): include
#0 /index.php(26): null
```

```
ErrorException: Warning: Attempt to read property "context" on null
#10 /var/www/roundcube/program/actions/mail/show.php(323): rcmail_action_mail_show::message_buttons
#9 /var/www/roundcube/program/actions/mail/show.php(360): rcmail_action_mail_show::message_objects
#8 /var/www/roundcube/program/include/rcmail_output_html.php(1484): rcmail_output_html::xml_command
#7 [internal](0): preg_replace_callback
#6 /var/www/roundcube/program/include/rcmail_output_html.php(1322): rcmail_output_html::parse_xml
#5 /var/www/roundcube/program/include/rcmail_output_html.php(825): rcmail_output_html::parse
#4 /var/www/roundcube/program/include/rcmail_output_html.php(654): rcmail_output_html::send
#3 /var/www/roundcube/program/actions/mail/show.php(164): rcmail_action_mail_show::run
#2 /var/www/roundcube/program/include/rcmail.php(282): rcmail::action_handler
#1 /var/www/roundcube/index.php(278): include
#0 /index.php(26): null
```

```
ErrorException: Warning: Trying to access array offset on value of type null
#3 /var/www/roundcube/program/actions/contacts/import.php(187): rcmail_action_contacts_import::run
#2 /var/www/roundcube/program/include/rcmail.php(282): rcmail::action_handler
#1 /var/www/roundcube/index.php(278): include
#0 /index.php(26): null
```

```
ErrorException: Warning: Attempt to read property "parts" on null
#9 /var/www/roundcube/program/actions/mail/show.php(645): rcmail_action_mail_show::message_body
#8 /var/www/roundcube/program/include/rcmail_output_html.php(1484): rcmail_output_html::xml_command
#7 [internal](0): preg_replace_callback
#6 /var/www/roundcube/program/include/rcmail_output_html.php(1322): rcmail_output_html::parse_xml
#5 /var/www/roundcube/program/include/rcmail_output_html.php(825): rcmail_output_html::parse
#4 /var/www/roundcube/program/include/rcmail_output_html.php(654): rcmail_output_html::send
#3 /var/www/roundcube/program/actions/mail/show.php(164): rcmail_action_mail_show::run
#2 /var/www/roundcube/program/include/rcmail.php(282): rcmail::action_handler
#1 /var/www/roundcube/index.php(278): include
#0 /index.php(26): null
```