### PR TITLE
Config option to save drafts silently

### DIFF
--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -1344,6 +1344,9 @@ $config['prettydate'] = true;
 // save compose message every 300 seconds (5min)
 $config['draft_autosave'] = 300;
 
+// save compose message silently
+$config['draft_autosave_silent'] = false;
+
 // Interface layout. Default: 'widescreen'.
 //  'widescreen' - three columns
 //  'desktop'    - two columns, preview on bottom

--- a/program/actions/mail/send.php
+++ b/program/actions/mail/send.php
@@ -272,8 +272,10 @@ class rcmail_action_mail_send extends rcmail_action
                         'folder' => $store_target
                 ]);
 
-                // display success
-                $rcmail->output->show_message(!empty($plugin['message']) ? $plugin['message'] : 'messagesaved', 'confirmation');
+                if ($rcmail->config->get('draft_autosave_silent') != true) {
+                    // display success
+                    $rcmail->output->show_message(!empty($plugin['message']) ? $plugin['message'] : 'messagesaved', 'confirmation');
+                }
 
                 // update "_draft_saveid" and the "cmp_hash" to prevent "Unsaved changes" warning
                 $COMPOSE['param']['draft_uid'] = $plugin['uid'];


### PR DESCRIPTION
This adds a config option to save drafts silently.

closes #8989