### PR TITLE
add delete field to message list

### DIFF
--- a/program/actions/mail/index.php
+++ b/program/actions/mail/index.php
@@ -389,7 +389,7 @@ class rcmail_action_mail_index extends rcmail_action
         $rcmail->output->set_env('sort_order', $_SESSION['sort_order']);
         $rcmail->output->set_env('messages', []);
         $rcmail->output->set_env('listcols', $listcols);
-        $rcmail->output->set_env('listcols_widescreen', ['threads', 'subject', 'fromto', 'date', 'size', 'flag', 'attachment']);
+        $rcmail->output->set_env('listcols_widescreen', ['threads', 'subject', 'fromto', 'date', 'size', 'flag', 'attachment', 'delete']);
 
         $rcmail->output->include_script('list.js');
 
@@ -471,7 +471,7 @@ class rcmail_action_mail_index extends rcmail_action
         $a_headers   = $plugin['messages'];
 
         // make sure minimum required columns are present (needed for widescreen layout)
-        $allcols = array_merge($a_show_cols, ['threads', 'subject', 'fromto', 'date', 'size', 'flag', 'attachment']);
+        $allcols = array_merge($a_show_cols, ['threads', 'subject', 'fromto', 'date', 'size', 'flag', 'attachment', 'delete']);
         $allcols = array_unique($allcols);
 
         $thead = !empty($head_replace) ? self::message_list_head($_SESSION['list_attrib'], $allcols) : null;

--- a/program/actions/mail/index.php
+++ b/program/actions/mail/index.php
@@ -146,7 +146,7 @@ class rcmail_action_mail_index extends rcmail_action
                     'flagged', 'unflagged', 'unread', 'deleted', 'replied', 'forwarded',
                     'priority', 'withattachment', 'fileuploaderror', 'mark', 'markallread',
                     'folders-cur', 'folders-sub', 'folders-all', 'cancel', 'bounce', 'bouncemsg',
-                    'sendingmessage');
+                    'sendingmessage', 'restore');
             }
         }
 

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -3184,6 +3184,13 @@ function rcube_webmail()
       $(row.flagicon).attr('class', css_class)
         .attr({'aria-label': label, title: label});
     }
+
+    if (row.deleteicon) {
+      css_class = (row.deleted ? 'undelete' : 'delete');
+      label = this.get_label(row.deleted ? 'restore' : 'delete');
+      $(row.deleteicon).attr('class', css_class)
+        .attr({'aria-label': label, title: label});
+    }
   };
 
   // set message status
@@ -3216,15 +3223,6 @@ function rcube_webmail()
 
     if (flag)
       this.set_message_status(uid, flag, status);
-
-    if (flag == 'deleted' && $(row.obj).find('span.delete').length > 0) {
-      if (row[flag]) {
-        $(row.obj).find('span.delete span.delete').removeClass('delete').addClass('undelete');
-      }
-      else {
-        $(row.obj).find('span.delete span.undelete').removeClass('undelete').addClass('delete');
-      }
-    }
 
     if ($.inArray(flag, ['unread', 'deleted', 'flagged']) > -1)
       $(row.obj)[row[flag] ? 'addClass' : 'removeClass'](flag);

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -3221,6 +3221,15 @@ function rcube_webmail()
     if (flag)
       this.set_message_status(uid, flag, status);
 
