### PR TITLE
Fix broken short date test with ICU >= 72.1

### DIFF
--- a/tests/Rcmail/Rcmail.php
+++ b/tests/Rcmail/Rcmail.php
@@ -279,7 +279,14 @@ class Rcmail_Rcmail extends ActionTestCase
         $this->assertSame(' Mon', $rcmail->format_date($date, ' D'));
         $this->assertSame('D Monday', $rcmail->format_date($date, '\\D l'));
         $this->assertSame('Jun June', $rcmail->format_date($date, 'M F'));
-        $this->assertSame('6/1/20, 12:20 PM', $rcmail->format_date($date, 'x'));
+        $date_x = '6/1/20, 12:20 PM';
+        if (defined('INTL_ICU_VERSION')
+              && version_compare(INTL_ICU_VERSION, '72.1', '>=')) {
+            // Starting with ICU 72.1, a NARROW NO-BREAK SPACE (NNBSP)
+            // is used instead of an ASCII space before the meridian.
+            $date_x = '6/1/20, 12:20 PM';
+        }
+        $this->assertSame($date_x, $rcmail->format_date($date, 'x'));
         $this->assertSame('1591014030', $rcmail->format_date($date, 'U'));
         $this->assertSame('2020-06-01T12:20:30+00:00', $rcmail->format_date($date, 'c'));
     }


### PR DESCRIPTION
* tests/Rcmail/Rcmail.php (test_format_date): Starting with ICU 72.1, a NARROW NO-BREAK SPACE (NNBSP) is used instead of an ASCII space before the meridian.  So, check for an NNBSP when using ICU >= 72.1.

References:
* https://icu.unicode.org/download/72
* https://cldr.unicode.org/index/downloads/cldr-42
* https://github.com/unicode-org/icu/pull/2103