### PR TITLE
create template object for message list actions

### DIFF
--- a/program/actions/mail/index.php
+++ b/program/actions/mail/index.php
@@ -719,14 +719,14 @@ class rcmail_action_mail_index extends rcmail_action
         $config = $rcmail->config->get('message_actions', ['size', 'date', 'flag', 'delete']);
 
         $actions = [
-            'size'      => null,
-            'date'      => null,
-            'read'      => ['label' => 'markasread', 'action' => 'mark/read'],
-            'unread'    => ['label' => 'markasunread', 'action' => 'mark/unread'],
-            'flag'      => ['label' => 'markasflagged', 'action' => 'mark/flagged'],
-            'unflag'    => ['label' => 'markasunflagged', 'action' => 'mark/unflagged'],
-            'delete'    => ['label' => 'deletemessage', 'action' => 'delete'],
-            'undelete'  => ['label' => 'undeletemessage', 'action' => 'mark/undelete'],
+            'size' => null,
+            'date' => null,
+            'read' => ['label' => 'markasread', 'action' => 'mark/read'],
+            'unread' => ['label' => 'markasunread', 'action' => 'mark/unread'],
+            'flag' => ['label' => 'markasflagged', 'action' => 'mark/flagged'],
+            'unflag' => ['label' => 'markasunflagged', 'action' => 'mark/unflagged'],
+            'delete' => ['label' => 'deletemessage', 'action' => 'delete'],
+            'undelete' => ['label' => 'undeletemessage', 'action' => 'mark/undelete'],
         ];
 
         $actions = array_filter($actions, static function ($action) use ($config) {
@@ -749,7 +749,7 @@ class rcmail_action_mail_index extends rcmail_action
         if (isset($attrib['actions'])) {
             $enabled_actions = $attrib['actions'];
             $enabled_actions = is_array($enabled_actions) ? $enabled_actions : preg_split('/[\s,;]+/', $attrib['actions']);
-            $actions         = array_intersect_key($actions, array_flip($enabled_actions));
+            $actions = array_intersect_key($actions, array_flip($enabled_actions));
         }
 
         $buttons = [];

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -10679,15 +10679,16 @@ function rcube_webmail() {
             menu = $(menu_element),
             hide_menu = function () {
                 if (record) {
-                    menu.css({top: '-1000px'});
+                    menu.css({ top: '-1000px' });
                     rcmail.triggerEvent('list-actions-hide', { element: $(record), menu: menu });
                     menu.data('message-uid', null);
                     record = null;
                 }
             },
-            show_menu = function(menu, record) {
-                if (!record.uid)
+            show_menu = function (menu, record) {
+                if (!record.uid) {
                     return;
+                }
 
                 var message = rcmail.message_list.rows[record.uid],
                     element = $(record),
@@ -10697,14 +10698,15 @@ function rcube_webmail() {
                         unread: !message.unread && !message.deleted,
                         flag: !message.flagged && !message.deleted,
                         unflag: message.flagged && !message.deleted,
-                        'delete': !message.deleted,
-                        undelete: message.deleted
+                        delete: !message.deleted,
+                        undelete: message.deleted,
                     };
 
                 if ((ret = rcmail.triggerEvent('list-actions-position', { element: element, menu: menu, message: message })) !== undefined) {
                     // abort if one of the handlers returned false
-                    if (ret === false)
+                    if (ret === false) {
                         return false;
+                    }
 
                     pos = ret;
                 }
@@ -10714,7 +10716,7 @@ function rcube_webmail() {
                 menu.data('message-uid', record.uid);
 
                 // Show/hide buttons according to the hovered message state
-                Object.keys(buttons).forEach(function(btn) {
+                Object.keys(buttons).forEach(function (btn) {
                     menu.find('a.' + btn)[buttons[btn] ? 'show' : 'hide']();
                 });
 
@@ -10742,7 +10744,7 @@ function rcube_webmail() {
             .on('mouseleave', hide_menu);
 
         // Buttons onclick handler
-        menu.find('a').click(function(e) {
+        menu.find('a').click(function (e) {
             // Hide the menu, event handlers will bring it back when needed, with refreshed state
             hide_menu();
         });

--- a/skins/elastic/styles/dark.less
+++ b/skins/elastic/styles/dark.less
@@ -1029,7 +1029,7 @@ html.dark-mode {
         border-color: @color-dark-border;
         box-shadow: 0 0 5px black;
 
-        a.button {
+        a {
             color: @color-dark-font;
 
             &:hover {
@@ -1037,7 +1037,8 @@ html.dark-mode {
             }
         }
 
-        span.txt {
+        span.date,
+        span.size {
             color: @color-dark-hint;
         }
     }

--- a/skins/elastic/styles/widgets/lists.less
+++ b/skins/elastic/styles/widgets/lists.less
@@ -219,7 +219,7 @@ ul.listing {
     box-shadow: 0 0 5px lightgrey;
     border-radius: 0.25em;
 
-    a.button {
+    a {
         cursor: pointer;
         display: inline-block;
         width: 1.5em;
@@ -228,11 +228,13 @@ ul.listing {
         color: @color-font;
 
         &:hover {
+            float: none;
             background: transparent;
         }
     }
 
-    span.txt {
+    span.date,
+    span.size {
         font-size: 90%;
         color: @color-black-shade-text;
         display: inline-block;

--- a/skins/elastic/styles/widgets/menu.less
+++ b/skins/elastic/styles/widgets/menu.less
@@ -563,7 +563,8 @@ a.toolbar-button {
     &.unflag:before {
         .font-icon-regular(@fa-var-flag);
     }
-    &.undo:before {
+    &.undo:before,
+    &.undelete:before {
         content: @fa-var-redo;
     }
     &.folders:before {

--- a/skins/elastic/templates/mail.html
+++ b/skins/elastic/templates/mail.html
@@ -104,6 +104,7 @@
 		<roundcube:object name="messages" id="messagelist" class="listing messagelist sortheader fixedheader"
 			aria-labelledby="aria-label-messagelist" data-list="message_list" data-label-msg="listempty"
 		/>
+		<roundcube:object name="messagelistactions" class="menu listing-hover-menu" />
 	</div>
 	<roundcube:include file="includes/pagenav.html" />
 </div>

--- a/skins/elastic/ui.js
+++ b/skins/elastic/ui.js
@@ -4342,13 +4342,12 @@ function rcube_elastic_ui() {
     }
 
     function list_actions_position(p) {
-        if (!touch) {
+        if (!is_touch()) {
             var top = p.element.offset().top - p.element.parent().offset().top + (p.element.height() - p.menu.outerHeight()) / 2;
-            return {top: top + 'px'};
+            return { top: top + 'px' };
         }
-        else {
-            return false;
-        }
+
+        return false;
     }
 }
 


### PR DESCRIPTION
I acknowledge that 9427ec1d35445170cd5d25b3aae9b69950610c3b is very new, I thought it might be helpful to setup a place to discus the possibilities of this new menu. I think the idea is great, better than adding extra columns for every action a user wants.

The first commit in this PR moves creation of the menu from the Elastic JS code into the core so in the future other skins could benefit from it and also plugins. Note: there is more to do, if Roundcube wants to go this way, more of the JS for the menu needs to move into `app.js` or may be `list.js` so it becomes a core function rather than a skin one.

There is a lot more to do, I wanted to post this draft now to start the discussion and get feedback on if its worth working on.

Unrelated to the organization of the code I have also been playing with the look of the menu. At the moment I have this:

![Untitled-1](https://github.com/roundcube/roundcubemail/assets/88682/bb6a378a-c652-4541-a082-8ed9a339079a)

- Position is moved to the top right corner of the message row
- The message row border color is used as a background color to try and make it look like a tab coming down from the corner of the row
- The size of the icons has been reduced and the text and icons have the same size so its not so intrusive