+    if (flag == 'deleted' && $(row.obj).find('span.delete').length > 0) {
+      if (row[flag]) {
+        $(row.obj).find('span.delete span.delete').removeClass('delete').addClass('undelete');
+      }
+      else {
+        $(row.obj).find('span.delete span.undelete').removeClass('undelete').addClass('delete');
+      }
+    }
+
     if ($.inArray(flag, ['unread', 'deleted', 'flagged']) > -1)
       $(row.obj)[row[flag] ? 'addClass' : 'removeClass'](flag);
 

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -2354,7 +2354,7 @@ function rcube_webmail()
       }
       else if (c == 'delete') {
         css_class = (flags.deleted ? 'undelete' : 'delete');
-        label = this.get_label(css_class);
+        label = this.get_label(flags.deleted ? 'restore' : 'delete');
         html = '<span id="deleteicn'+row.id+'" class="'+css_class+'" title="'+label+'"></span>';
       }
       else if (c == 'attachment') {

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -1049,25 +1049,21 @@ function rcube_webmail()
       case 'toggle_flag':
       case 'toggle_delete':
         if (uid = props) {
-          if (command == 'toggle_delete' && props && !this.message_list.rows[uid].deleted) {
-            this.delete_messages(event, uid);
-          }
-          else {
-            flag = command == 'toggle_flag' ? 'flagged' : 'read';
+          var flag;
 
-            // toggle flagged/unflagged
-            if (flag == 'flagged') {
-              if (this.message_list.rows[uid].flagged)
-                flag = 'unflagged';
-            }
-            // toggle read/unread
-            else if (this.message_list.rows[uid].deleted)
+          if (command == 'toggle_flag')
+            flag = this.message_list.rows[uid].flagged ? 'unflagged' : 'flagged';
+          else if (command == 'toggle_status' && !this.message_list.rows[uid].deleted)
+            flag = !this.message_list.rows[uid].unread ? 'unread' : 'read';
+          else if (command == 'toggle_delete') {
+            if (!this.message_list.rows[uid].deleted)
+              this.delete_messages(event, uid);
+            else
               flag = 'undelete';
-            else if (!this.message_list.rows[uid].unread)
-              flag = 'unread';
-
-            this.mark_message(flag, uid);
           }
+
+          if (flag)
+            this.mark_message(flag, uid);
         }
 
         break;

--- a/skins/elastic/styles/colors.less
+++ b/skins/elastic/styles/colors.less
@@ -239,6 +239,7 @@
 @color-dark-list-deleted:               darken(@color-dark-hint, 15%);
 @color-dark-list-droptarget-background: #4d4d00;
 @color-dark-list-border:                #2c373a;
+@color-dark-list-icon:                  fadeout(@color-dark-font, 25%);
 
 @color-dark-input:                      @color-dark-font;
 @color-dark-input-border:               #7c949c;

--- a/skins/elastic/styles/dark.less
+++ b/skins/elastic/styles/dark.less
@@ -293,7 +293,7 @@ html.dark-mode {
         color: @color-dark-font;
 
         tr:not(.deleted) td.flags > span {
-            color: @color-dark-font;
+            color: @color-dark-list-icon;
         }
 
         tr:not(.flagged):not(.deleted) {
@@ -341,7 +341,7 @@ html.dark-mode {
         }
 
         span.attachment span {
-            color: @color-dark-hint;
+            color: @color-dark-list-icon;
         }
     }
 

--- a/skins/elastic/styles/dark.less
+++ b/skins/elastic/styles/dark.less
@@ -292,6 +292,10 @@ html.dark-mode {
     .messagelist {
         color: @color-dark-font;
 
+        tr:not(.deleted) td.flags > span {
+            color: @color-dark-font;
+        }
+
         tr:not(.flagged):not(.deleted) {
             td.subject {
                 span.size,
@@ -309,10 +313,6 @@ html.dark-mode {
                 }
             }
 
-            span.flag {
-                color: @color-dark-font;
-            }
-
             &.selected {
                 td.subject {
                     a,
@@ -323,11 +323,8 @@ html.dark-mode {
             }
         }
 
-        tr.flagged:not(.deleted) {
-            td,
-            span.attachment span {
-                color: @color-list-flagged;
-            }
+        tr.flagged:not(.deleted) td {
+            color: @color-list-flagged;
         }
 
         tr.deleted {
@@ -337,7 +334,8 @@ html.dark-mode {
             td.subject span.msgicon.status.unread:before,
             td.subject span.subject a,
             td.subject span.date,
-            td.subject span.fromto {
+            td.subject span.fromto,
+            td.flags span span {
                 color: @color-dark-list-deleted;
             }
         }

--- a/skins/elastic/styles/widgets/lists.less
+++ b/skins/elastic/styles/widgets/lists.less
@@ -763,7 +763,7 @@ table.fixedcopy {
 
         > span.delete:before {
             &:extend(.font-icon-class);
-            .font-icon-regular(@fa-var-trash-alt);
+            content: @fa-var-trash-alt;
         }
     }
 
@@ -778,11 +778,6 @@ table.fixedcopy {
         .font-icon-regular(@fa-var-flag);
     }
 
-    tr:not(.deleted) span.unflagged:hover:before {
-        .font-icon-solid(@fa-var-flag);
-        color: @color-list-flagged;
-    }
-
     tr:not(.deleted):hover {
         span.attachment {
             display: none !important;
@@ -790,11 +785,6 @@ table.fixedcopy {
 
         span.delete {
             display: block !important;
-
-            > span.delete:hover:before {
-                color: @color-error;
-                .font-icon-solid(@fa-var-trash-alt);
-            }
         }
     }
 

--- a/skins/elastic/styles/widgets/lists.less
+++ b/skins/elastic/styles/widgets/lists.less
@@ -720,6 +720,7 @@ table.fixedcopy {
 
     tr.deleted td.subject span.msgicon.status {
         &:before {
+            cursor: default;
             .font-icon-solid(@fa-var-ban) !important;
             font-size: 1rem;
         }

--- a/skins/elastic/styles/widgets/lists.less
+++ b/skins/elastic/styles/widgets/lists.less
@@ -624,7 +624,8 @@ table.fixedcopy {
             line-height: 1.7em;
             display: block;
 
-            &.flag {
+            &.flag,
+            &.delete {
                 cursor: pointer;
             }
         }
@@ -744,6 +745,15 @@ table.fixedcopy {
         content: @fa-var-flag;
     }
 
+    span.delete {
+        display: none !important;
+
+        > span.delete:before {
+            &:extend(.font-icon-class);
+            .font-icon-regular(@fa-var-trash-alt);
+        }
+    }
+
     tr.flaggedroot:not(:hover) span.unflagged:before {
         &:extend(.font-icon-class);
         content: @fa-var-flag;
@@ -753,6 +763,16 @@ table.fixedcopy {
     tr:hover span.unflagged:before {
         &:extend(.font-icon-class);
         .font-icon-regular(@fa-var-flag);
+    }
+
+    tr:not(.deleted):hover {
+        span.attachment {
+            display: none !important;
+        }
+
+        span.delete {
+            display: block !important;
+        }
     }
 
     span.size {

--- a/skins/elastic/styles/widgets/lists.less
+++ b/skins/elastic/styles/widgets/lists.less
@@ -623,11 +623,19 @@ table.fixedcopy {
             height: 1.7em;
             line-height: 1.7em;
             display: block;
+            color: @color-list;
 
             &.flag,
             &.delete {
                 cursor: pointer;
             }
+        }
+    }
+
+    tr.deleted:not(.flagged) td.flags > span {
+        &.flag,
+        &.delete {
+            cursor: auto;
         }
     }
 
@@ -641,7 +649,8 @@ table.fixedcopy {
     tr.deleted td,
     tr.deleted td.subject span.subject a,
     tr.deleted td.subject span.date,
-    tr.deleted td.subject span.fromto {
+    tr.deleted td.subject span.fromto,
+    tr.deleted td.flags span span {
         color: @color-list-deleted;
     }
 
@@ -745,6 +754,10 @@ table.fixedcopy {
         content: @fa-var-flag;
     }
 
+    tr:not(.deleted) span.flagged:before {
+        color: @color-list-flagged;
+    }
+
     span.delete {
         display: none !important;
 
@@ -760,9 +773,14 @@ table.fixedcopy {
         color: @color-list-icon;
     }
 
-    tr:hover span.unflagged:before {
+    tr:not(.deleted):hover span.unflagged:before {
         &:extend(.font-icon-class);
         .font-icon-regular(@fa-var-flag);
+    }
+
+    tr:not(.deleted) span.unflagged:hover:before {
+        .font-icon-solid(@fa-var-flag);
+        color: @color-list-flagged;
     }
 
     tr:not(.deleted):hover {
@@ -772,6 +790,11 @@ table.fixedcopy {
 
         span.delete {
             display: block !important;
+
+            > span.delete:hover:before {
+                color: @color-error;
+                .font-icon-solid(@fa-var-trash-alt);
+            }
         }
     }
 

--- a/skins/elastic/styles/widgets/lists.less
+++ b/skins/elastic/styles/widgets/lists.less
@@ -633,8 +633,7 @@ table.fixedcopy {
     }
 
     tr.deleted:not(.flagged) td.flags > span {
-        &.flag,
-        &.delete {
+        &.flag {
             cursor: auto;
         }
     }
@@ -765,6 +764,11 @@ table.fixedcopy {
             &:extend(.font-icon-class);
             content: @fa-var-trash-alt;
         }
+
+        > span.undelete:before {
+            &:extend(.font-icon-class);
+            content: @fa-var-redo;
+        }
     }
 
     tr.flaggedroot:not(:hover) span.unflagged:before {
@@ -778,7 +782,7 @@ table.fixedcopy {
         .font-icon-regular(@fa-var-flag);
     }
 
-    tr:not(.deleted):hover {
+    tr:hover {
         span.attachment {
             display: none !important;
         }

--- a/skins/elastic/styles/widgets/lists.less
+++ b/skins/elastic/styles/widgets/lists.less
@@ -623,7 +623,7 @@ table.fixedcopy {
             height: 1.7em;
             line-height: 1.7em;
             display: block;
-            color: @color-list;
+            color: @color-list-icon;
 
             &.flag,
             &.delete {


### PR DESCRIPTION
Inspired by #7141

![Untitled-1](https://user-images.githubusercontent.com/88682/219968896-5c6fa06e-d975-47e0-a7c4-de273f6f3995.png)

Currently when hovering over a message in the list, for messages which are not flagged, a flag icon is displayed in the top right corner of the row. Also the message date is replaced with the message size.

This PR adds a new delete column to the message list so that in widescreen view a delete icon can be shown in additional to the flag icon. This delete icon is shown directly below the flag icon. For messages which have attachments the attachment icon is replaced by the delete icon on hover.

*This is a breaking change*.
A new span for the delete icon is added into the `flags` \<td\>.  I can create PRs for the legacy Classic and Larry skins to prevent display issues.