### PR TITLE
Add possibility to change ATTR_EMULATE_PREPARES via config file

### DIFF
--- a/program/lib/Roundcube/db/mysql.php
+++ b/program/lib/Roundcube/db/mysql.php
@@ -135,7 +135,9 @@ class rcube_db_mysql extends rcube_db
         $result[PDO::ATTR_AUTOCOMMIT] = true;
 
         // Disable emulating of prepared statements
-        $result[PDO::ATTR_EMULATE_PREPARES] = false;
+        // configured value has higher prio
+        $conf_value = rcmail::get_instance()->config->get('attr_emulate_prepares');
+        $result[PDO::ATTR_EMULATE_PREPARES] = (($conf_value) ? $conf_value : false);
 
         return $result;
     }

--- a/program/lib/Roundcube/db/mysql.php
+++ b/program/lib/Roundcube/db/mysql.php
@@ -135,9 +135,7 @@ class rcube_db_mysql extends rcube_db
         $result[PDO::ATTR_AUTOCOMMIT] = true;
 
         // Disable emulating of prepared statements
-        // configured value has higher prio
-        $conf_value = rcmail::get_instance()->config->get('attr_emulate_prepares');
-        $result[PDO::ATTR_EMULATE_PREPARES] = (($conf_value) ? (bool) $conf_value : false);
+        $result[PDO::ATTR_EMULATE_PREPARES] = (isset($dsn['verify_server_cert']) ? rcube_utils::get_boolean($dsn['attr_emulate_prepares']) : false);
 
         return $result;
     }

--- a/program/lib/Roundcube/db/mysql.php
+++ b/program/lib/Roundcube/db/mysql.php
@@ -137,7 +137,7 @@ class rcube_db_mysql extends rcube_db
         // Disable emulating of prepared statements
         // configured value has higher prio
         $conf_value = rcmail::get_instance()->config->get('attr_emulate_prepares');
-        $result[PDO::ATTR_EMULATE_PREPARES] = (($conf_value) ? $conf_value : false);
+        $result[PDO::ATTR_EMULATE_PREPARES] = (($conf_value) ? (bool) $conf_value : false);
 
         return $result;
     }

--- a/program/lib/Roundcube/db/mysql.php
+++ b/program/lib/Roundcube/db/mysql.php
@@ -135,7 +135,7 @@ class rcube_db_mysql extends rcube_db
         $result[PDO::ATTR_AUTOCOMMIT] = true;
 
         // Disable emulating of prepared statements
-        $result[PDO::ATTR_EMULATE_PREPARES] = (isset($dsn['verify_server_cert']) ? rcube_utils::get_boolean($dsn['attr_emulate_prepares']) : false);
+        $result[PDO::ATTR_EMULATE_PREPARES] = (isset($dsn['attr_emulate_prepares']) ? rcube_utils::get_boolean($dsn['attr_emulate_prepares']) : false);
 
         return $result;
     }


### PR DESCRIPTION
In past there were this commit which add this _ATTR_EMULATE_PREPARES_:
https://github.com/roundcube/roundcubemail/commit/9faea49f827a8b3e765513a023dafb5ece0c9fc0

But in some cases there is necessary to use bool "true", not only bool "false".
Every time after update RC I must manually change this line (OK, well, not manually, I am using "sed" command, but...)...
This is really annoying. So, using config file for "override" this behaviour is logical step for improving "administrator user experience".

I got this error with _ATTR_EMULATE_PREPARES_ on value "false":
`[1615] Prepared statement needs to be re-prepared`
This config make problem:
`$config['password_query'] = 'UPDATE XXX SET `password` = %P WHERE `user` = %u';`
After change ATTR_EMULATE_PREPARES on value "true", problem dissapears.
This change I am doing from year 2021, without any problems or BC. So, now is ideal to solve this via config file :)

**For this reasons, there should be possibility to change this behavior via config file. There is no BC with this change.**