### PR TITLE
Assert expected data types in tests

### DIFF
--- a/plugins/managesieve/tests/Script.php
+++ b/plugins/managesieve/tests/Script.php
@@ -25,7 +25,7 @@ class Managesieve_Script extends PHPUnit\Framework\TestCase
         $script = new rcube_sieve_script($input, $caps);
         $result = $script->as_text();
 
-        $this->assertEquals(trim($output), trim($result), $message);
+        $this->assertSame(trim($output), trim($result), $message);
     }
 
     /**
@@ -81,6 +81,6 @@ class Managesieve_Script extends PHPUnit\Framework\TestCase
     {
         $res = json_encode(rcube_sieve_script::tokenize($input, $num));
 
-        $this->assertEquals(trim($output), trim($res));
+        $this->assertSame(trim($output), trim($res));
     }
 }

--- a/plugins/password/tests/Password.php
+++ b/plugins/password/tests/Password.php
@@ -41,19 +41,19 @@ class Password_Plugin extends PHPUnit\Framework\TestCase
         $driver_class = $this->load_driver('cpanel');
 
         $error_result = $driver_class::decode_response(false);
-        $this->assertEquals($error_result, PASSWORD_CONNECT_ERROR);
+        $this->assertSame($error_result, PASSWORD_CONNECT_ERROR);
 
         $bad_result = $driver_class::decode_response(null);
-        $this->assertEquals($bad_result, PASSWORD_CONNECT_ERROR);
+        $this->assertSame($bad_result, PASSWORD_CONNECT_ERROR);
 
         $null_result = $driver_class::decode_response('null');
-        $this->assertEquals($null_result, PASSWORD_ERROR);
+        $this->assertSame($null_result, PASSWORD_ERROR);
 
         $malformed_result = $driver_class::decode_response('random {string]!');
-        $this->assertEquals($malformed_result, PASSWORD_ERROR);
+        $this->assertSame($malformed_result, PASSWORD_ERROR);
 
         $other_result = $driver_class::decode_response('{"a":"b"}');
-        $this->assertEquals($other_result, PASSWORD_ERROR);
+        $this->assertSame($other_result, PASSWORD_ERROR);
 
         $fail_response   = '{"data":null,"errors":["Execution of Email::passwdp'
                 . 'op (api version:3) is not permitted inside of webmail"],"sta'
@@ -65,12 +65,12 @@ class Password_Plugin extends PHPUnit\Framework\TestCase
             'message' => $error_message,
         ];
         $fail_result     = $driver_class::decode_response($fail_response);
-        $this->assertEquals($expected_result, $fail_result);
+        $this->assertSame($expected_result, $fail_result);
 
         $success_response = '{"metadata":{},"data":null,"messages":null,"errors'
                 . '":null,"status":1}';
         $good_result      = $driver_class::decode_response($success_response);
-        $this->assertEquals($good_result, PASSWORD_SUCCESS);
+        $this->assertSame($good_result, PASSWORD_SUCCESS);
     }
 
     /**

--- a/tests/Actions/Mail/Search.php
+++ b/tests/Actions/Mail/Search.php
@@ -117,7 +117,7 @@ class Actions_Mail_Search extends ActionTestCase
     function data_search_input(): iterable
     {
         $week  = new DateInterval('P1W');
-        $weekDate = (new DateTime('now'))->sub($week)->format('j-M-Y');
+        $weekDate = (new DateTime('now', new DateTimeZone('UTC')))->sub($week)->format('j-M-Y');
 
         return [
             [
@@ -307,14 +307,16 @@ class Actions_Mail_Search extends ActionTestCase
         $month = new DateInterval('P1M');
         $year  = new DateInterval('P1Y');
 
+        $utcTz = new DateTimeZone('UTC');
+
         return [
             ['', null],
-            ['1W', 'SINCE ' . (new DateTime('now'))->sub($week)->format('j-M-Y')],
-            ['1M', 'SINCE ' . (new DateTime('now'))->sub($month)->format('j-M-Y')],
-            ['1Y', 'SINCE ' . (new DateTime('now'))->sub($year)->format('j-M-Y')],
-            ['-1W', 'BEFORE ' . (new DateTime('now'))->sub($week)->format('j-M-Y')],
-            ['-1M', 'BEFORE ' . (new DateTime('now'))->sub($month)->format('j-M-Y')],
-            ['-1Y', 'BEFORE ' . (new DateTime('now'))->sub($year)->format('j-M-Y')],
+            ['1W', 'SINCE ' . (new DateTime('now', $utcTz))->sub($week)->format('j-M-Y')],
+            ['1M', 'SINCE ' . (new DateTime('now', $utcTz))->sub($month)->format('j-M-Y')],
+            ['1Y', 'SINCE ' . (new DateTime('now', $utcTz))->sub($year)->format('j-M-Y')],
+            ['-1W', 'BEFORE ' . (new DateTime('now', $utcTz))->sub($week)->format('j-M-Y')],
+            ['-1M', 'BEFORE ' . (new DateTime('now', $utcTz))->sub($month)->format('j-M-Y')],
+            ['-1Y', 'BEFORE ' . (new DateTime('now', $utcTz))->sub($year)->format('j-M-Y')],
         ];
     }
 

--- a/tests/Browser/Mail/GetunreadTest.php
+++ b/tests/Browser/Mail/GetunreadTest.php
@@ -35,7 +35,7 @@ class GetunreadTest extends \Tests\Browser\TestCase
             // Folders list state
             $browser->assertVisible('.folderlist li.inbox.unread');
 
-            $this->assertEquals(strval(self::$msgcount), $browser->text('.folderlist li.inbox span.unreadcount'));
+            $this->assertSame(strval(self::$msgcount), $browser->text('.folderlist li.inbox span.unreadcount'));
         });
     }
 }

--- a/tests/Browser/Mail/ListTest.php
+++ b/tests/Browser/Mail/ListTest.php
@@ -31,7 +31,7 @@ class ListTest extends \Tests\Browser\TestCase
             // check message list
             $browser->assertVisible('#messagelist tbody tr:first-child.unread');
 
-            $this->assertEquals('Test HTML with local and remote image',
+            $this->assertSame('Test HTML with local and remote image',
                 $browser->text('#messagelist tbody tr:first-child span.subject'));
 
             // Note: This element icon has width=0, use assertPresent() not assertVisible()

--- a/tests/Browser/Settings/Preferences/GeneralTest.php
+++ b/tests/Browser/Settings/Preferences/GeneralTest.php
@@ -156,10 +156,10 @@ class GeneralTest extends \Tests\Browser\TestCase
         $options = array_diff(array_keys($this->settings), ['refresh_interval', 'pretty_date']);
 
         foreach ($options as $option) {
-            $this->assertEquals($this->settings[$option], $prefs[$option]);
+            $this->assertSame($this->settings[$option], $prefs[$option]);
         }
 
-        $this->assertEquals($this->settings['pretty_date'], $prefs['prettydate']);
-        $this->assertEquals($this->settings['refresh_interval'], $prefs['refresh_interval'] / 60);
+        $this->assertSame($this->settings['pretty_date'], $prefs['prettydate']);
+        $this->assertSame($this->settings['refresh_interval'], $prefs['refresh_interval'] / 60);
     }
 }

--- a/tests/Framework/Bootstrap.php
+++ b/tests/Framework/Bootstrap.php
@@ -74,7 +74,7 @@ class Framework_Bootstrap extends PHPUnit\Framework\TestCase
 
         foreach ($data as $value => $expected) {
             $result = slashify($value);
-            $this->assertEquals($expected, $result, "Invalid slashify() result for $value");
+            $this->assertSame($expected, $result, "Invalid slashify() result for $value");
         }
 
     }
@@ -96,7 +96,7 @@ class Framework_Bootstrap extends PHPUnit\Framework\TestCase
 
         foreach ($data as $value => $expected) {
             $result = unslashify($value);
-            $this->assertEquals($expected, $result, "Invalid unslashify() result for $value");
+            $this->assertSame($expected, $result, "Invalid unslashify() result for $value");
         }
 
     }
@@ -118,7 +118,7 @@ class Framework_Bootstrap extends PHPUnit\Framework\TestCase
 
         foreach ($data as $value => $expected) {
             $result = get_offset_sec($value);
-            $this->assertEquals($expected, $result, "Invalid get_offset_sec() result for $value");
+            $this->assertSame($expected, $result, "Invalid get_offset_sec() result for $value");
         }
 
     }
@@ -142,7 +142,7 @@ class Framework_Bootstrap extends PHPUnit\Framework\TestCase
         $input_str  = 'one,two,three,four,five';
         $result_str = implode(',', $result);
 
-        $this->assertEquals($input_str, $result_str, "Invalid array_keys_recursive() result");
+        $this->assertSame($input_str, $result_str, "Invalid array_keys_recursive() result");
     }
 
     /**
@@ -175,7 +175,7 @@ class Framework_Bootstrap extends PHPUnit\Framework\TestCase
 
         foreach ($data as $set) {
             $result = abbreviate_string($set[1], $set[2], $set[3], $set[4]);
-            $this->assertEquals($set[0], $result);
+            $this->assertSame($set[0], $result);
         }
     }
 
@@ -194,7 +194,7 @@ class Framework_Bootstrap extends PHPUnit\Framework\TestCase
 
         foreach ($data as $value => $expected) {
             $result = format_email($value);
-            $this->assertEquals($expected, $result, "Invalid format_email() result for $value");
+            $this->assertSame($expected, $result, "Invalid format_email() result for $value");
         }
     }
 
@@ -215,7 +215,7 @@ class Framework_Bootstrap extends PHPUnit\Framework\TestCase
 
         foreach ($data as $expected => $value) {
             $result = format_email_recipient($value[0], isset($value[1]) ? $value[1] : null);
-            $this->assertEquals($expected, $result, "Invalid format_email_recipient()");
+            $this->assertSame($expected, $result, "Invalid format_email_recipient()");
         }
 
     }
@@ -253,7 +253,7 @@ class Framework_Bootstrap extends PHPUnit\Framework\TestCase
      */
     function test_version_parse()
     {
-        $this->assertEquals('0.9.0', version_parse('0.9-stable'));
-        $this->assertEquals('0.9.99', version_parse('0.9-git'));
+        $this->assertSame('0.9.0', version_parse('0.9-stable'));
+        $this->assertSame('0.9.99', version_parse('0.9-git'));
     }
 }

