### PR TITLE
unify message font settings

### DIFF
--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -1483,14 +1483,38 @@ $config['spellcheck_before_send'] = false;
 // Skip alternative email addresses in autocompletion (show one address per contact)
 $config['autocomplete_single'] = false;
 
-// Default font for composed HTML message.
-// Supported values: Andale Mono, Arial, Arial Black, Book Antiqua, Courier New,
-// Georgia, Helvetica, Impact, Tahoma, Terminal, Times New Roman, Trebuchet MS, Verdana
+// Default font for composed HTML message
+// See available_fonts for supported values
 $config['default_font'] = 'Verdana';
 
-// Default font size for composed HTML message.
-// Supported sizes: 8pt, 10pt, 12pt, 14pt, 18pt, 24pt, 36pt
+// List of available fonts for the user to choose from when composing HTML messages
+// Specify an array with 'font name' => 'comma separated list of font name/family'
+// Note: If a font name contains white-space, it must be quoted
+// Note: At minimum the font name set in default_font must be present in this array
+$config['available_fonts'] = [
+    'Andale Mono'     => '"Andale Mono",Times,monospace',
+    'Arial'           => 'Arial,Helvetica,sans-serif',
+    'Arial Black'     => '"Arial Black","Avant Garde",sans-serif',
+    'Book Antiqua'    => '"Book Antiqua",Palatino,serif',
+    'Courier New'     => '"Courier New",Courier,monospace',
+    'Georgia'         => 'Georgia,Palatino,serif',
+    'Helvetica'       => 'Helvetica,Arial,sans-serif',
+    'Impact'          => 'Impact,Chicago,sans-serif',
+    'Tahoma'          => 'Tahoma,Arial,Helvetica,sans-serif',
+    'Terminal'        => 'Terminal,Monaco,monospace',
+    'Times New Roman' => '"Times New Roman",Times,serif',
+    'Trebuchet MS'    => '"Trebuchet MS",Geneva,sans-serif',
+    'Verdana'         => 'Verdana,Geneva,sans-serif',
+];
+
+// Default font size for composed HTML message
+// See available_font_sizes for supported values
 $config['default_font_size'] = '10pt';
+
+// List of available font sizes for the user to choose from when composing HTML messages
+// Specify an array of font sizes
+// Note: At minimum the font size set in default_font_size must be present in this array
+$config['available_font_sizes'] = ['8pt', '9pt', '10pt', '11pt', '12pt', '14pt', '18pt', '24pt', '36pt'];
 
 // Enables display of email address with name instead of a name (and address in title)
 $config['message_show_email'] = false;

--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -1491,6 +1491,7 @@ $config['default_font'] = 'Verdana';
 // Specify an array with 'font name' => 'comma separated list of font name/family'
 // Note: If a font name contains white-space, it must be quoted
 // Note: At minimum the font name set in default_font must be present in this array
+// Setting a single value will hide the font select box in the interface
 $config['available_fonts'] = [
     'Andale Mono'     => '"Andale Mono",Times,monospace',
     'Arial'           => 'Arial,Helvetica,sans-serif',
@@ -1514,6 +1515,7 @@ $config['default_font_size'] = '10pt';
 // List of available font sizes for the user to choose from when composing HTML messages
 // Specify an array of font sizes
 // Note: At minimum the font size set in default_font_size must be present in this array
+// Setting a single value will hide the font size select box in the interface
 $config['available_font_sizes'] = ['8pt', '9pt', '10pt', '11pt', '12pt', '14pt', '18pt', '24pt', '36pt'];
 
 // Enables display of email address with name instead of a name (and address in title)

--- a/program/actions/mail/compose.php
+++ b/program/actions/mail/compose.php
@@ -135,7 +135,8 @@ class rcmail_action_mail_compose extends rcmail_action_mail_index
         }
 
         // default font size for HTML editor
