### PR TITLE
Dev/mail search scope

### DIFF
--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -1436,6 +1436,9 @@ $config['force_7bit'] = false;
 // Please note that folder names should to be in sync with $config['*_mbox'] options
 $config['search_mods'] = null;  // Example: ['*' => ['subject'=>1, 'from'=>1], 'Sent' => ['subject'=>1, 'to'=>1]];
 
+// Default search scope
+$config['search_scope'] = null; // Example: 'all' - for all folders, 'base' - for current folder, 'sub' - for this and subfolders
+
 // Defaults of the addressbook search field configuration.
 $config['addressbook_search_mods'] = null;  // Example: ['name'=>1, 'firstname'=>1, 'surname'=>1, 'email'=>1, '*'=>1];
 

--- a/program/actions/mail/index.php
+++ b/program/actions/mail/index.php
@@ -103,9 +103,10 @@ class rcmail_action_mail_index extends rcmail_action
                     $scope = $_SESSION['search_scope'];
                 }
 
-                if ($scope && preg_match('/^(all|sub)$/i', $scope)) {
-                    $rcmail->output->set_env('search_scope', strtolower($scope));
+                if (!$scope) {
+                    $scope = self::search_scope();
                 }
+                $rcmail->output->set_env('search_scope', strtolower($scope));
 
                 self::list_pagetitle();
             }
@@ -274,6 +275,21 @@ class rcmail_action_mail_index extends rcmail_action
         }
 
         return $mods;
+    }
+
+    /**
+    * Returns default search scopes
+    */
+    public static function search_scope()
+    {
+        $rcmail = rcmail::get_instance();
+        $scope = $rcmail->config->get('search_scope');
+
+        if (empty($scope)) {
+            $scope = 'base';
+        }
+
+        return $scope;
     }
 
     /**

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -2742,7 +2742,7 @@ function rcube_webmail()
     if (this.env.mailbox != mbox) {
       page = 1;
       this.env.current_page = page;
-      this.env.search_scope = 'base';
+      this.env.search_scope = this.env.search_scope || 'base';
       this.select_all_mode = false;
       this.reset_search_filter();
     }
@@ -5624,7 +5624,7 @@ function rcube_webmail()
       this.abort_request(this.env.qsearch);
 
     if (all) {
-      this.env.search_scope = 'base';
+      this.env.search_scope = this.env.search_scope || 'base';
       this.reset_search_filter();
     }
 


### PR DESCRIPTION
a patch for an ability to specify default search scope in config.php

search settings to get the following search params by default:

```
$config['search_mods'] = [ '*' => ['text' => 1]];
$config['search_scope'] = 'all';
```

![Screenshot 2023-07-25 at 13 27 09](https://github.com/roundcube/roundcubemail/assets/144679/95dacd44-51cb-4c14-86a6-b8d73b6c85f5)


