### PR TITLE
add signature template to new_user_dialog plugin

### DIFF
--- a/plugins/new_user_dialog/README.md
+++ b/plugins/new_user_dialog/README.md
@@ -1,0 +1,15 @@
+# RoundCube New User Dialog Plugin
+When a new user is created, this plugin checks the default identity and sets a session flag in case it is incomplete. An overlay box will appear on the screen until the user has reviewed/completed his identity.
+
+## Configuration
+Optional you can specify the default signature, `@EMAIL@` is replaced by the user email.
+
+```
+$config['new_user_dialog_signature_text'] = '
+Your Name
+
+E-Mail : @EMAIL@
+Website: some.domain
+Phone: 01234/567890
+';
+```

--- a/plugins/new_user_dialog/new_user_dialog.php
+++ b/plugins/new_user_dialog/new_user_dialog.php
@@ -19,9 +19,12 @@ class new_user_dialog extends rcube_plugin
 
     function init()
     {
+        $rcmail = rcmail::get_instance();
+        $this->load_config();
         $this->add_hook('identity_create', [$this, 'create_identity']);
         $this->add_hook('render_page', [$this, 'render_page']);
         $this->register_action('plugin.newusersave', [$this, 'save_data']);
+        $this->signature_text = $rcmail->config->get('new_user_dialog_signature_text');
     }
 
     /**
@@ -89,6 +92,7 @@ class new_user_dialog extends rcube_plugin
                     'name' => '_signature',
                     'rows' => '5',
                 ],
+                $out = str_replace('@EMAIL@', rcube_utils::idn_to_utf8($identity['email']) , $this->signature_text ?? ''),
                 $identity['signature']
             ));
 

--- a/plugins/new_user_dialog/new_user_dialog.php
+++ b/plugins/new_user_dialog/new_user_dialog.php
@@ -19,12 +19,9 @@ class new_user_dialog extends rcube_plugin
 
     function init()
     {
-        $rcmail = rcmail::get_instance();
-        $this->load_config();
         $this->add_hook('identity_create', [$this, 'create_identity']);
         $this->add_hook('render_page', [$this, 'render_page']);
         $this->register_action('plugin.newusersave', [$this, 'save_data']);
-        $this->signature_text = $rcmail->config->get('new_user_dialog_signature_text');
     }
 
     /**
@@ -52,6 +49,13 @@ class new_user_dialog extends rcube_plugin
 
             $identity         = $rcmail->user->get_identity();
             $identities_level = intval($rcmail->config->get('identities_level', 0));
+            $signature        = $identity['signature'] ?? '';
+
+            if (empty($signature)) {
+                $this->load_config();
+                $signature_text = $rcmail->config->get('new_user_dialog_signature_text', '');
+                $signature      = str_replace('@EMAIL@', rcube_utils::idn_to_utf8($identity['email']), $signature_text);
+            }
 
             // compose user-identity dialog
             $table = new html_table(['cols' => 2, 'class' => 'propform']);
@@ -92,8 +96,7 @@ class new_user_dialog extends rcube_plugin
                     'name' => '_signature',
                     'rows' => '5',
                 ],
-                $out = str_replace('@EMAIL@', rcube_utils::idn_to_utf8($identity['email']) , $this->signature_text ?? ''),
-                $identity['signature']
+                rcube::Q($signature, 'strict', false)
             ));
 
             // add overlay input box to html page


### PR DESCRIPTION
This adds the possibility to define a default signature. Additionally the signature email gets replaced with the user email if `@EMAIL@` get added at the signature.

To configure the default signature add this to the `config/config.inc.php`

`$config['new_user_dialog_signature_text'] = ' ... ';`

Just for full transparency, I have no PHP skills. So while it works perfectly for me I have no real idea if this is "properly" done.