-        if ($font_size = $rcmail->config->get('default_font_size')) {
+        $font_size = self::fontsize_defs($rcmail->config->get('default_font_size'));
+        if ($font_size && !is_array($font_size)) {
             $rcmail->output->set_env('default_font_size', $font_size);
         }
 

--- a/program/actions/mail/send.php
+++ b/program/actions/mail/send.php
@@ -86,11 +86,14 @@ class rcmail_action_mail_send extends rcmail_action
         if ($isHtml) {
             $bstyle = [];
 
-            if ($font_size = $rcmail->config->get('default_font_size')) {
+            $font_size = self::fontsize_defs($rcmail->config->get('default_font_size'));
+            if ($font_size && !is_array($font_size)) {
                 $bstyle[] = 'font-size: ' . $font_size;
             }
-            if ($font_family = $rcmail->config->get('default_font')) {
-                $bstyle[] = 'font-family: ' . self::font_defs($font_family);
+
+            $font_family = self::font_defs($rcmail->config->get('default_font'));
+            if ($font_family && !is_array($font_family)) {
+                $bstyle[] = 'font-family: ' . $font_family;
             }
 
             // append doctype and html/body wrappers

--- a/program/actions/settings/index.php
+++ b/program/actions/settings/index.php
@@ -1000,8 +1000,8 @@ class rcmail_action_settings_index extends rcmail_action
                     $blocks['main']['options']['default_font'] = [
                         'title' => html::label($field_id, rcube::Q($rcmail->gettext('defaultfont'))),
                         'content' => html::div('input-group',
-                            $select_font->show($rcmail->config->get('default_font', 1)) .
-                            $select_size->show($rcmail->config->get('default_font_size', 1))
+                            (!isset($no_override['default_font']) && count($fonts) > 1 ? $select_font->show($rcmail->config->get('default_font', 1)) : '') .
+                            (!isset($no_override['default_font_size']) && count($fontsizes) > 1 ? $select_size->show($rcmail->config->get('default_font_size', 1)) : '')
                         )
                     ];
                 }

--- a/program/actions/settings/index.php
+++ b/program/actions/settings/index.php
@@ -975,7 +975,9 @@ class rcmail_action_settings_index extends rcmail_action
                             'class' => 'custom-select'
                     ]);
 
-                    $fontsizes = ['', '8pt', '9pt', '10pt', '11pt', '12pt', '14pt', '18pt', '24pt', '36pt'];
+                    $select_size->add('', '');
+
+                    $fontsizes = self::fontsize_defs();
                     foreach ($fontsizes as $size) {
                         $select_size->add($size, $size);
                     }

--- a/program/actions/settings/index.php
+++ b/program/actions/settings/index.php
@@ -962,47 +962,65 @@ class rcmail_action_settings_index extends rcmail_action
                     ];
                 }
 
