### PR TITLE
patch-for-displaying-header-title

### DIFF
--- a/skins/elastic/styles/layout.less
+++ b/skins/elastic/styles/layout.less
@@ -358,7 +358,6 @@ body {
 
 @media screen and (min-width: (@screen-width-small + 1px)) {
     .floating-action-buttons,
-    #layout-content > .header > .header-title,
     #layout > div > .header > .buttons,
     a.toolbar-menu-button {
         display: none;


### PR DESCRIPTION
This fix allows the .header-title to be visible also in large screens. This is helpful, specially in the settings screens.