### PR TITLE
Ignore mbstring.func_overload in PHP 8

### DIFF
--- a/program/lib/Roundcube/bootstrap.php
+++ b/program/lib/Roundcube/bootstrap.php
@@ -28,11 +28,16 @@
 $config = [
     'display_errors'  => false,
     'log_errors'      => true,
-    // Some users are not using Installer, so we'll check some
-    // critical PHP settings here. Only these, which doesn't provide
-    // an error/warning in the logs later. See (#1486307).
-    'mbstring.func_overload' => 0,
 ];
+
+// Some users are not using Installer, so we'll check some
+// critical PHP settings here. Only these, which doesn't provide
+// an error/warning in the logs later. See (#1486307).
+if (PHP_MAJOR_VERSION < 8) {
+    $config += [
+        'mbstring.func_overload' => 0,
+    ];
+}
 
 // check these additional ini settings if not called via CLI
 if (php_sapi_name() != 'cli') {


### PR DESCRIPTION
The feature `mbstring.func_overload` is deprecated since PHP version 7.2 and removed since 8.0.0
(see https://www.php.net/manual/en/mbstring.overload.php).

Skip trying to set it for PHP version 8, e.g. to avoid failures with the sloppy comparison hardening of Snuffleupagus
(https://snuffleupagus.readthedocs.io/config.html#prevent-sloppy-comparison):

    ERROR: Wrong 'mbstring.func_overload' option value and it wasn't possible to set it to required value (0). Check your PHP configuration (including php_admin_flag).