-                if (!isset($no_override['default_font']) || !isset($no_override['default_font_size'])) {
+                // Font settings are made up of 2 parts, font name and font size
+                // Compute the settings first to discover is anything to display to the user
+                $font_settings = '';
+
+                // Default font
+                if (!isset($no_override['default_font'])) {
                     if (!$current) {
                         continue 2;
                     }
 
-                    // Default font size
-                    $field_id = 'rcmfd_default_font_size';
-                    $select_size = new html_select([
-                            'name'  => '_default_font_size',
-                            'id'    => $field_id,
-                            'class' => 'custom-select'
-                    ]);
+                    $fonts = self::font_defs();
+                    if (count($fonts) > 1) {
+                        $field_id = 'rcmfd_default_font';
+                        $select_font = new html_select([
+                                'name' => '_default_font',
+                                'id' => $field_id,
+                                'class' => 'custom-select'
+                        ]);
 
-                    $select_size->add('', '');
+                        $select_font->add('', '');
+
+                        foreach (array_keys($fonts) as $fname) {
+                            $select_font->add($fname, $fname);
+                        }
+
+                        $font_settings .= $select_font->show($rcmail->config->get('default_font', 1));
+                    }
+                }
+
+                // Default font size
+                if (!isset($no_override['default_font_size'])) {
+                    if (!$current) {
+                        continue 2;
+                    }
 
                     $fontsizes = self::fontsize_defs();
-                    foreach ($fontsizes as $size) {
-                        $select_size->add($size, $size);
+                    if (count($fontsizes) > 1) {
+                        $field_id = 'rcmfd_default_font_size';
+                        $select_size = new html_select([
+                                'name'  => '_default_font_size',
+                                'id'    => $field_id,
+                                'class' => 'custom-select'
+                        ]);
+
+                        $select_size->add('', '');
+
+                        foreach ($fontsizes as $size) {
+                            $select_size->add($size, $size);
+                        }
+
+                        $font_settings .= $select_size->show($rcmail->config->get('default_font_size', 1));
                     }
+                }
 
-                    // Default font
-                    $field_id = 'rcmfd_default_font';
-                    $select_font = new html_select([
-                            'name' => '_default_font',
-                            'id' => $field_id,
-                            'class' => 'custom-select'
-                    ]);
-
-                    $select_font->add('', '');
-
-                    $fonts = self::font_defs();
-                    foreach (array_keys($fonts) as $fname) {
-                        $select_font->add($fname, $fname);
-                    }
-
+                // Include font settings in the display only if at least one setting exists
+                if (!empty($font_settings)) {
                     $blocks['main']['options']['default_font'] = [
                         'title' => html::label($field_id, rcube::Q($rcmail->gettext('defaultfont'))),
-                        'content' => html::div('input-group',
-                            (!isset($no_override['default_font']) && count($fonts) > 1 ? $select_font->show($rcmail->config->get('default_font', 1)) : '') .
-                            (!isset($no_override['default_font_size']) && count($fontsizes) > 1 ? $select_size->show($rcmail->config->get('default_font_size', 1)) : '')
-                        )
+                        'content' => html::div('input-group', $font_settings)
                     ];
                 }
 

--- a/program/include/rcmail_action.php
+++ b/program/include/rcmail_action.php
@@ -680,21 +680,7 @@ abstract class rcmail_action
      */
     public static function font_defs($font = null)
     {
-        $fonts = rcmail::get_instance()->config->get('font_defs', [
-            'Andale Mono'     => '"Andale Mono",Times,monospace',
-            'Arial'           => 'Arial,Helvetica,sans-serif',
-            'Arial Black'     => '"Arial Black","Avant Garde",sans-serif',
-            'Book Antiqua'    => '"Book Antiqua",Palatino,serif',
-            'Courier New'     => '"Courier New",Courier,monospace',
-            'Georgia'         => 'Georgia,Palatino,serif',
-            'Helvetica'       => 'Helvetica,Arial,sans-serif',
-            'Impact'          => 'Impact,Chicago,sans-serif',
-            'Tahoma'          => 'Tahoma,Arial,Helvetica,sans-serif',
-            'Terminal'        => 'Terminal,Monaco,monospace',
-            'Times New Roman' => '"Times New Roman",Times,serif',
-            'Trebuchet MS'    => '"Trebuchet MS",Geneva,sans-serif',
-            'Verdana'         => 'Verdana,Geneva,sans-serif',
-        ]);
+        $fonts = rcmail::get_instance()->config->get('available_fonts', []);
 
         if ($font) {
             return !empty($fonts[$font]) ? $fonts[$font] : null;
@@ -712,7 +698,7 @@ abstract class rcmail_action
      */
     public static function fontsize_defs($size = null)
     {
-        $sizes = rcmail::get_instance()->config->get('fontsize_defs', ['8pt', '9pt', '10pt', '11pt', '12pt', '14pt', '18pt', '24pt', '36pt']);
+        $sizes = rcmail::get_instance()->config->get('available_font_sizes', []);
 
         if ($size) {
             return in_array($size, $sizes) ? $size : null;

--- a/program/include/rcmail_action.php
+++ b/program/include/rcmail_action.php
@@ -403,6 +403,8 @@ abstract class rcmail_action
             'skin_path'  => $skin_path,
             'spellcheck' => $spellcheck, // deprecated
             'spelldict'  => $spelldict,
+            'font_formats'     => self::font_defs(),
+            'fontsize_formats' => self::fontsize_defs(),
             'content_css'      => 'program/resources/tinymce/content.css',
             'disabled_plugins' => $hook['disabled_plugins'],
             'disabled_buttons' => $hook['disabled_buttons'],
@@ -678,27 +680,45 @@ abstract class rcmail_action
      */
     public static function font_defs($font = null)
     {
-        $fonts = [
-            'Andale Mono'   => '"Andale Mono",Times,monospace',
-            'Arial'         => 'Arial,Helvetica,sans-serif',
-            'Arial Black'   => '"Arial Black","Avant Garde",sans-serif',
-            'Book Antiqua'  => '"Book Antiqua",Palatino,serif',
-            'Courier New'   => '"Courier New",Courier,monospace',
-            'Georgia'       => 'Georgia,Palatino,serif',
-            'Helvetica'     => 'Helvetica,Arial,sans-serif',
-            'Impact'        => 'Impact,Chicago,sans-serif',
-            'Tahoma'        => 'Tahoma,Arial,Helvetica,sans-serif',
-            'Terminal'      => 'Terminal,Monaco,monospace',
+        $fonts = rcmail::get_instance()->config->get('font_defs', [
+            'Andale Mono'     => '"Andale Mono",Times,monospace',
+            'Arial'           => 'Arial,Helvetica,sans-serif',
+            'Arial Black'     => '"Arial Black","Avant Garde",sans-serif',
+            'Book Antiqua'    => '"Book Antiqua",Palatino,serif',
+            'Courier New'     => '"Courier New",Courier,monospace',
+            'Georgia'         => 'Georgia,Palatino,serif',
+            'Helvetica'       => 'Helvetica,Arial,sans-serif',
+            'Impact'          => 'Impact,Chicago,sans-serif',
+            'Tahoma'          => 'Tahoma,Arial,Helvetica,sans-serif',
+            'Terminal'        => 'Terminal,Monaco,monospace',
             'Times New Roman' => '"Times New Roman",Times,serif',
-            'Trebuchet MS'  => '"Trebuchet MS",Geneva,sans-serif',
-            'Verdana'       => 'Verdana,Geneva,sans-serif',
-        ];
+            'Trebuchet MS'    => '"Trebuchet MS",Geneva,sans-serif',
+            'Verdana'         => 'Verdana,Geneva,sans-serif',
+        ]);
 
         if ($font) {
             return !empty($fonts[$font]) ? $fonts[$font] : null;
         }
 
         return $fonts;
+    }
+
+    /**
+     * Returns supported font sizes
+     *
+     * @param string $size Font size
+     *
+     * @return string|array Font size array or string (if $size is used)
+     */
+    public static function fontsize_defs($size = null)
+    {
+        $sizes = rcmail::get_instance()->config->get('fontsize_defs', ['8pt', '9pt', '10pt', '11pt', '12pt', '14pt', '18pt', '24pt', '36pt']);
+
+        if ($size) {
+            return in_array($size, $sizes) ? $size : null;
+        }
+
+        return $sizes;
     }
 
     /**

--- a/program/js/editor.js
+++ b/program/js/editor.js
@@ -53,7 +53,6 @@ function rcube_text_editor(config, id)
       toolbar: 'bold italic underline | alignleft aligncenter alignright alignjustify'
         + ' | fontselect fontsizeselect | forecolor backcolor',
       extended_valid_elements: 'font[face|size|color|style],span[id|class|align|style]',
-      fontsize_formats: '8pt 9pt 10pt 11pt 12pt 14pt 18pt 24pt 36pt',
       // Allow style tag, have to be allowed inside body/div/blockquote (#7088)
       valid_children: '+body[style],+blockquote[style],+div[style]',
       relative_urls: false,
@@ -136,6 +135,16 @@ function rcube_text_editor(config, id)
   });
 
   conf.toolbar = conf.toolbar.replace('$extra', '').replace(/\|\s+\|/g, '|');
+
+  // font list, convert to TinyMCE format
+  var fonts = [];
+  $.each(config.font_formats || [], function(key) {
+    fonts.push(key + '=' + this.replace(/"/g, '').toLowerCase());
+  });
+  conf.font_formats = fonts.join('; ');
+
+  // font size list
+  conf.fontsize_formats = config.fontsize_formats.join(' ');
 
   // support external configuration settings e.g. from skin
   if (window.rcmail_editor_settings)

--- a/program/js/editor.js
+++ b/program/js/editor.js
@@ -51,7 +51,7 @@ function rcube_text_editor(config, id)
       // toolbar_sticky: true, // does not work in scrollable element: https://github.com/tinymce/tinymce/issues/5227
       toolbar_drawer: 'sliding',
       toolbar: 'bold italic underline | alignleft aligncenter alignright alignjustify'
-        + ' | fontselect fontsizeselect | forecolor backcolor',
+        + ' | $font | forecolor backcolor',
       extended_valid_elements: 'font[face|size|color|style],span[id|class|align|style]',
       // Allow style tag, have to be allowed inside body/div/blockquote (#7088)
       valid_children: '+body[style],+blockquote[style],+div[style]',
@@ -134,17 +134,23 @@ function rcube_text_editor(config, id)
     conf.toolbar = conf.toolbar.replace(this, '');
   });
 
-  conf.toolbar = conf.toolbar.replace('$extra', '').replace(/\|\s+\|/g, '|');
-
   // font list, convert to TinyMCE format
   var fonts = [];
   $.each(config.font_formats || [], function(key) {
     fonts.push(key + '=' + this.replace(/"/g, '').toLowerCase());
   });
   conf.font_formats = fonts.join('; ');
+  if (fonts.length > 1) {
+    conf.toolbar = conf.toolbar.replace('$font', 'fontselect $font');
+  }
 
   // font size list
   conf.fontsize_formats = config.fontsize_formats.join(' ');
+  if (config.fontsize_formats.length > 1) {
+    conf.toolbar = conf.toolbar.replace('$font', 'fontsizeselect $font');
+  }
+
+  conf.toolbar = conf.toolbar.replace(/($extra|$font)/, '').replace(/\|\s+\|/g, '|');
 
   // support external configuration settings e.g. from skin
   if (window.rcmail_editor_settings)

--- a/tests/Rcmail/Action.php
+++ b/tests/Rcmail/Action.php
@@ -121,6 +121,15 @@ class Rcmail_RcmailAction extends ActionTestCase
     }
 
     /**
+     * Test rcmail_action::fontsize_defs()
+     */
+    function test_fontsize_defs()
+    {
+        $result = rcmail_action::fontsize_defs();
+        $this->assertCount(9, $result);
+    }
+
+    /**
      * Test rcmail_action::show_bytes)
      */
     function test_show_bytes()


### PR DESCRIPTION
Inspired by https://www.roundcubeforum.net/index.php/topic,30621.msg77615.html

Move all the font settings for HTML messages to one place so that what is shown on the Composing Messages settings screen and in the HTML editor are the same. Currently this is only true for the font size settings which are hard coded in 2 places.

- create a `fontsize_defs()` function, similar to `font_defs()` to provide the list of font sizes
- pass the result of the `font_defs()` function to TinyMCE so that the font lists are consistent
- add a hidden config option (similar to `editor_css_location` for example) to allow admins to override the default font family and font size lists if they want