### PR TITLE
Yet another PHP 8 dynamic property deprecation warning

### DIFF
--- a/program/lib/Roundcube/rcube_message.php
+++ b/program/lib/Roundcube/rcube_message.php
@@ -67,6 +67,7 @@ class rcube_message
     public $is_safe      = false;
     public $pgp_mime     = false;
     public $encrypted_part;
+    public $reply_all;
 
     const BODY_MAX_SIZE = 1048576; // 1MB
 


### PR DESCRIPTION
fixes "Creation of dynamic property rcube_message::$reply_all is deprecated"
in program/actions/mail/compose.php
and in program/include/rcmail_sendmail.php