### PR TITLE
Fix format_date with "x" format for Windows

### DIFF
--- a/program/include/rcmail.php
+++ b/program/include/rcmail.php
@@ -212,6 +212,7 @@ class rcmail extends rcube
 
         // set localization
         setlocale(LC_ALL, $lang . '.utf8', $lang . '.UTF-8', 'en_US.utf8', 'en_US.UTF-8');
+        ini_set('intl.default_locale', $lang);
 
         // Workaround for http://bugs.php.net/bug.php?id=18556
         // Also strtoupper/strtolower and other methods are locale-aware
@@ -1698,7 +1699,7 @@ class rcmail extends rcube
                 $out .= $this->gettext('long'.strtolower(date('M', $timestamp)));
             }
             else if ($format[$i] == 'x') {
-                $formatter = new IntlDateFormatter('en_US', IntlDateFormatter::SHORT, IntlDateFormatter::SHORT);
+                $formatter = new IntlDateFormatter(null, IntlDateFormatter::SHORT, IntlDateFormatter::SHORT);
                 $out .= $formatter->format($timestamp);
             }
             else {

--- a/program/include/rcmail.php
+++ b/program/include/rcmail.php
@@ -1698,7 +1698,7 @@ class rcmail extends rcube
                 $out .= $this->gettext('long'.strtolower(date('M', $timestamp)));
             }
             else if ($format[$i] == 'x') {
-                $formatter = new IntlDateFormatter(setlocale(LC_ALL, '0'), IntlDateFormatter::SHORT, IntlDateFormatter::SHORT);
+                $formatter = new IntlDateFormatter('en_US', IntlDateFormatter::SHORT, IntlDateFormatter::SHORT);
                 $out .= $formatter->format($timestamp);
             }
             else {

--- a/tests/Rcmail/Rcmail.php
+++ b/tests/Rcmail/Rcmail.php
@@ -272,6 +272,7 @@ class Rcmail_Rcmail extends ActionTestCase
 
         // Test various formats
         setlocale(LC_ALL, 'en_US');
+        ini_set('intl.default_locale', 'en_US');
         $date = new DateTime('2020-06-01 12:20:30', new DateTimeZone('UTC'));
 
         $this->assertSame('2020-06-01 12:20', $rcmail->format_date($date));


### PR DESCRIPTION
the 1st param of `IntlDateFormatter::__construct` is Intl locale, not system locale

on Windows and PHP 8.3 and I getting `Found unconstructed IntlDateFormatter` exceptions - https://github.com/php/php-src/issues/12912