### PR TITLE
Add option to add all addresses of contacts to recipients when their group is added

### DIFF
--- a/program/actions/mail/group_expand.php
+++ b/program/actions/mail/group_expand.php
@@ -40,11 +40,21 @@ class rcmail_action_mail_group_expand extends rcmail_action
 
             $result  = $abook->list_records($rcmail->config->get('contactlist_fields'));
             $members = [];
+            $group_expand_all_emails = (bool) $rcmail->config->get('group_expand_all_emails');
 
             while ($result && ($record = $result->iterate())) {
-                $email = array_first((array) $abook->get_col_values('email', $record, true));
-                if (!empty($email)) {
-                    $members[] = format_email_recipient($email, rcube_addressbook::compose_list_name($record));
+                foreach ( (array) $abook->get_col_values('email', $record, true) as $email) {
+                    if (!empty($email)) {
+                        $members[] = format_email_recipient($email, 
+                                        rcube_addressbook::compose_list_name($record));
+
+                        // If we have expanded one email address for this recipient 
+                        // and do not want to expand all addresses for contacts in groups, 
+                        // we are done for this recipient
+                        if(!$group_expand_all_emails){
+                            break;
+                        }
+                    }
                 }
             }
 

--- a/program/actions/settings/index.php
+++ b/program/actions/settings/index.php
@@ -1183,6 +1183,20 @@ class rcmail_action_settings_index extends rcmail_action
                     ];
                 }
 
+                if (!isset($no_override['group_expand_all_emails'])) {
+                    if (!$current) {
+                        continue 2;
+                    }
+
+                    $field_id = 'rcmfd_group_expand_all_emails';
+                    $checkbox = new html_checkbox(['name' => '_group_expand_all_emails', 'id' => $field_id, 'value' => 1]);
+
+                    $blocks['main']['options']['group_expand_all_emails'] = [
+                        'title'   => html::label($field_id, rcube::Q($rcmail->gettext('groupexpandallemails'))),
+                        'content' => $checkbox->show($config['group_expand_all_emails']?1:0),
+                    ];
+                }
+
                 if (!isset($no_override['collected_recipients'])) {
                     if (!$current) {
                         continue 2;

--- a/program/actions/settings/prefs_save.php
+++ b/program/actions/settings/prefs_save.php
@@ -116,14 +116,15 @@ class rcmail_action_settings_prefs_save extends rcmail_action
 
         case 'addressbook':
             $a_user_prefs = [
-                'default_addressbook'  => rcube_utils::get_input_string('_default_addressbook', rcube_utils::INPUT_POST, true),
-                'collected_recipients' => rcube_utils::get_input_string('_collected_recipients', rcube_utils::INPUT_POST, true),
-                'collected_senders'    => rcube_utils::get_input_string('_collected_senders', rcube_utils::INPUT_POST, true),
-                'autocomplete_single'  => isset($_POST['_autocomplete_single']),
-                'addressbook_sort_col' => self::prefs_input('addressbook_sort_col', '/^[a-z_]+$/'),
+                'default_addressbook'      => rcube_utils::get_input_string('_default_addressbook', rcube_utils::INPUT_POST, true),
+                'collected_recipients'     => rcube_utils::get_input_string('_collected_recipients', rcube_utils::INPUT_POST, true),
+                'collected_senders'        => rcube_utils::get_input_string('_collected_senders', rcube_utils::INPUT_POST, true),
+                'autocomplete_single'      => isset($_POST['_autocomplete_single']),
+                'group_expand_all_emails'  => isset($_POST['_group_expand_all_emails']),
+                'addressbook_sort_col'     => self::prefs_input('addressbook_sort_col', '/^[a-z_]+$/'),
                 'addressbook_name_listing' => self::prefs_input_int('addressbook_name_listing'),
-                'addressbook_pagesize' => max(2, self::prefs_input_int('addressbook_pagesize')),
-                'contact_form_mode'    => self::prefs_input('contact_form_mode', '/^(private|business)$/'),
+                'addressbook_pagesize'     => max(2, self::prefs_input_int('addressbook_pagesize')),
+                'contact_form_mode'        => self::prefs_input('contact_form_mode', '/^(private|business)$/'),
             ];
 
             break;

--- a/program/localization/de_DE/labels.inc
+++ b/program/localization/de_DE/labels.inc
@@ -548,6 +548,7 @@ $labels['reqdsn'] = 'Übermittlungsbestätigung (DSN) immer anfordern';
 $labels['replysamefolder'] = 'Antworten im selben Ordner wie Original speichern';
 $labels['defaultabook'] = 'Standardadressbuch';
 $labels['autocompletesingle'] = 'Alternative E-Mail-Adressen bei der Auto-Vervollständigung nicht berücksichtigen';
+$labels['groupexpandallemails'] = 'Alle E-Mail-Adressen einfügen, wenn ein Empfänger als Teil einer Gruppe hinzugefügt wird';
 $labels['listnamedisplay'] = 'Kontakte auflisten als';
 $labels['contactformmode'] = 'Kontaktformular-Modus';
 $labels['privatemode'] = 'Privat (Zuhause)';

--- a/program/localization/en_US/labels.inc
+++ b/program/localization/en_US/labels.inc
@@ -609,6 +609,7 @@ $labels['reqdsn'] = 'Always request a delivery status notification';
 $labels['replysamefolder'] = 'Place replies in the folder of the message being replied to';
 $labels['defaultabook'] = 'Default address book';
 $labels['autocompletesingle'] = 'Skip alternative email addresses in autocompletion';
+$labels['groupexpandallemails'] = 'Expand all email addresses for recipients added as part of a group';
 $labels['listnamedisplay'] = 'List contacts as';
 $labels['contactformmode'] = 'Contact form mode';
 $labels['privatemode'] = 'Private (Home)';


### PR DESCRIPTION
As discussed in issue #7742 it is difficult to add all email-addresses of contacts to the recipients when they are organized in groups. To make it easier this PR implements an option to expand all addresses of all contacts in a group when the group is added to the recipients of an email.