### PR TITLE
Fix PHP8 deprecation warning in the markasjunk's "email_learn" driver

### DIFF
--- a/plugins/markasjunk/drivers/email_learn.php
+++ b/plugins/markasjunk/drivers/email_learn.php
@@ -159,6 +159,10 @@ class markasjunk_email_learn
 
     private function _parse_vars($data, $spam, $from)
     {
+        if (empty($data)) {
+            return $data;
+        }
+
         $data = str_replace('%u', $_SESSION['username'], $data);
         $data = str_replace('%t', $spam ? 'spam' : 'ham', $data);
         $data = str_replace('%l', $this->rcube->user->get_username('local'), $data);


### PR DESCRIPTION
```
str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /var/www/rc/plugins/markasjunk/drivers/email_learn.php on line 162
```