### PR TITLE
Add option to skins to decide adding or merging localization

### DIFF
--- a/program/include/rcmail_output_html.php
+++ b/program/include/rcmail_output_html.php
@@ -382,7 +382,11 @@ EOF;
         if (!empty($meta['localization'])) {
             $locdir = $meta['localization'] === true ? 'localization' : $meta['localization'];
             if ($texts = $this->app->read_localization(RCUBE_INSTALL_PATH . $skin_path . '/' . $locdir)) {
-                $this->app->load_language($_SESSION['language'], $texts);
+                if(isset($meta['localization_merge']) && $meta['localization_merge'] === true) {
+                    $this->app->load_language($_SESSION['language'], null, $texts);
+                } else {
+                    $this->app->load_language($_SESSION['language'], $texts);
+                }
             }
         }
 


### PR DESCRIPTION
Hi,

It would be a nice feature if there was an option in the skin's meta.json to decide the method of adding (or merging) the localized strings to the system.
In my case, I extended the elastic skin just to completely change the login page and I wanted to change the "Username" label to "E-mail address", to provide a bit more information to the user what to write to that field. I found out that I only can do that changing the text in the `program/localization/$lang/labels.inc` file. Putting it in the `skins/$skin/localization/$lang.inc` cannot override the system's label, only adds new ones.
The `load_language()` function already supports merging the additional texts besides the adding. I think it would be a good way defining a new variable in the skins's meta.json, for example `localization_merge` with a boolean value, and parse it in the `load_skin()` method. The default behavior should be adding, so nothing changes without explicitly adding the variable to meta.json.
