### PR TITLE
Enable UTF8=ACCEPT if the IMAP server supports that.

### DIFF
--- a/program/lib/Roundcube/rcube.php
+++ b/program/lib/Roundcube/rcube.php
@@ -1714,6 +1714,10 @@ class rcube
             }
         }
 
+        if (preg_match('/[\x80-\xff]/u', $domain_part)) {
+            $domain_part = idn_to_ascii($domain_part);
+        }
+
         return sprintf('<%s@%s>', $local_part, $domain_part);
     }
 

--- a/program/lib/Roundcube/rcube_imap_generic.php
+++ b/program/lib/Roundcube/rcube_imap_generic.php
@@ -1012,6 +1012,11 @@ class rcube_imap_generic
                 $this->data['ID'] = $this->id($this->prefs['ident']);
             }
 
+            // Enable unicode addresses if the server supports it
+            if ($this->hasCapability('ENABLE')) {
+                $this->enable( "UTF8=ACCEPT" ); 
+            }
+
             return true;
         }
 

--- a/tests/Framework/Rcube.php
+++ b/tests/Framework/Rcube.php
@@ -41,6 +41,23 @@ class Framework_Rcube extends PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test that gen_message_id produces a message-ID that can be
+     * used safely in References and In-Reply-To messages.
+     */
+    function test_gen_message_id()
+    {
+        $rcube = rcube::get_instance();
+
+        $result = $rcube->gen_message_id('a@example.com');
+        $result = preg_replace('/.*@/', '', $result);
+        $this->assertSame('example.com>', $result);
+
+        $result = $rcube->gen_message_id('a@dømi.fo');
+        $result = preg_replace('/.*@/', '', $result);
+        $this->assertSame('xn--dmi-0na.fo>', $result);
+   }
+
+    /**
      * rcube::encrypt() and rcube::decrypt()
      */
     function test_encrypt_and_decrypt()

--- a/tests/Framework/Smtp.php
+++ b/tests/Framework/Smtp.php
@@ -45,6 +45,34 @@ class Framework_Smtp extends PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test preparing unicode headers.
+     *
+     * When either the sender or any recipient requires EAI, then it's
+     * okay to send UTF-8 in headers (without RFC2047 encoding, that
+     * is). This test tests that Roundcube chooses plain UTF-8 in the
+     * Subject, in a the display-name of an address, and in the
+     * message-id.
+     */
+    function test_prepare_unicode_headers()
+    {
+        $smtp = new rcube_smtp;
+
+        $headers = [
+            'Subject' => 'भारत',
+            'From' => '"भारत" <भारत@भारत.भारत>'
+        ];
+
+        $result = invokeMethod($smtp, '_prepare_headers', [$headers]);
+
+        $this->assertCount(2, $result);
+        $this->assertSame('भारत@भारत.भारत', $result[0]);
+        $this->assertSame(
+            "Subject: भारत\r\nFrom: \"भारत\" <भारत@भारत.भारत>\r\n",
+            $result[1]
+        );
+    }
+
+    /**
      * Test parsing email address input
      */
     function test_parse_rfc822()


### PR DESCRIPTION
With this tiny patch, Roundcube supports using arabic email addresses flawlessly. (Hardly anyone else does, but someone has to be first.)

Note that it's not necessary to check for hasCapability("UTF8=ACCEPT"), RFC5161 permits clients to request enabling whatever they want, even things the server does not support.