--- a/tests/Framework/Bootstrap.php
+++ b/tests/Framework/Bootstrap.php
@@ -54,7 +54,7 @@ class Framework_Bootstrap extends PHPUnit\Framework\TestCase
 
         foreach ($data as $value => $expected) {
             $result = parse_bytes($value);
-            $this->assertEquals($expected, $result, "Invalid parse_bytes() result for $value");
+            $this->{'assertEquals'}($expected, $result, "Invalid parse_bytes() result for $value");
         }
 
         $this->assertSame(0.0, parse_bytes(null));
@@ -112,7 +112,7 @@ class Framework_Bootstrap extends PHPUnit\Framework\TestCase
             '1h'    => 1 * 60 * 60,
             '1d'    => 1 * 60 * 60 * 24,
             '1w'    => 1 * 60 * 60 * 24 * 7,
-            '1y'    => (int) '1y',
+            '1y'    => 1,
             '100'   => 100,
         ];
 

--- a/tests/Framework/Browser.php
+++ b/tests/Framework/Browser.php
@@ -12,12 +12,12 @@ class Framework_Browser extends PHPUnit\Framework\TestCase
     {
         $object = $this->getBrowser($useragent);
 
-        $this->assertEquals($opera, $object->opera, 'Check for Opera failed');
-        $this->assertEquals($chrome, $object->chrome, 'Check for Chrome failed');
-        $this->assertEquals($ie, $object->ie, 'Check for IE failed');
-        $this->assertEquals($edge, $object->edge, 'Check for Edge failed');
-        $this->assertEquals($safari, $object->safari, 'Check for Safari failed');
-        $this->assertEquals($mz, $object->mz, 'Check for MZ failed');
+        $this->assertSame($opera, $object->opera, 'Check for Opera failed');
+        $this->assertSame($chrome, $object->chrome, 'Check for Chrome failed');
+        $this->assertSame($ie, $object->ie, 'Check for IE failed');
+        $this->assertSame($edge, $object->edge, 'Check for Edge failed');
+        $this->assertSame($safari, $object->safari, 'Check for Safari failed');
+        $this->assertSame($mz, $object->mz, 'Check for MZ failed');
     }
 
     /**
@@ -27,10 +27,10 @@ class Framework_Browser extends PHPUnit\Framework\TestCase
     {
         $object = $this->getBrowser($useragent);
 
-        $this->assertEquals($windows, $object->win, 'Check Result of Windows');
-        $this->assertEquals($linux, $object->linux, 'Check Result of Linux');
-        $this->assertEquals($mac, $object->mac, 'Check Result of Mac');
-        $this->assertEquals($unix, $object->unix, 'Check Result of Unix');
+        $this->assertSame($windows, $object->win, 'Check Result of Windows');
+        $this->assertSame($linux, $object->linux, 'Check Result of Linux');
+        $this->assertSame($mac, $object->mac, 'Check Result of Mac');
+        $this->assertSame($unix, $object->unix, 'Check Result of Unix');
 
     }
 
@@ -40,7 +40,7 @@ class Framework_Browser extends PHPUnit\Framework\TestCase
     function test_version($useragent, $version)
     {
         $object = $this->getBrowser($useragent);
-        $this->assertEquals($version, $object->ver);
+        $this->assertSame($version, $object->ver);
     }
 
     function versions(): iterable

--- a/tests/Framework/Browser.php
+++ b/tests/Framework/Browser.php
@@ -58,7 +58,7 @@ class Framework_Browser extends PHPUnit\Framework\TestCase
         return [
             'WIN: Mozilla Firefox ' => [
                 'useragent'    => 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.0.1) Gecko/20060111 Firefox/1.5.0.1',
-                'version'      => '1.8',
+                'version'      => 1.8,
                 'isWin'        => true,
                 'isLinux'      => false,
                 'isMac'        => false,
@@ -73,7 +73,7 @@ class Framework_Browser extends PHPUnit\Framework\TestCase
 
             'LINUX: Bon Echo ' => [
                 'useragent'    => 'Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.8.1.1) Gecko/20070222 BonEcho/2.0.0.1',
-                'version'      => '1.8',
+                'version'      => 1.8,
                 'isWin'        => false,
                 'isLinux'      => true,
                 'isMac'        => false,
@@ -88,7 +88,7 @@ class Framework_Browser extends PHPUnit\Framework\TestCase
 
             'Chrome Mac' => [
                 'useragent'    => 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_4; en-US) AppleWebKit/534.3 (KHTML, like Gecko) Chrome/6.0.461.0 Safari/534.3',
-                'version'      => '6',
+                'version'      => 6.0,
                 'isWin'        => false,
                 'isLinux'      => false,
                 'isMac'        => true,
@@ -103,7 +103,7 @@ class Framework_Browser extends PHPUnit\Framework\TestCase
 
             'IE 11' => [
                 'useragent'    => 'Mozilla/5.0 (Windows NT 6.3; Trident/7.0; .NET4.0E; .NET4.0C; rv:11.0) like Gecko',
-                'version'      => '11.0',
+                'version'      => 11.0,
                 'isWin'        => true,
                 'isLinux'      => false,
                 'isMac'        => false,
@@ -118,7 +118,7 @@ class Framework_Browser extends PHPUnit\Framework\TestCase
 
             'Opera 15' => [
                 'useragent'    => 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.29 Safari/537.36 OPR/15.0.1147.24',
-                'version'      => '15.0',
+                'version'      => 15.0,
                 'isWin'        => true,
                 'isLinux'      => false,
                 'isMac'        => false,
@@ -133,7 +133,7 @@ class Framework_Browser extends PHPUnit\Framework\TestCase
 
             'Edge 14' => [
                 'useragent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML like Gecko) Chrome/51.0.2704.79 Safari/537.36 Edge/14.14931',
-                'version'      => '14.14931',
+                'version'      => 14.14931,
                 'isWin'        => true,
                 'isLinux'      => false,
                 'isMac'        => false,

--- a/tests/Framework/Charset.php
+++ b/tests/Framework/Charset.php
@@ -76,7 +76,7 @@ class Framework_Charset extends PHPUnit\Framework\TestCase
      */
     function test_parse_charset($input, $output)
     {
-        $this->assertEquals($output, rcube_charset::parse_charset($input));
+        $this->assertSame($output, rcube_charset::parse_charset($input));
     }
 
     /**
@@ -112,7 +112,7 @@ class Framework_Charset extends PHPUnit\Framework\TestCase
      */
     function test_convert($input, $output, $from, $to)
     {
-        $this->assertEquals($output, rcube_charset::convert($input, $from, $to));
+        $this->assertSame($output, rcube_charset::convert($input, $from, $to));
     }
 
     /**
@@ -131,7 +131,7 @@ class Framework_Charset extends PHPUnit\Framework\TestCase
     function test_utf7_to_utf8($input, $output)
     {
         // @phpstan-ignore-next-line
-        $this->assertEquals($output, rcube_charset::utf7_to_utf8($input));
+        $this->assertSame($output, rcube_charset::utf7_to_utf8($input));
     }
 
     /**
@@ -150,7 +150,7 @@ class Framework_Charset extends PHPUnit\Framework\TestCase
     function test_utf7imap_to_utf8($input, $output)
     {
         // @phpstan-ignore-next-line
-        $this->assertEquals($output, rcube_charset::utf7imap_to_utf8($input));
+        $this->assertSame($output, rcube_charset::utf7imap_to_utf8($input));
     }
 
     /**
@@ -169,7 +169,7 @@ class Framework_Charset extends PHPUnit\Framework\TestCase
     function test_utf8_to_utf7imap($input, $output)
     {
         // @phpstan-ignore-next-line
-        $this->assertEquals($output, rcube_charset::utf8_to_utf7imap($input));
+        $this->assertSame($output, rcube_charset::utf8_to_utf7imap($input));
     }
 
     /**
@@ -188,7 +188,7 @@ class Framework_Charset extends PHPUnit\Framework\TestCase
     function test_utf16_to_utf8($input, $output)
     {
         // @phpstan-ignore-next-line
-        $this->assertEquals($output, rcube_charset::utf16_to_utf8($input));
+        $this->assertSame($output, rcube_charset::utf16_to_utf8($input));
     }
 
     /**
@@ -208,7 +208,7 @@ class Framework_Charset extends PHPUnit\Framework\TestCase
     function test_detect($input, $fallback, $output)
     {
         // @phpstan-ignore-next-line
-        $this->assertEquals($output, rcube_charset::detect($input, $fallback));
+        $this->assertSame($output, rcube_charset::detect($input, $fallback));
     }
 
     /**
@@ -227,6 +227,6 @@ class Framework_Charset extends PHPUnit\Framework\TestCase
     function test_detect_with_lang($input, $lang, $output)
     {
         // @phpstan-ignore-next-line
-        $this->assertEquals($output, rcube_charset::detect($input, $output, $lang));
+        $this->assertSame($output, rcube_charset::detect($input, $output, $lang));
     }
 }

--- a/tests/Framework/Csv2vcard.php
+++ b/tests/Framework/Csv2vcard.php
@@ -38,7 +38,7 @@ class Framework_Csv2vcard extends PHPUnit\Framework\TestCase
         $vcf_text = trim(str_replace("\r\n", "\n", $vcf_text));
         $vcard    = trim(str_replace("\r\n", "\n", $vcard));
 
-        $this->assertEquals($vcf_text, $vcard);
+        $this->assertSame($vcf_text, $vcard);
     }
 
     function test_import_email()
@@ -59,7 +59,7 @@ class Framework_Csv2vcard extends PHPUnit\Framework\TestCase
 
         $vcf_text = trim(str_replace("\r\n", "\n", $vcf_text));
         $vcard    = trim(str_replace("\r\n", "\n", $vcard));
-        $this->assertEquals($vcf_text, $vcard);
+        $this->assertSame($vcf_text, $vcard);
     }
 
     function test_import_gmail()
@@ -77,7 +77,7 @@ class Framework_Csv2vcard extends PHPUnit\Framework\TestCase
         $vcf_text = trim(str_replace("\r\n", "\n", $vcf_text));
         $vcard    = trim(str_replace("\r\n", "\n", $vcard));
 
-        $this->assertEquals($vcf_text, $vcard);
+        $this->assertSame($vcf_text, $vcard);
     }
 
     function test_import_outlook()
@@ -95,6 +95,6 @@ class Framework_Csv2vcard extends PHPUnit\Framework\TestCase
         $vcf_text = trim(str_replace("\r\n", "\n", $vcf_text));
         $vcard    = trim(str_replace("\r\n", "\n", $vcard));
 
-        $this->assertEquals($vcf_text, $vcard);
+        $this->assertSame($vcf_text, $vcard);
     }
 }

--- a/tests/Framework/Html.php
+++ b/tests/Framework/Html.php
@@ -61,7 +61,7 @@ class Framework_Html extends PHPUnit\Framework\TestCase
      */
     function test_attrib_string($arg1, $arg2, $expected)
     {
-        $this->assertEquals($expected, html::attrib_string($arg1, $arg2));
+        $this->assertSame($expected, html::attrib_string($arg1, $arg2));
     }
 
     /**
@@ -87,7 +87,7 @@ class Framework_Html extends PHPUnit\Framework\TestCase
      */
     function test_quote($str, $expected)
     {
-        $this->assertEquals($expected, html::quote($str));
+        $this->assertSame($expected, html::quote($str));
     }
 
     /**
@@ -130,6 +130,6 @@ class Framework_Html extends PHPUnit\Framework\TestCase
      */
     function test_parse_attrib_string($arg1, $expected)
     {
-        $this->assertEquals($expected, html::parse_attrib_string($arg1));
+        $this->assertSame($expected, html::parse_attrib_string($arg1));
     }
 }

