### PR TITLE
Fix explode_quoted_string for multibyte delimiter

### DIFF
--- a/program/lib/Roundcube/rcube_utils.php
+++ b/program/lib/Roundcube/rcube_utils.php
@@ -922,22 +922,31 @@ class rcube_utils
      */
     public static function explode_quoted_string($delimiter, $string)
     {
-        $result = [];
-        $strlen = strlen($string);
+        $res = [];
+        $parts = preg_split('/("(?:[^"\\\\]+|\\\\.)*+(?:"|\\\\?$))/s', $string, 0, PREG_SPLIT_DELIM_CAPTURE);
+        $isQuoted = false;
+        $tmp = '';
+        foreach ($parts as $part) {
+            if ($isQuoted) {
+                $tmp .= $part;
+            } else {
+                $isFirst = true;
+                foreach (preg_split('/' . $delimiter . '/', $part) as $v) {
+                    if ($isFirst) {
+                        $tmp .= $v;
+                        $isFirst = false;
+                    } else {
+                        $res[] = $tmp;
+                        $tmp = $v;
+                    }
+                }
+            }
 
-        for ($q=$p=$i=0; $i < $strlen; $i++) {
-            if ($string[$i] == "\"" && (!isset($string[$i-1]) || $string[$i-1] != "\\")) {
-                $q = $q ? false : true;
-            }
-            else if (!$q && preg_match("/$delimiter/", $string[$i])) {
-                $result[] = substr($string, $p, $i - $p);
-                $p = $i + 1;
-            }
+            $isQuoted = !$isQuoted;
         }
+        $res[] = $tmp;
 
-        $result[] = (string) substr($string, $p);
-
-        return $result;
+        return $res;
     }
 
     /**

--- a/tests/Framework/Utils.php
+++ b/tests/Framework/Utils.php
@@ -423,6 +423,9 @@ class Framework_Utils extends PHPUnit\Framework\TestCase
             '"a,b"' => ['"a,b"'],
             '"a,b","c,d"' => ['"a,b"','"c,d"'],
             '"a,\\"b",d' => ['"a,\\"b"', 'd'],
+            'a,' => ['a', ''],
+            '"a,' => ['"a,'],
+            '"a,\\' => ['"a,\\'],
         ];
 
         foreach ($data as $text => $res) {
@@ -441,6 +444,24 @@ class Framework_Utils extends PHPUnit\Framework\TestCase
         foreach ($data as $text) {
             $result = rcube_utils::explode_quoted_string(',', $text);
             $this->assertSame(explode(',', $text), $result);
+        }
+    }
+
+    /**
+     * Check rcube_utils::explode_quoted_string() with multibyte delimiter
+     */
+    function test_explode_quoted_string_multibyte_delimiter()
+    {
+        $data = [
+            "a\nb" => ['a', 'b'],
+            "a\r\nb" => ['a', 'b'],
+            "a\r\n\nb" => ['a', 'b'],
+            "\"a\n\\\"\n\"\nb" => ["\"a\n\\\"\n\"", 'b'],
+        ];
+
+        foreach ($data as $text => $res) {
+            $result = rcube_utils::explode_quoted_string('[\n\r]+', $text);
+            $this->assertSame($res, $result);
         }
     }
 


### PR DESCRIPTION
Also much more performant, previously the string was processed byte by byte.

What is the controbution policy, what branch should it target?