### PR TITLE
Fix #5051 by always showing inline attachments in list of attachments

### DIFF
--- a/program/lib/Roundcube/rcube_message.php
+++ b/program/lib/Roundcube/rcube_message.php
@@ -939,6 +939,13 @@ class rcube_message
                         && (!empty($mail_part->content_id) || !empty($mail_part->content_location))
                     ) {
                         $this->add_part($mail_part, 'inline');
+
+                        // Always show inline attachements in the list of attachments,
+                        // as sometimes the attachment has a content-id but is not referred to in
+                        // the HTML. Also if you switch to plaintext you won't be able to
+                        // see the attachments. #5051
+                        // https://github.com/roundcube/roundcubemail/issues/5051
+                        $this->add_part($mail_part, 'attachment');
                     }
 
                     // Any non-inline attachment


### PR DESCRIPTION
When a message has attachments with a Content-Id or a Content-Location, they are added as inline, expecting the attachment to show up in the message HTML body.

```
--==_=_650c1f3a7e07d-b7578f07ad
Content-Type: image/png; name="2023-09-21 12_35_30-XXXX Pierre (Membres actifs) - Chromium.png"
Content-Transfer-Encoding: base64
Content-Disposition: inline; filename="2023-09-21 12_35_30-XXX Pierre (Membres actifs) - Chromium.png"
Content-ID: <f_lmt1smiu1>
```

But, in some cases the attachments are not referred to in the HTML body.
And when you are viewing emails as plaintext only, you still won't see the attachments.

It's weird as the message is seen as having attachments in the messages list, but no attachments show up in the message view:

![image](https://github.com/roundcube/roundcubemail/assets/584819/02031d13-9111-43c8-9401-f0791951d220)

This patch always adds the inline attachment in the list of attachements, as is the case in most email software, so that you can see and download the attachments.