### PR TITLE
include source folder name in message details when multi folder search acitve

### DIFF
--- a/program/actions/mail/index.php
+++ b/program/actions/mail/index.php
@@ -248,8 +248,10 @@ class rcmail_action_mail_index extends rcmail_action
     /**
      * Pretty folder path
      */
-    public static function pretty_folderpath($mbox_name, $delimiter = null)
+    public static function pretty_folderpath($mbox_name)
     {
+        static $delimiter;
+
         if (empty($delimiter)) {
             $delimiter = rcmail::get_instance()->storage->get_hierarchy_delimiter();
         }
@@ -460,7 +462,6 @@ class rcmail_action_mail_index extends rcmail_action
             $head_replace = true;
         }
 
-        $delimiter = $rcmail->storage->get_hierarchy_delimiter();
         $search_set = $rcmail->storage->get_search_set();
         $multifolder = $search_set && !empty($search_set[1]->multi);
 
@@ -568,7 +569,7 @@ class rcmail_action_mail_index extends rcmail_action
                 } elseif ($col == 'folder') {
                     if (!isset($last_folder) || !isset($last_folder_name) || $last_folder !== $header->folder) {
                         $last_folder = $header->folder;
-                        $last_folder_name = self::pretty_folderpath($last_folder, $delimiter);
+                        $last_folder_name = self::pretty_folderpath($last_folder);
                     }
 
                     $cont = rcube::SQ($last_folder_name);

--- a/program/actions/mail/index.php
+++ b/program/actions/mail/index.php
@@ -239,12 +239,25 @@ class rcmail_action_mail_index extends rcmail_action
             $pagetitle = $rcmail->gettext('searchresult');
         } else {
             $mbox_name = $rcmail->output->get_env('mailbox') ?: $rcmail->storage->get_folder();
-            $delimiter = $rcmail->storage->get_hierarchy_delimiter();
-            $pagetitle = self::localize_foldername($mbox_name, true);
-            $pagetitle = str_replace($delimiter, " \xC2\xBB ", $pagetitle);
+            $pagetitle = self::pretty_folderpath($mbox_name);
         }
 
         $rcmail->output->set_pagetitle($pagetitle);
+    }
+
+    /**
+     * Pretty folder path
+     */
+    public static function pretty_folderpath($mbox_name, $delimiter = null)
+    {
+        if (empty($delimiter)) {
+            $delimiter = rcmail::get_instance()->storage->get_hierarchy_delimiter();
+        }
+
+        $folderpath = self::localize_foldername($mbox_name, true);
+        $folderpath = str_replace($delimiter, " \xC2\xBB ", $folderpath);
+
+        return $folderpath;
     }
 
     /**
@@ -555,8 +568,7 @@ class rcmail_action_mail_index extends rcmail_action
                 } elseif ($col == 'folder') {
                     if (!isset($last_folder) || !isset($last_folder_name) || $last_folder !== $header->folder) {
                         $last_folder = $header->folder;
-                        $last_folder_name = self::localize_foldername($last_folder, true);
-                        $last_folder_name = str_replace($delimiter, " \xC2\xBB ", $last_folder_name);
+                        $last_folder_name = self::pretty_folderpath($last_folder, $delimiter);
                     }
 
                     $cont = rcube::SQ($last_folder_name);

--- a/program/actions/mail/show.php
+++ b/program/actions/mail/show.php
@@ -433,7 +433,7 @@ class rcmail_action_mail_show extends rcmail_action_mail_index
 
         // show these headers
         $standard_headers = ['subject', 'from', 'sender', 'to', 'cc', 'bcc', 'replyto',
-            'mail-reply-to', 'mail-followup-to', 'date', 'priority'];
+            'mail-reply-to', 'mail-followup-to', 'date', 'priority', 'folder'];
         $exclude_headers = !empty($attrib['exclude']) ? explode(',', $attrib['exclude']) : [];
         $output_headers = [];
 
@@ -488,6 +488,19 @@ class rcmail_action_mail_show extends rcmail_action_mail_index
                 $ishtml = true;
             } elseif ($hkey == 'subject' && empty($value)) { // @phpstan-ignore-line
                 $header_value = $rcmail->gettext('nosubject');
+            } elseif ($hkey == 'folder') {
+                if (empty($_REQUEST['_search'])) {
+                    continue;
+                }
+
+                $search_set  = $rcmail->storage->get_search_set();
+                $multifolder = $search_set && !empty($search_set[1]->multi);
+                if ($multifolder) {
+                    $mbox_name    = $rcmail->storage->get_folder();
+                    $delimiter    = $rcmail->storage->get_hierarchy_delimiter();
+                    $header_value = self::localize_foldername($mbox_name, true);
+                    $header_value = str_replace($delimiter, " \xC2\xBB ", $header_value);
+                }
             } else {
                 $value = is_array($value) ? implode(' ', $value) : $value;
                 $header_value = trim(rcube_mime::decode_header($value, $charset));

--- a/program/actions/mail/show.php
+++ b/program/actions/mail/show.php
@@ -493,11 +493,11 @@ class rcmail_action_mail_show extends rcmail_action_mail_index
                     continue;
                 }
 
-                $search_set  = $rcmail->storage->get_search_set();
+                $search_set = $rcmail->storage->get_search_set();
                 $multifolder = $search_set && !empty($search_set[1]->multi);
                 if ($multifolder) {
-                    $mbox_name    = $rcmail->storage->get_folder();
-                    $delimiter    = $rcmail->storage->get_hierarchy_delimiter();
+                    $mbox_name = $rcmail->storage->get_folder();
+                    $delimiter = $rcmail->storage->get_hierarchy_delimiter();
                     $header_value = self::localize_foldername($mbox_name, true);
                     $header_value = str_replace($delimiter, " \xC2\xBB ", $header_value);
                 }


### PR DESCRIPTION
possible solution for https://github.com/roundcube/roundcubemail/issues/7950

adds a "Folder" entry to the message details (To, From, Date, etc) show at the top of the message display when a multi folder search is active. Only visible in the details (expanded) view, no the summary.