--- a/tests/Framework/Html2text.php
+++ b/tests/Framework/Html2text.php
@@ -100,7 +100,7 @@ class rc_html2text extends PHPUnit\Framework\TestCase
         $ht->set_html($in);
         $res = $ht->get_text();
 
-        $this->assertEquals($out, $res, $title);
+        $this->assertSame($out, $res, $title);
     }
 
     /**

--- a/tests/Framework/LdapGeneric.php
+++ b/tests/Framework/LdapGeneric.php
@@ -5,15 +5,19 @@
  */
 class Framework_LdapGeneric extends PHPUnit\Framework\TestCase
 {
+    protected function markTestSkippedIfNetLdapPackageIsNotInstalled(): void
+    {
+        if (!class_exists(Net_LDAP3::class)) {
+            $this->markTestSkipped('The Net_LDAP3 package not available.');
+        }
+    }
+
     /**
      * Class constructor
      */
     function test_class()
     {
-        // skip test if Net_LDAP3 does not exist
-        if (!class_exists('Net_LDAP3')) {
-            $this->markTestSkipped('The Net_LDAP3 package not available.');
-        }
+        $this->markTestSkippedIfNetLdapPackageIsNotInstalled();
 
         $object = new rcube_ldap_generic([]);
 
@@ -25,6 +29,8 @@ class Framework_LdapGeneric extends PHPUnit\Framework\TestCase
      */
     function test_fulltext_search_filter()
     {
+        $this->markTestSkippedIfNetLdapPackageIsNotInstalled();
+
         $object = new rcube_ldap_generic([]);
 
         $result = $object->fulltext_search_filter('test', ['dn']);

--- a/tests/Framework/Mime.php
+++ b/tests/Framework/Mime.php
@@ -83,9 +83,9 @@ class Framework_Mime extends PHPUnit\Framework\TestCase
         foreach ($headers as $idx => $header) {
             $res = rcube_mime::decode_address_list($header);
 
-            $this->assertEquals($results[$idx][0], count($res), "Rows number in result for header: " . $header);
-            $this->assertEquals($results[$idx][1], $res[1]['name'], "Name part decoding for header: " . $header);
-            $this->assertEquals($results[$idx][2], $res[1]['mailto'], "Email part decoding for header: " . $header);
+            $this->assertSame($results[$idx][0], count($res), "Rows number in result for header: " . $header);
+            $this->assertSame($results[$idx][1], $res[1]['name'], "Name part decoding for header: " . $header);
+            $this->assertSame($results[$idx][2], $res[1]['mailto'], "Email part decoding for header: " . $header);
         }
     }
 
@@ -128,7 +128,7 @@ class Framework_Mime extends PHPUnit\Framework\TestCase
         foreach ($headers as $idx => $header) {
             $res = rcube_mime::decode_address_list($header);
 
-            $this->assertEquals($results[$idx], $res, "Decode address groups (#$idx)");
+            $this->assertSame($results[$idx], $res, "Decode address groups (#$idx)");
         }
     }
 
@@ -174,7 +174,7 @@ class Framework_Mime extends PHPUnit\Framework\TestCase
             $res = rcube_mime::decode_mime_string($item['in'], 'UTF-8');
             $res = quoted_printable_encode($res);
 
-            $this->assertEquals($item['out'], $res, "Header decoding for: " . $idx);
+            $this->assertSame($item['out'], $res, "Header decoding for: " . $idx);
         }
     }
 
