### PR TITLE
Trivial: update about.php copyright year to 2023

### DIFF
--- a/program/actions/settings/about.php
+++ b/program/actions/settings/about.php
@@ -37,7 +37,7 @@ class rcmail_action_settings_about extends rcmail_action
                 'supportlink' => [$this, 'supportlink'],
                 'pluginlist'  => [$this, 'plugins_list'],
                 'copyright'   => function() {
-                    return 'Copyright &copy; 2005-2022, The Roundcube Dev Team';
+                    return 'Copyright &copy; 2005-2023, The Roundcube Dev Team';
                 },
                 'license' => function() {
                     return 'This program is free software; you can redistribute it and/or modify it under the terms '


### PR DESCRIPTION
Fixes #9049.