### PR TITLE
[managesieve] allow custom USER-scriptname in kolab-mode

### DIFF
--- a/plugins/managesieve/config.inc.php.dist
+++ b/plugins/managesieve/config.inc.php.dist
@@ -65,6 +65,9 @@ $config['managesieve_debug'] = false;
 // Enables features described in http://wiki.kolab.org/KEP:14
 $config['managesieve_kolab_master'] = false;
 
+// Name of kolab USER file, applies only on active managesieve_kolab_master
+$config['managesieve_kolab_userscript'] = 'USER'
+
 // Script name extension used for scripts including. Dovecot uses '.sieve',
 // Cyrus uses '.siv'. Doesn't matter if you have managesieve_kolab_master disabled.
 $config['managesieve_filename_extension'] = '.sieve';

--- a/plugins/managesieve/lib/Roundcube/rcube_sieve_engine.php
+++ b/plugins/managesieve/lib/Roundcube/rcube_sieve_engine.php
@@ -577,7 +577,7 @@ class rcube_sieve_engine
             else if (!empty($exceptions) && in_array($name, (array)$exceptions)) {
                 $this->errors['name'] = $this->plugin->gettext('namereserved');
             }
-            else if (!empty($kolab) && in_array($name_uc, ['MASTER', 'USER', 'MANAGEMENT'])) {
+            else if (!empty($kolab) && in_array($name_uc, ['MASTER', 'MANAGEMENT', $this->rc->config->get('managesieve_kolab_userscript', 'USER')])) {
                 $this->errors['name'] = $this->plugin->gettext('namereserved');
             }
             else if (in_array($name, $list)) {
@@ -2943,6 +2943,8 @@ class rcube_sieve_engine
 
         // Handle active script(s) and list of scripts according to Kolab's KEP:14
         if ($this->rc->config->get('managesieve_kolab_master')) {
+            // Allow custom USER scriptname
+            $kolab_userscript_name = $this->rc->config->get('managesieve_kolab_userscript', 'USER');
             // Skip protected names
             foreach ((array) $this->list as $idx => $name) {
                 $_name = strtoupper($name);
@@ -2952,7 +2954,7 @@ class rcube_sieve_engine
                 else if ($_name == 'MANAGEMENT') {
                     $management_script = $name;
                 }
-                else if ($_name == 'USER') {
+                else if ($_name == $kolab_userscript_name) {
                     $user_script = $name;
                 }
                 else {
@@ -2992,10 +2994,10 @@ class rcube_sieve_engine
                     ."# For more information, see http://wiki.kolab.org/KEP:14#USER\n"
                     ."#\n";
 
-                if ($this->sieve->save_script('USER', $content)) {
-                    $_SESSION['managesieve_user_script'] = 'USER';
+                if ($this->sieve->save_script($kolab_userscript_name, $content)) {
+                    $_SESSION['managesieve_user_script'] = $kolab_userscript_name;
                     if (empty($this->master_file)) {
-                        $this->sieve->activate('USER');
+                        $this->sieve->activate($kolab_userscript_name);
                     }
                 }
             }


### PR DESCRIPTION
Hello,

we have an kolab-like sieve enviroment, where there's an generated sieve-script file which then includes the users own script.
With this patch the hardcoded USER-Scriptname can be customized, so that users can use all the roundcube sieve-features and we still have the company-generated in place and activated.