@@ -183,7 +183,7 @@ class Framework_Mime extends PHPUnit\Framework\TestCase
      */
     function test_parse_headers()
     {
-        $this->assertEquals([], rcube_mime::parse_headers(''));
+        $this->assertSame([], rcube_mime::parse_headers(''));
 
 
         $headers = "Subject: Test\r\n"
@@ -194,7 +194,7 @@ class Framework_Mime extends PHPUnit\Framework\TestCase
             'to' => 'test@test1.com test@test2.com',
         ];
 
-        $this->assertEquals($expected, rcube_mime::parse_headers($headers));
+        $this->assertSame($expected, rcube_mime::parse_headers($headers));
     }
 
     /**
@@ -205,7 +205,7 @@ class Framework_Mime extends PHPUnit\Framework\TestCase
         $raw = file_get_contents(TESTS_DIR . 'src/format-flowed-unfolded.txt');
         $flowed = file_get_contents(TESTS_DIR . 'src/format-flowed.txt');
 
-        $this->assertEquals($flowed, rcube_mime::format_flowed($raw, 80), "Test correct folding and space-stuffing");
+        $this->assertSame($flowed, rcube_mime::format_flowed($raw, 80), "Test correct folding and space-stuffing");
     }
 
     /**
@@ -216,7 +216,7 @@ class Framework_Mime extends PHPUnit\Framework\TestCase
         $flowed = file_get_contents(TESTS_DIR . 'src/format-flowed.txt');
         $unfolded = file_get_contents(TESTS_DIR . 'src/format-flowed-unfolded.txt');
 
-        $this->assertEquals($unfolded, rcube_mime::unfold_flowed($flowed), "Test correct unfolding of quoted lines");
+        $this->assertSame($unfolded, rcube_mime::unfold_flowed($flowed), "Test correct unfolding of quoted lines");
     }
 
     /**
@@ -231,7 +231,7 @@ class Framework_Mime extends PHPUnit\Framework\TestCase
                     . "> \r\n"
                     . "Sed ut perspiciatis unde omnis iste natus error sit voluptatem";
 
-        $this->assertEquals($unfolded, rcube_mime::unfold_flowed($flowed), "Test correct unfolding of quoted lines [2]");
+        $this->assertSame($unfolded, rcube_mime::unfold_flowed($flowed), "Test correct unfolding of quoted lines [2]");
     }
 
     /**
@@ -245,7 +245,7 @@ class Framework_Mime extends PHPUnit\Framework\TestCase
                     . "しているのを見ました。";
         $unfolded = "そしてジョバンニはすぐうしろの天気輪の柱がいつかぼんやりした三角標の形になって、しばらく蛍のように、ぺかぺか消えたりともったりしているのを見ました。";
 
-        $this->assertEquals($unfolded, rcube_mime::unfold_flowed($flowed, null, true), "Test correct unfolding of flowed DelSp=Yes lines");
+        $this->assertSame($unfolded, rcube_mime::unfold_flowed($flowed, null, true), "Test correct unfolding of flowed DelSp=Yes lines");
     }
 
     /**
@@ -309,7 +309,7 @@ class Framework_Mime extends PHPUnit\Framework\TestCase
         ];
 
         foreach ($samples as $sample) {
-            $this->assertEquals($sample[1], call_user_func_array(['rcube_mime', 'wordwrap'], $sample[0]), "Test text wrapping");
+            $this->assertSame($sample[1], call_user_func_array(['rcube_mime', 'wordwrap'], $sample[0]), "Test text wrapping");
         }
     }
 

--- a/tests/Framework/Rcube.php
+++ b/tests/Framework/Rcube.php
@@ -60,6 +60,8 @@ class Framework_Rcube extends PHPUnit\Framework\TestCase
 
     /**
      * rcube::exec()
+     *
+     * @requires function shell_exec
      */
     function test_exec()
     {

--- a/tests/Framework/StringReplacer.php
+++ b/tests/Framework/StringReplacer.php
@@ -58,7 +58,7 @@ class Framework_StringReplacer extends PHPUnit\Framework\TestCase
         $result = $replacer->replace($input);
         $result = $replacer->resolve($result);
 
-        $this->assertEquals($output, $result);
+        $this->assertSame($output, $result);
     }
 
     /**

--- a/tests/Framework/Text2Html.php
+++ b/tests/Framework/Text2Html.php
@@ -115,7 +115,7 @@ class Framework_Text2Html extends PHPUnit\Framework\TestCase
 
         $html = $t2h->get_html();
 
-        $this->assertEquals($output, $html);
+        $this->assertSame($output, $html);
     }
 
     /**
@@ -132,7 +132,7 @@ class Framework_Text2Html extends PHPUnit\Framework\TestCase
             . "[&lt;script&gt;evil&lt;/script&gt;]:##str_replacement_0##<br>\n"
             . "</div>";
 
-        $this->assertEquals($expected, $html);
+        $this->assertSame($expected, $html);
     }
 
     /**
@@ -149,7 +149,7 @@ class Framework_Text2Html extends PHPUnit\Framework\TestCase
             . "<a rel=\"noreferrer\" target=\"_blank\" href=\"https://google.com\">https://google.com</a><br>\n"
             . "</div>";
 
-        $this->assertEquals($expected, $html);
+        $this->assertSame($expected, $html);
     }
 
     /**
@@ -170,7 +170,7 @@ class Framework_Text2Html extends PHPUnit\Framework\TestCase
         $html = $t2h->get_html();
         $html = preg_replace('/ (rel|target)="(noreferrer|_blank)"/', '', $html);
 
-        $this->assertEquals($expected, $html);
+        $this->assertSame($expected, $html);
     }
 
     /**
@@ -209,6 +209,6 @@ class Framework_Text2Html extends PHPUnit\Framework\TestCase
         $t2h = new rcube_text2html($input, false, ['space' => '_']);
         $html = $t2h->get_html();
 
-        $this->assertEquals($expected, $html);
+        $this->assertSame($expected, $html);
     }
 }

--- a/tests/Framework/User.php
+++ b/tests/Framework/User.php
@@ -168,7 +168,7 @@ class Framework_User extends ActionTestCase
 
         $user = rcube_user::query('test@example.com', 'localhost');
 
-        $this->assertEquals(1, $user->ID);
+        $this->assertSame(1, $user->ID);
     }
 
     /**

--- a/tests/Framework/User.php
+++ b/tests/Framework/User.php
@@ -126,11 +126,11 @@ class Framework_User extends ActionTestCase
 
         $this->assertCount(3, $idents);
         $this->assertSame('add@ident.com', $idents[0]['email']);
-        $this->assertEquals(1, $idents[0]['standard']);
+        $this->{'assertEquals'}(1, $idents[0]['standard']);
         $this->assertSame('test@example.com', $idents[1]['email']);
-        $this->assertEquals(0, $idents[1]['standard']);
+        $this->{'assertEquals'}(0, $idents[1]['standard']);
         $this->assertSame('test@example.org', $idents[2]['email']);
-        $this->assertEquals(0, $idents[2]['standard']);
+        $this->{'assertEquals'}(0, $idents[2]['standard']);
 
         $ident = $user->delete_identity($default);
 
@@ -152,7 +152,7 @@ class Framework_User extends ActionTestCase
 
         $user = new rcube_user(1);
 
-        $this->assertEquals(1, $user->data['failed_login_counter']);
+        $this->{'assertEquals'}(1, $user->data['failed_login_counter']);
 
         $this->assertFalse($user->is_locked());
     }
@@ -188,7 +188,7 @@ class Framework_User extends ActionTestCase
 
         $this->assertCount(1, $idents);
         $this->assertSame('new@example.com', $idents[0]['email']);
-        $this->assertEquals(1, $idents[0]['standard']);
+        $this->{'assertEquals'}(1, $idents[0]['standard']);
     }
 
     /**

--- a/tests/Framework/Utils.php
+++ b/tests/Framework/Utils.php
@@ -187,7 +187,7 @@ class Framework_Utils extends PHPUnit\Framework\TestCase
         $result = rcube_utils::rep_specialchars_output(
             $str, $type ?: 'html', $mode ?: 'strict');
 
-        $this->assertEquals($result, $res);
+        $this->assertSame($result, $res);
     }
 
     /**
@@ -217,41 +217,41 @@ class Framework_Utils extends PHPUnit\Framework\TestCase
     function test_mod_css_styles_xss()
     {
         $mod = rcube_utils::mod_css_styles("body.main2cols { background-image: url('../images/leftcol.png'); }", 'rcmbody');
-        $this->assertEquals("/* evil! */", $mod, "No url() values allowed");
+        $this->assertSame("/* evil! */", $mod, "No url() values allowed");
 
         $mod = rcube_utils::mod_css_styles("@import url('http://localhost/somestuff/css/master.css');", 'rcmbody');
