### PR TITLE
Remove imap readonly folder check

### DIFF
--- a/program/lib/Roundcube/rcube_imap.php
+++ b/program/lib/Roundcube/rcube_imap.php
@@ -2865,11 +2865,6 @@ class rcube_imap extends rcube_storage
             return false;
         }
 
-        if (!$this->conn->data['READ-WRITE']) {
-            $this->conn->setError(rcube_imap_generic::ERROR_READONLY, "Folder is read-only");
-            return false;
-        }
-
         // CLOSE(+SELECT) should be faster than EXPUNGE
         if (empty($uids) || !empty($all_mode)) {
             $result = $this->conn->close();


### PR DESCRIPTION
At this point `$this->conn` can't reach `setError` function as it is `protected`, so making it public

https://github.com/progsmile/roundcubemail/blob/master/program/lib/Roundcube/rcube_imap.php#L2869