### PR TITLE
Fix sort_folder_comparator

### DIFF
--- a/program/lib/Roundcube/rcube_imap.php
+++ b/program/lib/Roundcube/rcube_imap.php
@@ -4517,7 +4517,10 @@ class rcube_imap extends rcube_storage
         $path1 = explode($this->delimiter, $str1);
         $path2 = explode($this->delimiter, $str2);
 
-        foreach ($path1 as $idx => $folder1) {
+        $len = max(count($path1), count($path2));
+
+        for ($idx = 0; $idx < $len; $idx++) {
+            $folder1 = $path1[$idx] ?? '';
             $folder2 = $path2[$idx] ?? '';
 
             if ($folder1 === $folder2) {


### PR DESCRIPTION
In case $path2 is longer than $path1, and all folders in $path1 are
equal to the corresponding folder in $path2 (in other words: $path2 is a
subfolder of $path1), sort_folder_comparator currently considers them
equal because it stops comparing when it reaches the end of $path1.

This breaks the ordering done by uasort() above, and breaks code that
relies on the folder list being sorted, notably the folders settings
page.