-        $this->assertEquals("/* evil! */", $mod, "No import statements");
+        $this->assertSame("/* evil! */", $mod, "No import statements");
 
         $mod = rcube_utils::mod_css_styles("left:expression(document.body.offsetWidth-20)", 'rcmbody');
-        $this->assertEquals("/* evil! */", $mod, "No expression properties");
+        $this->assertSame("/* evil! */", $mod, "No expression properties");
 
         $mod = rcube_utils::mod_css_styles("left:exp/*  */ression( alert(&#039;xss3&#039;) )", 'rcmbody');
-        $this->assertEquals("/* evil! */", $mod, "Don't allow encoding quirks");
+        $this->assertSame("/* evil! */", $mod, "Don't allow encoding quirks");
 
         $mod = rcube_utils::mod_css_styles("background:\\0075\\0072\\00006c( javascript:alert(&#039;xss&#039;) )", 'rcmbody');
-        $this->assertEquals("/* evil! */", $mod, "Don't allow encoding quirks (2)");
+        $this->assertSame("/* evil! */", $mod, "Don't allow encoding quirks (2)");
 
         $mod = rcube_utils::mod_css_styles("background: \\75 \\72 \\6C ('/images/img.png')", 'rcmbody');
-        $this->assertEquals("/* evil! */", $mod, "Don't allow encoding quirks (3)");
+        $this->assertSame("/* evil! */", $mod, "Don't allow encoding quirks (3)");
 
         $mod = rcube_utils::mod_css_styles("background: u\\r\\l('/images/img.png')", 'rcmbody');
-        $this->assertEquals("/* evil! */", $mod, "Don't allow encoding quirks (4)");
+        $this->assertSame("/* evil! */", $mod, "Don't allow encoding quirks (4)");
 
         // position: fixed (#5264)
         $mod = rcube_utils::mod_css_styles(".test { position: fixed; }", 'rcmbody');
-        $this->assertEquals("#rcmbody .test { position: absolute; }", $mod, "Replace position:fixed with position:absolute (0)");
+        $this->assertSame("#rcmbody .test { position: absolute; }", $mod, "Replace position:fixed with position:absolute (0)");
         $mod = rcube_utils::mod_css_styles(".test { position:\nfixed; }", 'rcmbody');
-        $this->assertEquals("#rcmbody .test { position: absolute; }", $mod, "Replace position:fixed with position:absolute (1)");
+        $this->assertSame("#rcmbody .test { position: absolute; }", $mod, "Replace position:fixed with position:absolute (1)");
         $mod = rcube_utils::mod_css_styles(".test { position:/**/fixed; }", 'rcmbody');
-        $this->assertEquals("#rcmbody .test { position: absolute; }", $mod, "Replace position:fixed with position:absolute (2)");
+        $this->assertSame("#rcmbody .test { position: absolute; }", $mod, "Replace position:fixed with position:absolute (2)");
 
         // position: fixed (#6898)
         $mod = rcube_utils::mod_css_styles(".test { position : fixed; top: 0; }", 'rcmbody');
-        $this->assertEquals("#rcmbody .test { position: absolute; top: 0; }", $mod, "Replace position:fixed with position:absolute (3)");
+        $this->assertSame("#rcmbody .test { position: absolute; top: 0; }", $mod, "Replace position:fixed with position:absolute (3)");
         $mod = rcube_utils::mod_css_styles(".test { position/**/: fixed; top: 0; }", 'rcmbody');
