### PR TITLE
Fix minimal kolab/net_ldap3 version for PHP 8.3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup composer
         run: |
             cp composer.json-dist composer.json
-            composer require "kolab/net_ldap3:~1.1.1" --no-update
+            composer require "kolab/net_ldap3:~1.1.4" --no-update
 
       - name: Install dependencies
         run: composer install --prefer-dist --no-interaction --no-progress
@@ -86,7 +86,7 @@ jobs:
       - name: Setup composer
         run: |
             cp composer.json-dist composer.json
-            composer require "kolab/net_ldap3:~1.1.1" --no-update
+            composer require "kolab/net_ldap3:~1.1.4" --no-update
 
       - name: Install dependencies
         run: composer install --prefer-dist --no-interaction --no-progress

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ complete: roundcubemail-git
 	cp -RH roundcubemail-git roundcubemail-$(VERSION)
 	(cd roundcubemail-$(VERSION); cp composer.json-dist composer.json)
 	(cd roundcubemail-$(VERSION); php /tmp/composer.phar config platform.php $(PHP_VERSION))
-	(cd roundcubemail-$(VERSION); php /tmp/composer.phar require "kolab/net_ldap3:~1.1.1" --no-update --no-install)
+	(cd roundcubemail-$(VERSION); php /tmp/composer.phar require "kolab/net_ldap3:~1.1.4" --no-update --no-install)
 	(cd roundcubemail-$(VERSION); php /tmp/composer.phar config --unset suggest.kolab/net_ldap3)
 	(cd roundcubemail-$(VERSION); php /tmp/composer.phar config --unset require-dev)
 	(cd roundcubemail-$(VERSION); php /tmp/composer.phar install --prefer-dist --no-dev --no-interaction)

--- a/composer.json-dist
+++ b/composer.json-dist
@@ -26,7 +26,7 @@
         "phpunit/phpunit": "^9"
     },
     "suggest": {
-        "kolab/net_ldap3": "~1.1.1 required for connecting to LDAP",
+        "kolab/net_ldap3": "~1.1.4 required for connecting to LDAP",
         "bjeavons/zxcvbn-php": "^1.0 required for Zxcvbn password strength driver"
     },
     "config": {


### PR DESCRIPTION
Otherwise user can get the following error:
```
Fatal error: Please check the Roundcube error log and/or server error logs for more information.
```

error log:
```
[12-Dec-2023 23:10:13 UTC] PHP Fatal error:  During inheritance of Iterator: Uncaught Return type of Net_LDAP3_Result::current() should either be compatible with Iterator::current(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
```