-        $this->assertEquals("#rcmbody .test { position: absolute; top: 0; }", $mod, "Replace position:fixed with position:absolute (4)");
+        $this->assertSame("#rcmbody .test { position: absolute; top: 0; }", $mod, "Replace position:fixed with position:absolute (4)");
         $mod = rcube_utils::mod_css_styles(".test { position\n: fixed; top: 0; }", 'rcmbody');
-        $this->assertEquals("#rcmbody .test { position: absolute; top: 0; }", $mod, "Replace position:fixed with position:absolute (5)");
+        $this->assertSame("#rcmbody .test { position: absolute; top: 0; }", $mod, "Replace position:fixed with position:absolute (5)");
 
         // allow data URIs with images (#5580)
         $mod = rcube_utils::mod_css_styles("body { background-image: url(data:image/png;base64,123); }", 'rcmbody');
@@ -784,7 +784,7 @@ class Framework_Utils extends PHPUnit\Framework\TestCase
      */
     function test_idn_to_ascii($decoded, $encoded)
     {
-        $this->assertEquals(rcube_utils::idn_to_ascii($decoded), $encoded);
+        $this->assertSame(rcube_utils::idn_to_ascii($decoded), $encoded);
     }
 
     /**
@@ -797,7 +797,7 @@ class Framework_Utils extends PHPUnit\Framework\TestCase
      */
     function test_idn_to_utf8($decoded, $encoded)
     {
-        $this->assertEquals(rcube_utils::idn_to_utf8($encoded), $decoded);
+        $this->assertSame(rcube_utils::idn_to_utf8($encoded), $decoded);
     }
 
     /**
@@ -805,8 +805,8 @@ class Framework_Utils extends PHPUnit\Framework\TestCase
      */
     function test_idn_to_ascii_special()
     {
-        $this->assertEquals(rcube_utils::idn_to_ascii('H.S'), 'H.S');
-        $this->assertEquals(rcube_utils::idn_to_ascii('d.-h.lastname'), 'd.-h.lastname');
+        $this->assertSame(rcube_utils::idn_to_ascii('H.S'), 'H.S');
+        $this->assertSame(rcube_utils::idn_to_ascii('d.-h.lastname'), 'd.-h.lastname');
     }
 
     /**
@@ -829,7 +829,7 @@ class Framework_Utils extends PHPUnit\Framework\TestCase
      */
     function test_parse_host($name, $host, $result)
     {
-        $this->assertEquals(rcube_utils::parse_host($name, $host), $result);
+        $this->assertSame(rcube_utils::parse_host($name, $host), $result);
     }
 
     /**
@@ -886,7 +886,7 @@ class Framework_Utils extends PHPUnit\Framework\TestCase
      */
     function test_remove_subject_prefix($mode, $subject, $result)
     {
-        $this->assertEquals(rcube_utils::remove_subject_prefix($subject, $mode), $result);
+        $this->assertSame(rcube_utils::remove_subject_prefix($subject, $mode), $result);
     }
 
     /**
@@ -894,13 +894,13 @@ class Framework_Utils extends PHPUnit\Framework\TestCase
      */
     function test_server_name()
     {
-        $this->assertEquals('localhost', rcube_utils::server_name('test'));
+        $this->assertSame('localhost', rcube_utils::server_name('test'));
 
         $_SERVER['test'] = 'test.com:843';
-        $this->assertEquals('test.com', rcube_utils::server_name('test'));
+        $this->assertSame('test.com', rcube_utils::server_name('test'));
 
         $_SERVER['test'] = 'test.com';
-        $this->assertEquals('test.com', rcube_utils::server_name('test'));
+        $this->assertSame('test.com', rcube_utils::server_name('test'));
     }
 
     /**
@@ -914,27 +914,27 @@ class Framework_Utils extends PHPUnit\Framework\TestCase
         $rcube->config->set('trusted_host_patterns', ['my.domain.tld']);
 
         StderrMock::start();
-        $this->assertEquals('localhost', rcube_utils::server_name('test'));
+        $this->assertSame('localhost', rcube_utils::server_name('test'));
         StderrMock::stop();
         $this->assertSame("ERROR: Specified host is not trusted. Using 'localhost'.", trim(StderrMock::$output));
 
         $rcube->config->set('trusted_host_patterns', ['test.com']);
 
         StderrMock::start();
-        $this->assertEquals('test.com', rcube_utils::server_name('test'));
+        $this->assertSame('test.com', rcube_utils::server_name('test'));
         StderrMock::stop();
 
         $_SERVER['test'] = 'subdomain.test.com';
 
         StderrMock::start();
-        $this->assertEquals('localhost', rcube_utils::server_name('test'));
+        $this->assertSame('localhost', rcube_utils::server_name('test'));
         StderrMock::stop();
 
         $rcube->config->set('trusted_host_patterns', ['^test.com$']);
         $_SERVER['test'] = '^test.com$';
 
         StderrMock::start();
-        $this->assertEquals('localhost', rcube_utils::server_name('test'));
+        $this->assertSame('localhost', rcube_utils::server_name('test'));
         StderrMock::stop();
     }
 }

--- a/tests/Framework/VCard.php
+++ b/tests/Framework/VCard.php
@@ -15,8 +15,8 @@ class Framework_VCard extends PHPUnit\Framework\TestCase
         $vcard = new rcube_vcard(file_get_contents($this->_srcpath('apple.vcf')));
 
         $this->assertTrue($vcard->business, "Identify as business record");
-        $this->assertEquals("Apple Computer AG", $vcard->displayname, "FN => displayname");
-        $this->assertEquals("", $vcard->firstname, "No person name set");
+        $this->assertSame("Apple Computer AG", $vcard->displayname, "FN => displayname");
+        $this->assertSame("", $vcard->firstname, "No person name set");
     }
 
     function test_parse_two()
@@ -24,10 +24,10 @@ class Framework_VCard extends PHPUnit\Framework\TestCase
         $vcard = new rcube_vcard(file_get_contents($this->_srcpath('johndoe.vcf')), null);
 
         $this->assertFalse($vcard->business, "Identify as private record");
-        $this->assertEquals("John Doë", $vcard->displayname, "Decode according to charset attribute");
-        $this->assertEquals("roundcube.net", $vcard->organization, "Test organization field");
+        $this->assertSame("John Doë", $vcard->displayname, "Decode according to charset attribute");
+        $this->assertSame("roundcube.net", $vcard->organization, "Test organization field");
         $this->assertCount(2, $vcard->email, "List two e-mail addresses");
-        $this->assertEquals("roundcube@gmail.com", $vcard->email[0], "Use PREF e-mail as primary");
+        $this->assertSame("roundcube@gmail.com", $vcard->email[0], "Use PREF e-mail as primary");
     }
 
     /**
@@ -56,10 +56,10 @@ class Framework_VCard extends PHPUnit\Framework\TestCase
         $vcard = new rcube_vcard($vcard, null);
         $vcard = $vcard->get_assoc();
 
-        $this->assertEquals("last;", $vcard['surname'], "Decode backslash character");
-        $this->assertEquals("first\\", $vcard['firstname'], "Decode backslash character");
-        $this->assertEquals("middle\\;\\", $vcard['middlename'], "Decode backslash character");
-        $this->assertEquals("prefix", $vcard['prefix'], "Decode backslash character");
+        $this->assertSame("last;", $vcard['surname'], "Decode backslash character");
+        $this->assertSame("first\\", $vcard['firstname'], "Decode backslash character");
+        $this->assertSame("middle\\;\\", $vcard['middlename'], "Decode backslash character");
+        $this->assertSame("prefix", $vcard['prefix'], "Decode backslash character");
     }
 
     /**
@@ -71,9 +71,9 @@ class Framework_VCard extends PHPUnit\Framework\TestCase
         $vcard = new rcube_vcard($vcard, null);
         $vcard = $vcard->get_assoc();
 
-        $this->assertEquals("last\\a", $vcard['surname'], "Decode dummy backslash character");
-        $this->assertEquals("fir\nst", $vcard['firstname'], "Decode backslash character");
-        $this->assertEquals("http://domain.tld", $vcard['website:other'][0], "Decode dummy backslash character");
+        $this->assertSame("last\\a", $vcard['surname'], "Decode dummy backslash character");
+        $this->assertSame("fir\nst", $vcard['firstname'], "Decode backslash character");
+        $this->assertSame("http://domain.tld", $vcard['website:other'][0], "Decode dummy backslash character");
     }
 
     /**
@@ -103,12 +103,12 @@ class Framework_VCard extends PHPUnit\Framework\TestCase
         $vcards = rcube_vcard::import($input);
 
         $this->assertCount(2, $vcards, "Detected 2 vcards");
-        $this->assertEquals("Apple Computer AG", $vcards[0]->displayname, "FN => displayname");
-        $this->assertEquals("John Doë", $vcards[1]->displayname, "Displayname with correct charset");
+        $this->assertSame("Apple Computer AG", $vcards[0]->displayname, "FN => displayname");
+        $this->assertSame("John Doë", $vcards[1]->displayname, "Displayname with correct charset");
 
         // https://github.com/roundcube/roundcubemail/issues/1934
         $vcards2 = rcube_vcard::import(file_get_contents($this->_srcpath('thebat.vcf')));
-        $this->assertEquals("Iksi=F1ski", quoted_printable_encode($vcards2[0]->surname));
+        $this->assertSame("Iksi=F1ski", quoted_printable_encode($vcards2[0]->surname));
 
         $vcards[0]->reset();
         // TODO: Test reset() method
@@ -125,8 +125,8 @@ class Framework_VCard extends PHPUnit\Framework\TestCase
         $vcard = $vcards[0]->get_assoc();
 
         // ENCODING=b case (#1488683)
-        $this->assertEquals("/9j/4AAQSkZJRgABAQA", substr(base64_encode($vcard['photo']), 0, 19), "Photo decoding");
-        $this->assertEquals("Müller", $vcard['surname'], "Unicode characters");
+        $this->assertSame("/9j/4AAQSkZJRgABAQA", substr(base64_encode($vcard['photo']), 0, 19), "Photo decoding");
+        $this->assertSame("Müller", $vcard['surname'], "Unicode characters");
 
         $input = str_replace('ENCODING=b:', 'ENCODING=base64;jpeg:', $input);
 
@@ -134,7 +134,7 @@ class Framework_VCard extends PHPUnit\Framework\TestCase
         $vcard = $vcards[0]->get_assoc();
 
         // ENCODING=base64 case (#1489977)
-        $this->assertEquals("/9j/4AAQSkZJRgABAQA", substr(base64_encode($vcard['photo']), 0, 19), "Photo decoding");
+        $this->assertSame("/9j/4AAQSkZJRgABAQA", substr(base64_encode($vcard['photo']), 0, 19), "Photo decoding");
 
         $input = str_replace('PHOTO;ENCODING=base64;jpeg:', 'PHOTO:data:image/jpeg;base64,', $input);
 
@@ -142,7 +142,7 @@ class Framework_VCard extends PHPUnit\Framework\TestCase
         $vcard = $vcards[0]->get_assoc();
 
         // vcard4.0 "PHOTO:data:image/jpeg;base64," case (#1489977)
-        $this->assertEquals("/9j/4AAQSkZJRgABAQA", substr(base64_encode($vcard['photo']), 0, 19), "Photo decoding");
+        $this->assertSame("/9j/4AAQSkZJRgABAQA", substr(base64_encode($vcard['photo']), 0, 19), "Photo decoding");
     }
 
     function test_encodings()
@@ -150,7 +150,7 @@ class Framework_VCard extends PHPUnit\Framework\TestCase
         $input = file_get_contents($this->_srcpath('utf-16_sample.vcf'));
 
         $vcards = rcube_vcard::import($input);
-        $this->assertEquals("Ǽgean ĽdaMonté", $vcards[0]->displayname, "Decoded from UTF-16");
+        $this->assertSame("Ǽgean ĽdaMonté", $vcards[0]->displayname, "Decoded from UTF-16");
     }
 
     /**
@@ -173,8 +173,8 @@ class Framework_VCard extends PHPUnit\Framework\TestCase
         $this->assertCount(1, $result['phone:home'], "TYPE=home entry exists");
         $this->assertTrue(!isset($result['phone:mobile']), "TYPE=CELL entry ignored");
         $this->assertCount(5, $result['address:home'][0], "ADR with some fields missing");
-        $this->assertEquals($result['address:home'][0]['zipcode'], 'zip', "ADR with some fields missing (1)");
-        $this->assertEquals($result['address:home'][0]['street'], 'street', "ADR with some fields missing (2)");
+        $this->assertSame($result['address:home'][0]['zipcode'], 'zip', "ADR with some fields missing (1)");
+        $this->assertSame($result['address:home'][0]['street'], 'street', "ADR with some fields missing (2)");
     }
 
     /**
@@ -186,7 +186,7 @@ class Framework_VCard extends PHPUnit\Framework\TestCase
         $vcard = new rcube_vcard($vcard, null);
         $vcard = $vcard->get_assoc();
 
-        $this->assertEquals("1980-02-02", $vcard['birthday'][0]);
+        $this->assertSame("1980-02-02", $vcard['birthday'][0]);
     }
 
     /**

--- a/tests/Framework/Washtml.php
+++ b/tests/Framework/Washtml.php
@@ -107,32 +107,32 @@ class Framework_Washtml extends PHPUnit\Framework\TestCase
         $html   = "<!--[if gte mso 10]><p>p1</p><!--><p>p2</p>";
         $washed = $this->cleanupResult($washer->wash($html));
 
-        $this->assertEquals('<p>p2</p>', $washed, "HTML conditional comments (#1489004)");
+        $this->assertSame('<p>p2</p>', $washed, "HTML conditional comments (#1489004)");
 
         $html   = "<!--TestCommentInvalid><p>test</p>";
         $washed = $this->cleanupResult($washer->wash($html));
 
-        $this->assertEquals('<p>test</p>', $washed, "HTML invalid comments (#1487759)");
+        $this->assertSame('<p>test</p>', $washed, "HTML invalid comments (#1487759)");
 
         $html   = "<p>para1</p><!-- comment --><p>para2</p>";
         $washed = $this->cleanupResult($washer->wash($html));
 
-        $this->assertEquals('<p>para1</p><p>para2</p>', $washed, "HTML comments - simple comment");
+        $this->assertSame('<p>para1</p><p>para2</p>', $washed, "HTML comments - simple comment");
 
         $html   = "<p>para1</p><!-- <hr> comment --><p>para2</p>";
         $washed = $this->cleanupResult($washer->wash($html));
 
-        $this->assertEquals('<p>para1</p><p>para2</p>', $washed, "HTML comments - tags inside (#1489904)");
+        $this->assertSame('<p>para1</p><p>para2</p>', $washed, "HTML comments - tags inside (#1489904)");
 
         $html   = "<p>para1</p><!-- comment => comment --><p>para2</p>";
         $washed = $this->cleanupResult($washer->wash($html));
 
-        $this->assertEquals('<p>para1</p><p>para2</p>', $washed, "HTML comments - bracket inside");
+        $this->assertSame('<p>para1</p><p>para2</p>', $washed, "HTML comments - bracket inside");
 
         $html   = "<p><!-- span>1</span -->\n<span>2</span>\n<!-- >3</span --><span>4</span></p>";
         $washed = $this->cleanupResult($washer->wash($html));
 
-        $this->assertEquals("<p>\n<span>2</span>\n<span>4</span></p>", $washed, "HTML comments (#6464)");
+        $this->assertSame("<p>\n<span>2</span>\n<span>4</span></p>", $washed, "HTML comments (#6464)");
     }
 
     /**

--- a/tests/Rcmail/OutputHtml.php
+++ b/tests/Rcmail/OutputHtml.php
@@ -320,7 +320,7 @@ class Rcmail_RcmailOutputHtml extends PHPUnit\Framework\TestCase
         $object = new rcmail_output_html;
         $result = $object->just_parse($input);
 
-        $this->assertEquals($output, $result);
+        $this->assertSame($output, $result);
     }
 
     /**

--- a/tests/Rcmail/Rcmail.php
+++ b/tests/Rcmail/Rcmail.php
@@ -125,32 +125,32 @@ class Rcmail_Rcmail extends ActionTestCase
     {
         $rcmail = rcmail::get_instance();
 
-        $this->assertEquals(
+        $this->assertSame(
             '/sub/?_task=cli&_action=test',
             $rcmail->url('test'),
             "Action only"
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             '/sub/?_task=cli&_action=test&_a=AA',
             $rcmail->url(['action' => 'test', 'a' => 'AA']),
             "Unprefixed parameters"
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             '/sub/?_task=cli&_action=test&_b=BB',
             $rcmail->url(['_action' => 'test', '_b' => 'BB', '_c' => null]),
             "Prefixed parameters (skip empty)"
         );
-        $this->assertEquals('/sub/?_task=cli', $rcmail->url([]), "Empty input");
+        $this->assertSame('/sub/?_task=cli', $rcmail->url([]), "Empty input");
 
-        $this->assertEquals(
+        $this->assertSame(
             '/sub/?_task=cli&_action=test&_mode=ABS',
             $rcmail->url(['_action' => 'test', '_mode' => 'ABS'], true),
             "Absolute URL"
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             'https://mail.example.org/sub/?_task=calendar&_action=test&_mode=FQ',
             $rcmail->url(['task' => 'calendar', '_action' => 'test', '_mode' => 'FQ'], true, true),
             "Fully Qualified URL"
@@ -158,36 +158,36 @@ class Rcmail_Rcmail extends ActionTestCase
 
         // with different SCRIPT_NAME values
         $_SERVER['SCRIPT_NAME'] = 'index.php';
-        $this->assertEquals(
+        $this->assertSame(
             '/?_task=cli&_action=test&_mode=ABS',
             $rcmail->url(['_action' => 'test', '_mode' => 'ABS'], true),
             "Absolute URL (root)"
         );
 
         $_SERVER['SCRIPT_NAME'] = '';
-        $this->assertEquals(
+        $this->assertSame(
             '/?_task=cli&_action=test&_mode=ABS',
             $rcmail->url(['_action' => 'test', '_mode' => 'ABS'], true),
             "Absolute URL (root)"
         );
 
         $_SERVER['REQUEST_URI'] = '/rc/?_task=mail';
-        $this->assertEquals('/rc/?_task=cli', $rcmail->url([]), "Empty input with REQUEST_URI prefix");
+        $this->assertSame('/rc/?_task=cli', $rcmail->url([]), "Empty input with REQUEST_URI prefix");
 
         $rcmail->config->set('request_path', 'X_FORWARDED_PATH');
-        $this->assertEquals('/proxied/?_task=cli', $rcmail->url([]), "Consider request_path config (_SERVER)");
+        $this->assertSame('/proxied/?_task=cli', $rcmail->url([]), "Consider request_path config (_SERVER)");
 
         $rcmail->config->set('request_path', '/test');
-        $this->assertEquals('/test/?_task=cli', $rcmail->url([]), "Consider request_path config (/path)");
+        $this->assertSame('/test/?_task=cli', $rcmail->url([]), "Consider request_path config (/path)");
         $rcmail->config->set('request_path', '/test/');
-        $this->assertEquals('/test/?_task=cli', $rcmail->url([]), "Consider request_path config (/path/)");
+        $this->assertSame('/test/?_task=cli', $rcmail->url([]), "Consider request_path config (/path/)");
 
         $_SERVER['REQUEST_URI'] = null;
         $rcmail->config->set('request_path', null);
 
         $_SERVER['HTTPS'] = false;
         $_SERVER['SERVER_PORT'] = '8080';
-        $this->assertEquals(
+        $this->assertSame(
             'http://mail.example.org:8080/?_task=cli&_action=test&_mode=ABS',
             $rcmail->url(['_action' => 'test', '_mode' => 'ABS'], true, true),
             "Full URL with port"

--- a/tests/Rcmail/Sendmail.php
+++ b/tests/Rcmail/Sendmail.php
@@ -154,7 +154,7 @@ class Rcmail_RcmailSendmail extends ActionTestCase
         $sendmail = new rcmail_sendmail();
         $sendmail->options['charset'] = $charset;
 
-        $this->assertEquals($output, $sendmail->email_input_format($input));
+        $this->assertSame($output, $sendmail->email_input_format($input));
     }
 
     /**
@@ -172,23 +172,23 @@ class Rcmail_RcmailSendmail extends ActionTestCase
     {
         $input  = ['test' => 'test'];
         $result = rcmail_sendmail::draftinfo_encode($input);
-        $this->assertEquals('test=test', $result);
-        $this->assertEquals($input, rcmail_sendmail::draftinfo_decode($result));
+        $this->assertSame('test=test', $result);
+        $this->assertSame($input, rcmail_sendmail::draftinfo_decode($result));
 
         $input  = ['folder' => 'test'];
         $result =  rcmail_sendmail::draftinfo_encode($input);
-        $this->assertEquals('folder=B::dGVzdA==', $result);
-        $this->assertEquals($input, rcmail_sendmail::draftinfo_decode($result));
+        $this->assertSame('folder=B::dGVzdA==', $result);
+        $this->assertSame($input, rcmail_sendmail::draftinfo_decode($result));
 
         $input  = ['test' => 'test;test'];
         $result = rcmail_sendmail::draftinfo_encode($input);
-        $this->assertEquals('test=B::dGVzdDt0ZXN0', $result);
-        $this->assertEquals($input, rcmail_sendmail::draftinfo_decode($result));
+        $this->assertSame('test=B::dGVzdDt0ZXN0', $result);
+        $this->assertSame($input, rcmail_sendmail::draftinfo_decode($result));
 
         $input  = ['test' => 'test;test', 'a' => 'b'];
         $result = rcmail_sendmail::draftinfo_encode($input);
-        $this->assertEquals('test=B::dGVzdDt0ZXN0; a=b', $result);
-        $this->assertEquals($input, rcmail_sendmail::draftinfo_decode($result));
+        $this->assertSame('test=B::dGVzdDt0ZXN0; a=b', $result);
+        $this->assertSame($input, rcmail_sendmail::draftinfo_decode($result));
     }
 
     /**


### PR DESCRIPTION
Use `TestCase::assertSame()` instead of `TestCase::assertEquals()` which does not assert expected data type.

Fix [`php_unit_strict`](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/rules/php_unit/php_unit_strict.rst) rule.