### PR TITLE
Add override method attributes

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,6 +4,7 @@ includes:
 
 parameters:
     level: 4
+    checkMissingOverrideMethodAttribute: true
     paths:
         - .
     excludePaths:

--- a/plugins/acl/acl.php
+++ b/plugins/acl/acl.php
@@ -34,6 +34,7 @@ class acl extends rcube_plugin
     /**
      * Plugin initialization
      */
+    #[Override]
     public function init()
     {
         $this->rc = rcmail::get_instance();

--- a/plugins/additional_message_headers/additional_message_headers.php
+++ b/plugins/additional_message_headers/additional_message_headers.php
@@ -18,6 +18,7 @@ class additional_message_headers extends rcube_plugin
     /**
      * Plugin initialization
      */
+    #[Override]
     public function init()
     {
         $this->add_hook('message_before_send', [$this, 'message_headers']);

--- a/plugins/archive/archive.php
+++ b/plugins/archive/archive.php
@@ -22,6 +22,7 @@ class archive extends rcube_plugin
     /**
      * Plugin initialization.
      */
+    #[Override]
     public function init()
     {
         $rcmail = rcmail::get_instance();

--- a/plugins/archive/tests/Browser/MailTest.php
+++ b/plugins/archive/tests/Browser/MailTest.php
@@ -7,6 +7,7 @@ use Tests\Browser\TestCase;
 
 class MailTest extends TestCase
 {
+    #[\Override]
     public static function setUpBeforeClass(): void
     {
         \bootstrap::init_db();

--- a/plugins/archive/tests/Browser/SettingsTest.php
+++ b/plugins/archive/tests/Browser/SettingsTest.php
@@ -6,6 +6,7 @@ use Tests\Browser\TestCase;
 
 class SettingsTest extends TestCase
 {
+    #[\Override]
     public static function setUpBeforeClass(): void
     {
         \bootstrap::init_db();

--- a/plugins/attachment_reminder/attachment_reminder.php
+++ b/plugins/attachment_reminder/attachment_reminder.php
@@ -33,6 +33,7 @@ class attachment_reminder extends rcube_plugin
     /**
      * Plugin initialization
      */
+    #[Override]
     public function init()
     {
         $rcmail = rcmail::get_instance();

--- a/plugins/attachment_reminder/tests/Browser/PluginTest.php
+++ b/plugins/attachment_reminder/tests/Browser/PluginTest.php
@@ -7,6 +7,7 @@ use Tests\Browser\TestCase;
 
 class PluginTest extends TestCase
 {
+    #[\Override]
     public static function setUpBeforeClass(): void
     {
         \bootstrap::init_db();

--- a/plugins/autologon/autologon.php
+++ b/plugins/autologon/autologon.php
@@ -14,6 +14,7 @@ class autologon extends rcube_plugin
     /**
      * Plugin initialization
      */
+    #[Override]
     public function init()
     {
         $this->add_hook('startup', [$this, 'startup']);

--- a/plugins/autologout/autologout.php
+++ b/plugins/autologout/autologout.php
@@ -31,6 +31,7 @@ class autologout extends rcube_plugin
     /**
      * Plugin initialization
      */
+    #[Override]
     public function init()
     {
         $this->add_hook('startup', [$this, 'startup']);

--- a/plugins/database_attachments/database_attachments.php
+++ b/plugins/database_attachments/database_attachments.php
@@ -42,6 +42,7 @@ class database_attachments extends filesystem_attachments
     /**
      * Save a newly uploaded attachment
      */
+    #[Override]
     public function upload($args)
     {
         $args['status'] = false;
@@ -69,6 +70,7 @@ class database_attachments extends filesystem_attachments
     /**
      * Save an attachment from a non-upload source (draft or forward)
      */
+    #[Override]
     public function save($args)
     {
         $args['status'] = false;
@@ -101,6 +103,7 @@ class database_attachments extends filesystem_attachments
      * Remove an attachment from storage
      * This is triggered by the remove attachment button on the compose screen
      */
+    #[Override]
     public function remove($args)
     {
         $cache = $this->get_cache();
@@ -116,6 +119,7 @@ class database_attachments extends filesystem_attachments
      * For this plugin, $this->get() will check the file and
      * return it's contents
      */
+    #[Override]
     public function display($args)
     {
         return $this->get($args);
@@ -125,6 +129,7 @@ class database_attachments extends filesystem_attachments
      * When displaying or sending the attachment the file contents are fetched
      * using this method. This is also called by the attachment_display hook.
      */
+    #[Override]
     public function get($args)
     {
         $cache = $this->get_cache();
@@ -143,6 +148,7 @@ class database_attachments extends filesystem_attachments
     /**
      * Delete all temp files associated with this user
      */
+    #[Override]
     public function cleanup($args)
     {
         // check if cache object exist, it may be empty on session_destroy (#1489726)

--- a/plugins/debug_logger/debug_logger.php
+++ b/plugins/debug_logger/debug_logger.php
@@ -63,6 +63,7 @@ class debug_logger extends rcube_plugin
 {
     protected $runlog;
 
+    #[Override]
     public function init()
     {
         require_once __DIR__ . '/runlog/runlog.php';

--- a/plugins/emoticons/emoticons.php
+++ b/plugins/emoticons/emoticons.php
@@ -19,6 +19,7 @@ class emoticons extends rcube_plugin
     /**
      * Plugin initialization.
      */
+    #[Override]
     public function init()
     {
         $rcube = rcmail::get_instance();

--- a/plugins/enigma/enigma.php
+++ b/plugins/enigma/enigma.php
@@ -30,6 +30,7 @@ class enigma extends rcube_plugin
     /**
      * Plugin initialization.
      */
+    #[Override]
     public function init()
     {
         $this->rc = rcmail::get_instance();

--- a/plugins/enigma/lib/enigma_driver_gnupg.php
+++ b/plugins/enigma/lib/enigma_driver_gnupg.php
@@ -31,6 +31,7 @@ class enigma_driver_gnupg extends enigma_driver
      *
      * @param rcube_user $user User object
      */
+    #[Override]
     public function __construct($user)
     {
         $this->rc = rcmail::get_instance();
@@ -43,6 +44,7 @@ class enigma_driver_gnupg extends enigma_driver
      *
      * @return enigma_error|null NULL on success, enigma_error on failure
      */
+    #[Override]
     public function init()
     {
         $homedir = $this->rc->config->get('enigma_pgp_homedir');
@@ -124,6 +126,7 @@ class enigma_driver_gnupg extends enigma_driver
      *
      * @return string|enigma_error Encrypted message or enigma_error on failure
      */
+    #[Override]
     public function encrypt($text, $keys, $sign_key = null)
     {
         try {
@@ -157,6 +160,7 @@ class enigma_driver_gnupg extends enigma_driver
      *
      * @return mixed Decrypted message or enigma_error on failure
      */
+    #[Override]
     public function decrypt($text, $keys = [], &$signature = null)
     {
         try {
@@ -195,6 +199,7 @@ class enigma_driver_gnupg extends enigma_driver
      *
      * @return mixed True on success or enigma_error on failure
      */
+    #[Override]
     public function sign($text, $key, $mode = null)
     {
         try {
@@ -219,6 +224,7 @@ class enigma_driver_gnupg extends enigma_driver
      *
      * @return enigma_signature|enigma_error Signature information or enigma_error
      */
+    #[Override]
     public function verify($text, $signature)
     {
         try {
@@ -238,6 +244,7 @@ class enigma_driver_gnupg extends enigma_driver
      *
      * @return mixed Import status array or enigma_error
      */
+    #[Override]
     public function import($content, $isfile = false, $passwords = [])
     {
         try {
@@ -269,6 +276,7 @@ class enigma_driver_gnupg extends enigma_driver
      *
      * @return string|enigma_error Key content or enigma_error
      */
+    #[Override]
     public function export($keyid, $with_private = false, $passwords = [])
     {
         try {
@@ -297,6 +305,7 @@ class enigma_driver_gnupg extends enigma_driver
      *
      * @return enigma_key[]|enigma_error Array of keys or enigma_error
      */
+    #[Override]
     public function list_keys($pattern = '')
     {
         try {
@@ -320,6 +329,7 @@ class enigma_driver_gnupg extends enigma_driver
      *
      * @return enigma_key|enigma_error Key object or enigma_error
      */
+    #[Override]
     public function get_key($keyid)
     {
         $list = $this->list_keys($keyid);
@@ -339,6 +349,7 @@ class enigma_driver_gnupg extends enigma_driver
      *
      * @return mixed Key (enigma_key) object or enigma_error
      */
+    #[Override]
     public function gen_key($data)
     {
         try {
@@ -367,6 +378,7 @@ class enigma_driver_gnupg extends enigma_driver
      *
      * @return mixed True on success or enigma_error
      */
+    #[Override]
     public function delete_key($keyid)
     {
         // delete public key
@@ -401,6 +413,7 @@ class enigma_driver_gnupg extends enigma_driver
      *
      * @return string Hash algorithm name e.g. sha1
      */
+    #[Override]
     public function signature_algorithm()
     {
         return $this->last_sig_algorithm;
@@ -411,6 +424,7 @@ class enigma_driver_gnupg extends enigma_driver
      *
      * @return array Capabilities list
      */
+    #[Override]
     public function capabilities()
     {
         $caps = [enigma_driver::SUPPORT_RSA];

--- a/plugins/enigma/lib/enigma_driver_phpssl.php
+++ b/plugins/enigma/lib/enigma_driver_phpssl.php
@@ -20,6 +20,7 @@ class enigma_driver_phpssl extends enigma_driver
     private $homedir; // @phpstan-ignore-line
     private $user;
 
+    #[Override]
     public function __construct($user)
     {
         $rcmail = rcmail::get_instance();
@@ -33,6 +34,7 @@ class enigma_driver_phpssl extends enigma_driver
      *
      * @return enigma_error|null NULL on success, enigma_error on failure
      */
+    #[Override]
     public function init()
     {
         $homedir = $this->rc->config->get('enigma_smime_homedir', INSTALL_PATH . '/plugins/enigma/home');
@@ -73,21 +75,25 @@ class enigma_driver_phpssl extends enigma_driver
         return null;
     }
 
+    #[Override]
     public function encrypt($text, $keys, $sign_key = null)
     {
         return new enigma_error(enigma_error::INTERNAL, 'Not implemented');
     }
 
+    #[Override]
     public function decrypt($text, $keys = [], &$signature = null)
     {
         return new enigma_error(enigma_error::INTERNAL, 'Not implemented');
     }
 
+    #[Override]
     public function sign($text, $key, $mode = null)
     {
         return new enigma_error(enigma_error::INTERNAL, 'Not implemented');
     }
 
+    #[Override]
     public function verify($struct, $message)
     {
         /*
@@ -131,31 +137,37 @@ class enigma_driver_phpssl extends enigma_driver
         return new enigma_error(enigma_error::INTERNAL, 'Not implemented');
     }
 
+    #[Override]
     public function import($content, $isfile = false, $passwords = [])
     {
         return new enigma_error(enigma_error::INTERNAL, 'Not implemented');
     }
 
+    #[Override]
     public function export($key, $with_private = false, $passwords = [])
     {
         return new enigma_error(enigma_error::INTERNAL, 'Not implemented');
     }
 
+    #[Override]
     public function list_keys($pattern = '')
     {
         return new enigma_error(enigma_error::INTERNAL, 'Not implemented');
     }
 
+    #[Override]
     public function get_key($keyid)
     {
         return new enigma_error(enigma_error::INTERNAL, 'Not implemented');
     }
 
+    #[Override]
     public function gen_key($data)
     {
         return new enigma_error(enigma_error::INTERNAL, 'Not implemented');
     }
 
+    #[Override]
     public function delete_key($keyid)
     {
         return new enigma_error(enigma_error::INTERNAL, 'Not implemented');
@@ -167,6 +179,7 @@ class enigma_driver_phpssl extends enigma_driver
      *
      * @return string Hash algorithm name e.g. sha1
      */
+    #[Override]
     public function signature_algorithm()
     {
         return ''; // TODO

--- a/plugins/enigma/lib/enigma_mime_message.php
+++ b/plugins/enigma/lib/enigma_mime_message.php
@@ -56,6 +56,7 @@ class enigma_mime_message extends Mail_mime
      *
      * @return bool True if it is multipart, otherwise False
      */
+    #[Override]
     public function isMultipart()
     {
         return $this->message instanceof self
@@ -163,6 +164,7 @@ class enigma_mime_message extends Mail_mime
      *
      * @return mixed The MIME message content string, null or PEAR error object
      */
+    #[Override]
     public function get($params = null, $filename = null, $skip_head = false)
     {
         if (!empty($params)) {
@@ -277,6 +279,7 @@ class enigma_mime_message extends Mail_mime
      *
      * @return array Headers array
      */
+    #[Override]
     protected function contentHeaders()
     {
         $this->checkParams();

--- a/plugins/example_addressbook/example_addressbook.php
+++ b/plugins/example_addressbook/example_addressbook.php
@@ -14,6 +14,7 @@ class example_addressbook extends rcube_plugin
     private $abook_id = 'static';
     private $abook_name = 'Static List';
 
+    #[Override]
     public function init()
     {
         $this->add_hook('addressbooks_list', [$this, 'address_sources']);

--- a/plugins/example_addressbook/example_addressbook_backend.php
+++ b/plugins/example_addressbook/example_addressbook_backend.php
@@ -60,6 +60,7 @@ class example_addressbook_backend extends rcube_addressbook
      *
      * @return ?array Group properties as hash array, null in case of error.
      */
+    #[Override]
     public function get_group($group_id)
     {
         foreach ($this->db_groups as $group) {
@@ -71,27 +72,32 @@ class example_addressbook_backend extends rcube_addressbook
         return null;
     }
 
+    #[Override]
     public function get_name()
     {
         return $this->name;
     }
 
+    #[Override]
     public function set_search_set($filter): void
     {
         $this->filter = $filter;
     }
 
+    #[Override]
     public function get_search_set()
     {
         return $this->filter;
     }
 
+    #[Override]
     public function reset(): void
     {
         $this->result = null;
         $this->filter = null;
     }
 
+    #[Override]
     public function list_groups($search = null, $mode = 0)
     {
         if (is_string($search) && strlen($search)) {
@@ -109,6 +115,7 @@ class example_addressbook_backend extends rcube_addressbook
         return $this->db_groups;
     }
 
+    #[Override]
     public function list_records($cols = null, $subset = 0, $nocount = false)
     {
         // Note: Paging is not implemented
@@ -116,6 +123,7 @@ class example_addressbook_backend extends rcube_addressbook
         return $this->result = $this->count();
     }
 
+    #[Override]
     public function search($fields, $value, $mode = 0, $select = true, $nocount = false, $required = [])
     {
         // Note: we do not implement all possible search request modes and variants.
@@ -143,6 +151,7 @@ class example_addressbook_backend extends rcube_addressbook
         return $result;
     }
 
+    #[Override]
     public function count()
     {
         // Note: Paging is not implemented
@@ -166,11 +175,13 @@ class example_addressbook_backend extends rcube_addressbook
         return $result;
     }
 
+    #[Override]
     public function get_result()
     {
         return $this->result;
     }
 
+    #[Override]
     public function get_record($id, $assoc = false)
     {
         $result = new rcube_result_set(0);
@@ -196,6 +207,7 @@ class example_addressbook_backend extends rcube_addressbook
      *
      * @return array List of assigned groups, indexed by group ID
      */
+    #[Override]
     public function get_record_groups($id)
     {
         $result = [];
@@ -216,11 +228,13 @@ class example_addressbook_backend extends rcube_addressbook
     /**
      * Setter for the current group
      */
+    #[Override]
     public function set_group($gid)
     {
         $this->group_id = $gid;
     }
 
+    #[Override]
     public function create_group($name)
     {
         $result = false;
@@ -228,21 +242,25 @@ class example_addressbook_backend extends rcube_addressbook
         return $result;
     }
 
+    #[Override]
     public function delete_group($gid)
     {
         return false;
     }
 
+    #[Override]
     public function rename_group($gid, $newname, &$newid)
     {
         return $newname;
     }
 
+    #[Override]
     public function add_to_group($group_id, $ids)
     {
         return 0;
     }
 
+    #[Override]
     public function remove_from_group($group_id, $ids)
     {
         return 0;

--- a/plugins/filesystem_attachments/filesystem_attachments.php
+++ b/plugins/filesystem_attachments/filesystem_attachments.php
@@ -29,6 +29,7 @@ class filesystem_attachments extends rcube_plugin
     public $task = '?(?!login).*';
     public $initialized = false;
 
+    #[Override]
     public function init()
     {
         // Find filesystem_attachments-based plugins, we can use only one

--- a/plugins/help/help.php
+++ b/plugins/help/help.php
@@ -18,6 +18,7 @@ class help extends rcube_plugin
     // we've got no ajax handlers
     public $noajax = true;
 
+    #[Override]
     public function init()
     {
         $this->load_config();

--- a/plugins/hide_blockquote/hide_blockquote.php
+++ b/plugins/hide_blockquote/hide_blockquote.php
@@ -20,6 +20,7 @@ class hide_blockquote extends rcube_plugin
     /**
      * Plugin initialization
      */
+    #[Override]
     public function init()
     {
         $rcmail = rcmail::get_instance();

--- a/plugins/http_authentication/http_authentication.php
+++ b/plugins/http_authentication/http_authentication.php
@@ -20,6 +20,7 @@ class http_authentication extends rcube_plugin
 {
     private $redirect_query;
 
+    #[Override]
     public function init()
     {
         $this->add_hook('startup', [$this, 'startup']);

--- a/plugins/identicon/identicon.php
+++ b/plugins/identicon/identicon.php
@@ -24,6 +24,7 @@ class identicon extends rcube_plugin
     /**
      * Plugin initialization.
      */
+    #[Override]
     public function init()
     {
         $this->add_hook('contact_photo', [$this, 'contact_photo']);

--- a/plugins/identity_select/identity_select.php
+++ b/plugins/identity_select/identity_select.php
@@ -23,6 +23,7 @@ class identity_select extends rcube_plugin
 {
     public $task = 'mail';
 
+    #[Override]
     public function init()
     {
         $this->add_hook('identity_select', [$this, 'select']);

--- a/plugins/jqueryui/jqueryui.php
+++ b/plugins/jqueryui/jqueryui.php
@@ -28,6 +28,7 @@ class jqueryui extends rcube_plugin
     /**
      * Plugin initialization
      */
+    #[Override]
     public function init()
     {
         $rcmail = rcmail::get_instance();

--- a/plugins/krb_authentication/krb_authentication.php
+++ b/plugins/krb_authentication/krb_authentication.php
@@ -18,6 +18,7 @@ class krb_authentication extends rcube_plugin
     /**
      * Plugin initialization
      */
+    #[Override]
     public function init()
     {
         $this->add_hook('startup', [$this, 'startup']);

--- a/plugins/managesieve/lib/Roundcube/rcube_sieve_forward.php
+++ b/plugins/managesieve/lib/Roundcube/rcube_sieve_forward.php
@@ -27,6 +27,7 @@ class rcube_sieve_forward extends rcube_sieve_engine
     protected $script_name;
     protected $forward = [];
 
+    #[Override]
     public function actions()
     {
         $error = $this->start('forward');
@@ -53,6 +54,7 @@ class rcube_sieve_forward extends rcube_sieve_engine
      *
      * @return int Connection status: 0 on success, >0 on failure
      */
+    #[Override]
     protected function load_script($script_name = null)
     {
         if ($this->script_name !== null) {
@@ -388,6 +390,7 @@ class rcube_sieve_forward extends rcube_sieve_engine
     /**
      * API: connect to managesieve server
      */
+    #[Override]
     public function connect($username, $password)
     {
         $error = parent::connect($username, $password);

--- a/plugins/managesieve/lib/Roundcube/rcube_sieve_vacation.php
+++ b/plugins/managesieve/lib/Roundcube/rcube_sieve_vacation.php
@@ -27,6 +27,7 @@ class rcube_sieve_vacation extends rcube_sieve_engine
     protected $script_name;
     protected $vacation = [];
 
+    #[Override]
     public function actions()
     {
         $error = $this->start('vacation');
@@ -53,6 +54,7 @@ class rcube_sieve_vacation extends rcube_sieve_engine
      *
      * @return int Connection status: 0 on success, >0 on failure
      */
+    #[Override]
     protected function load_script($script_name = null)
     {
         if ($this->script_name !== null) {
@@ -864,6 +866,7 @@ class rcube_sieve_vacation extends rcube_sieve_engine
     /**
      * API: connect to managesieve server
      */
+    #[Override]
     public function connect($username, $password)
     {
         $error = parent::connect($username, $password);

--- a/plugins/managesieve/managesieve.php
+++ b/plugins/managesieve/managesieve.php
@@ -40,6 +40,7 @@ class managesieve extends rcube_plugin
     /**
      * Plugin initialization
      */
+    #[Override]
     public function init()
     {
         $this->rc = rcube::get_instance();

--- a/plugins/markasjunk/markasjunk.php
+++ b/plugins/markasjunk/markasjunk.php
@@ -47,6 +47,7 @@ class markasjunk extends rcube_plugin
     /**
      * Plugin initialization
      */
+    #[Override]
     public function init()
     {
         $this->register_action('plugin.markasjunk.junk', [$this, 'mark_message']);

--- a/plugins/markasjunk/tests/Browser/MailTest.php
+++ b/plugins/markasjunk/tests/Browser/MailTest.php
@@ -6,6 +6,7 @@ use Tests\Browser\TestCase;
 
 class MailTest extends TestCase
 {
+    #[\Override]
     public static function setUpBeforeClass(): void
     {
         \bootstrap::init_db();

--- a/plugins/new_user_dialog/new_user_dialog.php
+++ b/plugins/new_user_dialog/new_user_dialog.php
@@ -16,6 +16,7 @@ class new_user_dialog extends rcube_plugin
     public $task = '';
     public $noframe = true;
 
+    #[Override]
     public function init()
     {
         $this->add_hook('identity_create', [$this, 'create_identity']);

--- a/plugins/new_user_identity/new_user_identity.php
+++ b/plugins/new_user_identity/new_user_identity.php
@@ -20,6 +20,7 @@ class new_user_identity extends rcube_plugin
     /**
      * Plugin initialization. API hooks binding.
      */
+    #[Override]
     public function init()
     {
         $this->rc = rcmail::get_instance();

--- a/plugins/newmail_notifier/newmail_notifier.php
+++ b/plugins/newmail_notifier/newmail_notifier.php
@@ -38,6 +38,7 @@ class newmail_notifier extends rcube_plugin
     /**
      * Plugin initialization
      */
+    #[Override]
     public function init()
     {
         $this->rc = rcmail::get_instance();

--- a/plugins/password/drivers/ldap_exop.php
+++ b/plugins/password/drivers/ldap_exop.php
@@ -31,6 +31,7 @@ require_once __DIR__ . '/ldap_simple.php';
 
 class rcube_ldap_exop_password extends rcube_ldap_simple_password
 {
+    #[Override]
     public function save($curpass, $passwd)
     {
         if (!function_exists('ldap_exop_passwd')) {

--- a/plugins/password/drivers/ldap_samba_ad.php
+++ b/plugins/password/drivers/ldap_samba_ad.php
@@ -32,6 +32,7 @@ require_once __DIR__ . '/ldap_simple.php';
 
 class rcube_ldap_samba_ad_password extends rcube_ldap_simple_password
 {
+    #[Override]
     public function save($curpass, $passwd)
     {
         if (!function_exists('ldap_mod_replace')) {

--- a/plugins/password/password.php
+++ b/plugins/password/password.php
@@ -53,6 +53,7 @@ class password extends rcube_plugin
     private $drivers = [];
     private $rc;
 
+    #[Override]
     public function init()
     {
         $this->rc = rcmail::get_instance();

--- a/plugins/reconnect/reconnect.php
+++ b/plugins/reconnect/reconnect.php
@@ -15,6 +15,7 @@ class reconnect extends rcube_plugin
     /**
      * Plugin initialization
      */
+    #[Override]
     public function init()
     {
         $this->add_hook('storage_connect', [$this, 'storage_connect']);

--- a/plugins/redundant_attachments/redundant_attachments.php
+++ b/plugins/redundant_attachments/redundant_attachments.php
@@ -98,6 +98,7 @@ class redundant_attachments extends filesystem_attachments
     /**
      * Save a newly uploaded attachment
      */
+    #[Override]
     public function upload($args)
     {
         $args = parent::upload($args);
@@ -124,6 +125,7 @@ class redundant_attachments extends filesystem_attachments
     /**
      * Save an attachment from a non-upload source (draft or forward)
      */
+    #[Override]
     public function save($args)
     {
         $args = parent::save($args);
@@ -155,6 +157,7 @@ class redundant_attachments extends filesystem_attachments
      * Remove an attachment from storage
      * This is triggered by the remove attachment button on the compose screen
      */
+    #[Override]
     public function remove($args)
     {
         parent::remove($args);
@@ -179,6 +182,7 @@ class redundant_attachments extends filesystem_attachments
      * For this plugin, $this->get() will check the file and
      * return it's contents
      */
+    #[Override]
     public function display($args)
     {
         return $this->get($args);
@@ -188,6 +192,7 @@ class redundant_attachments extends filesystem_attachments
      * When displaying or sending the attachment the file contents are fetched
      * using this method. This is also called by the attachment_display hook.
      */
+    #[Override]
     public function get($args)
     {
         // attempt to get file from local file system
@@ -218,6 +223,7 @@ class redundant_attachments extends filesystem_attachments
     /**
      * Delete all temp files associated with this user
      */
+    #[Override]
     public function cleanup($args)
     {
         $this->_load_drivers();

--- a/plugins/show_additional_headers/show_additional_headers.php
+++ b/plugins/show_additional_headers/show_additional_headers.php
@@ -19,6 +19,7 @@ class show_additional_headers extends rcube_plugin
     /**
      * Plugin initialization
      */
+    #[Override]
     public function init()
     {
         $rcmail = rcmail::get_instance();

--- a/plugins/squirrelmail_usercopy/squirrelmail_usercopy.php
+++ b/plugins/squirrelmail_usercopy/squirrelmail_usercopy.php
@@ -15,6 +15,7 @@ class squirrelmail_usercopy extends rcube_plugin
     private $identities_level = 0;
     private $abook = [];
 
+    #[Override]
     public function init()
     {
         $this->add_hook('user_create', [$this, 'create_user']);

--- a/plugins/subscriptions_option/subscriptions_option.php
+++ b/plugins/subscriptions_option/subscriptions_option.php
@@ -29,6 +29,7 @@ class subscriptions_option extends rcube_plugin
     /**
      * Plugin initialization
      */
+    #[Override]
     public function init()
     {
         $dont_override = rcmail::get_instance()->config->get('dont_override', []);

--- a/plugins/userinfo/userinfo.php
+++ b/plugins/userinfo/userinfo.php
@@ -10,6 +10,7 @@ class userinfo extends rcube_plugin
     public $noajax = true;
     public $noframe = true;
 
+    #[Override]
     public function init()
     {
         $this->add_texts('localization/', ['userinfo']);

--- a/plugins/vcard_attachments/vcard_attachments.php
+++ b/plugins/vcard_attachments/vcard_attachments.php
@@ -19,6 +19,7 @@ class vcard_attachments extends rcube_plugin
     /**
      * Plugin initialization
      */
+    #[Override]
     public function init()
     {
         $rcmail = rcmail::get_instance();

--- a/plugins/virtuser_file/virtuser_file.php
+++ b/plugins/virtuser_file/virtuser_file.php
@@ -19,6 +19,7 @@ class virtuser_file extends rcube_plugin
     /**
      * Plugin initialization
      */
+    #[Override]
     public function init()
     {
         $this->app = rcmail::get_instance();

--- a/plugins/virtuser_query/virtuser_query.php
+++ b/plugins/virtuser_query/virtuser_query.php
@@ -31,6 +31,7 @@ class virtuser_query extends rcube_plugin
     private $app;
     private $db;
 
+    #[Override]
     public function init()
     {
         $this->app = rcmail::get_instance();

--- a/plugins/zipdownload/tests/Browser/MailTest.php
+++ b/plugins/zipdownload/tests/Browser/MailTest.php
@@ -7,6 +7,7 @@ use Tests\Browser\TestCase;
 
 class MailTest extends TestCase
 {
+    #[\Override]
     public static function setUpBeforeClass(): void
     {
         \bootstrap::init_imap();

--- a/plugins/zipdownload/zipdownload.php
+++ b/plugins/zipdownload/zipdownload.php
@@ -26,6 +26,7 @@ class zipdownload extends rcube_plugin
     /**
      * Plugin initialization
      */
+    #[Override]
     public function init()
     {
         // check requirements first
@@ -388,6 +389,7 @@ class zipdownload extends rcube_plugin
 
 class zipdownload_mbox_filter extends php_user_filter
 {
+    #[Override]
     #[ReturnTypeWillChange]
     public function filter($in, $out, &$consumed, $closing)
     {

--- a/program/actions/contacts/copy.php
+++ b/program/actions/contacts/copy.php
@@ -27,6 +27,7 @@ class rcmail_action_contacts_copy extends rcmail_action_contacts_index
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/contacts/delete.php
+++ b/program/actions/contacts/delete.php
@@ -27,6 +27,7 @@ class rcmail_action_contacts_delete extends rcmail_action_contacts_index
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/contacts/edit.php
+++ b/program/actions/contacts/edit.php
@@ -24,6 +24,7 @@ class rcmail_action_contacts_edit extends rcmail_action_contacts_index
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();
@@ -209,6 +210,7 @@ class rcmail_action_contacts_edit extends rcmail_action_contacts_index
      *
      * @todo: Use rcmail_action::get_form_tags()
      */
+    #[Override]
     public static function get_form_tags($attrib, $action = null, $id = null, $hidden = null)
     {
         static $edit_form;

--- a/program/actions/contacts/export.php
+++ b/program/actions/contacts/export.php
@@ -26,6 +26,7 @@ class rcmail_action_contacts_export extends rcmail_action_contacts_index
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/contacts/group_addmembers.php
+++ b/program/actions/contacts/group_addmembers.php
@@ -27,6 +27,7 @@ class rcmail_action_contacts_group_addmembers extends rcmail_action_contacts_ind
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/contacts/group_create.php
+++ b/program/actions/contacts/group_create.php
@@ -27,6 +27,7 @@ class rcmail_action_contacts_group_create extends rcmail_action_contacts_index
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/contacts/group_delete.php
+++ b/program/actions/contacts/group_delete.php
@@ -27,6 +27,7 @@ class rcmail_action_contacts_group_delete extends rcmail_action_contacts_index
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/contacts/group_delmembers.php
+++ b/program/actions/contacts/group_delmembers.php
@@ -27,6 +27,7 @@ class rcmail_action_contacts_group_delmembers extends rcmail_action_contacts_ind
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/contacts/group_rename.php
+++ b/program/actions/contacts/group_rename.php
@@ -27,6 +27,7 @@ class rcmail_action_contacts_group_rename extends rcmail_action_contacts_index
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/contacts/import.php
+++ b/program/actions/contacts/import.php
@@ -29,6 +29,7 @@ class rcmail_action_contacts_import extends rcmail_action_contacts_index
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/contacts/index.php
+++ b/program/actions/contacts/index.php
@@ -247,6 +247,7 @@ class rcmail_action_contacts_index extends rcmail_action
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/contacts/list.php
+++ b/program/actions/contacts/list.php
@@ -27,6 +27,7 @@ class rcmail_action_contacts_list extends rcmail_action_contacts_index
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/contacts/mailto.php
+++ b/program/actions/contacts/mailto.php
@@ -27,6 +27,7 @@ class rcmail_action_contacts_mailto extends rcmail_action_contacts_index
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/contacts/move.php
+++ b/program/actions/contacts/move.php
@@ -28,6 +28,7 @@ class rcmail_action_contacts_move extends rcmail_action_contacts_index
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $cids = self::get_cids();

--- a/program/actions/contacts/photo.php
+++ b/program/actions/contacts/photo.php
@@ -27,6 +27,7 @@ class rcmail_action_contacts_photo extends rcmail_action_contacts_index
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/contacts/print.php
+++ b/program/actions/contacts/print.php
@@ -28,6 +28,7 @@ class rcmail_action_contacts_print extends rcmail_action_contacts_index
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/contacts/qrcode.php
+++ b/program/actions/contacts/qrcode.php
@@ -32,6 +32,7 @@ class rcmail_action_contacts_qrcode extends rcmail_action_contacts_index
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         // Get contact ID and source ID from request

--- a/program/actions/contacts/save.php
+++ b/program/actions/contacts/save.php
@@ -26,6 +26,7 @@ class rcmail_action_contacts_save extends rcmail_action_contacts_index
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/contacts/search.php
+++ b/program/actions/contacts/search.php
@@ -26,6 +26,7 @@ class rcmail_action_contacts_search extends rcmail_action_contacts_index
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/contacts/search_create.php
+++ b/program/actions/contacts/search_create.php
@@ -29,6 +29,7 @@ class rcmail_action_contacts_search_create extends rcmail_action
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/contacts/search_delete.php
+++ b/program/actions/contacts/search_delete.php
@@ -29,6 +29,7 @@ class rcmail_action_contacts_search_delete extends rcmail_action
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/contacts/show.php
+++ b/program/actions/contacts/show.php
@@ -26,6 +26,7 @@ class rcmail_action_contacts_show extends rcmail_action_contacts_index
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/contacts/undo.php
+++ b/program/actions/contacts/undo.php
@@ -26,6 +26,7 @@ class rcmail_action_contacts_undo extends rcmail_action_contacts_index
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/contacts/upload_photo.php
+++ b/program/actions/contacts/upload_photo.php
@@ -32,6 +32,7 @@ class rcmail_action_contacts_upload_photo extends rcmail_action_contacts_index
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/login/oauth.php
+++ b/program/actions/login/oauth.php
@@ -24,6 +24,7 @@ class rcmail_action_login_oauth extends rcmail_action
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/login/oauth_backchannel.php
+++ b/program/actions/login/oauth_backchannel.php
@@ -28,6 +28,7 @@ class rcmail_action_login_oauth_backchannel extends rcmail_action
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/mail/addcontact.php
+++ b/program/actions/mail/addcontact.php
@@ -27,6 +27,7 @@ class rcmail_action_mail_addcontact extends rcmail_action
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/mail/attachment_delete.php
+++ b/program/actions/mail/attachment_delete.php
@@ -27,6 +27,7 @@ class rcmail_action_mail_attachment_delete extends rcmail_action_mail_attachment
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         self::init();

--- a/program/actions/mail/attachment_display.php
+++ b/program/actions/mail/attachment_display.php
@@ -26,6 +26,7 @@ class rcmail_action_mail_attachment_display extends rcmail_action_mail_attachmen
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         self::init();

--- a/program/actions/mail/attachment_rename.php
+++ b/program/actions/mail/attachment_rename.php
@@ -27,6 +27,7 @@ class rcmail_action_mail_attachment_rename extends rcmail_action_mail_attachment
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/mail/attachment_upload.php
+++ b/program/actions/mail/attachment_upload.php
@@ -32,6 +32,7 @@ class rcmail_action_mail_attachment_upload extends rcmail_action_mail_index
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/mail/autocomplete.php
+++ b/program/actions/mail/autocomplete.php
@@ -28,6 +28,7 @@ class rcmail_action_mail_autocomplete extends rcmail_action
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/mail/bounce.php
+++ b/program/actions/mail/bounce.php
@@ -27,6 +27,7 @@ class rcmail_action_mail_bounce extends rcmail_action
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/mail/check_recent.php
+++ b/program/actions/mail/check_recent.php
@@ -27,6 +27,7 @@ class rcmail_action_mail_check_recent extends rcmail_action_mail_index
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/mail/compose.php
+++ b/program/actions/mail/compose.php
@@ -34,6 +34,7 @@ class rcmail_action_mail_compose extends rcmail_action_mail_index
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/mail/copy.php
+++ b/program/actions/mail/copy.php
@@ -27,6 +27,7 @@ class rcmail_action_mail_copy extends rcmail_action_mail_index
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/mail/delete.php
+++ b/program/actions/mail/delete.php
@@ -26,6 +26,7 @@ class rcmail_action_mail_delete extends rcmail_action_mail_index
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/mail/folder_expunge.php
+++ b/program/actions/mail/folder_expunge.php
@@ -27,6 +27,7 @@ class rcmail_action_mail_folder_expunge extends rcmail_action
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/mail/folder_purge.php
+++ b/program/actions/mail/folder_purge.php
@@ -27,6 +27,7 @@ class rcmail_action_mail_folder_purge extends rcmail_action_mail_index
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/mail/get.php
+++ b/program/actions/mail/get.php
@@ -27,6 +27,7 @@ class rcmail_action_mail_get extends rcmail_action_mail_index
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/mail/getunread.php
+++ b/program/actions/mail/getunread.php
@@ -27,6 +27,7 @@ class rcmail_action_mail_getunread extends rcmail_action_mail_index
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/mail/group_expand.php
+++ b/program/actions/mail/group_expand.php
@@ -27,6 +27,7 @@ class rcmail_action_mail_group_expand extends rcmail_action
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/mail/headers.php
+++ b/program/actions/mail/headers.php
@@ -26,6 +26,7 @@ class rcmail_action_mail_headers extends rcmail_action_mail_index
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/mail/import.php
+++ b/program/actions/mail/import.php
@@ -28,6 +28,7 @@ class rcmail_action_mail_import extends rcmail_action
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/mail/index.php
+++ b/program/actions/mail/index.php
@@ -41,6 +41,7 @@ class rcmail_action_mail_index extends rcmail_action
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/mail/list.php
+++ b/program/actions/mail/list.php
@@ -26,6 +26,7 @@ class rcmail_action_mail_list extends rcmail_action_mail_index
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/mail/list_contacts.php
+++ b/program/actions/mail/list_contacts.php
@@ -26,6 +26,7 @@ class rcmail_action_mail_list_contacts extends rcmail_action_mail_index
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/mail/mark.php
+++ b/program/actions/mail/mark.php
@@ -26,6 +26,7 @@ class rcmail_action_mail_mark extends rcmail_action_mail_index
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/mail/move.php
+++ b/program/actions/mail/move.php
@@ -26,6 +26,7 @@ class rcmail_action_mail_move extends rcmail_action_mail_index
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/mail/pagenav.php
+++ b/program/actions/mail/pagenav.php
@@ -26,6 +26,7 @@ class rcmail_action_mail_pagenav extends rcmail_action_mail_index
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/mail/search.php
+++ b/program/actions/mail/search.php
@@ -27,6 +27,7 @@ class rcmail_action_mail_search extends rcmail_action_mail_index
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/mail/search_contacts.php
+++ b/program/actions/mail/search_contacts.php
@@ -26,6 +26,7 @@ class rcmail_action_mail_search_contacts extends rcmail_action_mail_list_contact
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/mail/send.php
+++ b/program/actions/mail/send.php
@@ -25,6 +25,7 @@ class rcmail_action_mail_send extends rcmail_action
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/mail/sendmdn.php
+++ b/program/actions/mail/sendmdn.php
@@ -26,6 +26,7 @@ class rcmail_action_mail_sendmdn extends rcmail_action
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/mail/show.php
+++ b/program/actions/mail/show.php
@@ -29,6 +29,7 @@ class rcmail_action_mail_show extends rcmail_action_mail_index
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/mail/viewsource.php
+++ b/program/actions/mail/viewsource.php
@@ -24,6 +24,7 @@ class rcmail_action_mail_viewsource extends rcmail_action
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/settings/about.php
+++ b/program/actions/settings/about.php
@@ -27,6 +27,7 @@ class rcmail_action_settings_about extends rcmail_action
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/settings/folder_delete.php
+++ b/program/actions/settings/folder_delete.php
@@ -27,6 +27,7 @@ class rcmail_action_settings_folder_delete extends rcmail_action
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/settings/folder_edit.php
+++ b/program/actions/settings/folder_edit.php
@@ -26,6 +26,7 @@ class rcmail_action_settings_folder_edit extends rcmail_action_settings_folders
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/settings/folder_purge.php
+++ b/program/actions/settings/folder_purge.php
@@ -27,6 +27,7 @@ class rcmail_action_settings_folder_purge extends rcmail_action
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/settings/folder_rename.php
+++ b/program/actions/settings/folder_rename.php
@@ -27,6 +27,7 @@ class rcmail_action_settings_folder_rename extends rcmail_action_settings_folder
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/settings/folder_save.php
+++ b/program/actions/settings/folder_save.php
@@ -26,6 +26,7 @@ class rcmail_action_settings_folder_save extends rcmail_action_settings_folder_e
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         // WARNING: folder names in UI are encoded with RCUBE_CHARSET

--- a/program/actions/settings/folder_size.php
+++ b/program/actions/settings/folder_size.php
@@ -27,6 +27,7 @@ class rcmail_action_settings_folder_size extends rcmail_action
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/settings/folder_subscribe.php
+++ b/program/actions/settings/folder_subscribe.php
@@ -27,6 +27,7 @@ class rcmail_action_settings_folder_subscribe extends rcmail_action
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/settings/folder_unsubscribe.php
+++ b/program/actions/settings/folder_unsubscribe.php
@@ -27,6 +27,7 @@ class rcmail_action_settings_folder_unsubscribe extends rcmail_action
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/settings/folders.php
+++ b/program/actions/settings/folders.php
@@ -27,6 +27,7 @@ class rcmail_action_settings_folders extends rcmail_action_settings_index
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/settings/identities.php
+++ b/program/actions/settings/identities.php
@@ -26,6 +26,7 @@ class rcmail_action_settings_identities extends rcmail_action
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/settings/identity_delete.php
+++ b/program/actions/settings/identity_delete.php
@@ -26,6 +26,7 @@ class rcmail_action_settings_identity_delete extends rcmail_action
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/settings/identity_edit.php
+++ b/program/actions/settings/identity_edit.php
@@ -27,6 +27,7 @@ class rcmail_action_settings_identity_edit extends rcmail_action
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/settings/identity_save.php
+++ b/program/actions/settings/identity_save.php
@@ -26,6 +26,7 @@ class rcmail_action_settings_identity_save extends rcmail_action_settings_index
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/settings/index.php
+++ b/program/actions/settings/index.php
@@ -50,6 +50,7 @@ class rcmail_action_settings_index extends rcmail_action
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/settings/prefs_edit.php
+++ b/program/actions/settings/prefs_edit.php
@@ -28,6 +28,7 @@ class rcmail_action_settings_prefs_edit extends rcmail_action_settings_index
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/settings/prefs_save.php
+++ b/program/actions/settings/prefs_save.php
@@ -27,6 +27,7 @@ class rcmail_action_settings_prefs_save extends rcmail_action
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/settings/response_delete.php
+++ b/program/actions/settings/response_delete.php
@@ -26,6 +26,7 @@ class rcmail_action_settings_response_delete extends rcmail_action
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/settings/response_edit.php
+++ b/program/actions/settings/response_edit.php
@@ -27,6 +27,7 @@ class rcmail_action_settings_response_edit extends rcmail_action_settings_respon
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/settings/response_get.php
+++ b/program/actions/settings/response_get.php
@@ -26,6 +26,7 @@ class rcmail_action_settings_response_get extends rcmail_action
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/settings/response_save.php
+++ b/program/actions/settings/response_save.php
@@ -26,6 +26,7 @@ class rcmail_action_settings_response_save extends rcmail_action_settings_index
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/settings/responses.php
+++ b/program/actions/settings/responses.php
@@ -26,6 +26,7 @@ class rcmail_action_settings_responses extends rcmail_action_settings_index
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/settings/upload.php
+++ b/program/actions/settings/upload.php
@@ -26,6 +26,7 @@ class rcmail_action_settings_upload extends rcmail_action
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/settings/upload_display.php
+++ b/program/actions/settings/upload_display.php
@@ -26,6 +26,7 @@ class rcmail_action_settings_upload_display extends rcmail_action
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         if (!empty($_GET['_file']) && preg_match('/^rcmfile(\w+)$/', $_GET['_file'], $regs)) {

--- a/program/actions/utils/error.php
+++ b/program/actions/utils/error.php
@@ -24,6 +24,7 @@ class rcmail_action_utils_error extends rcmail_action
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/utils/html2text.php
+++ b/program/actions/utils/html2text.php
@@ -26,6 +26,7 @@ class rcmail_action_utils_html2text extends rcmail_action
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $html = file_get_contents(self::$source);

--- a/program/actions/utils/killcache.php
+++ b/program/actions/utils/killcache.php
@@ -24,6 +24,7 @@ class rcmail_action_utils_killcache extends rcmail_action
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/utils/modcss.php
+++ b/program/actions/utils/modcss.php
@@ -25,6 +25,7 @@ class rcmail_action_utils_modcss extends rcmail_action
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/utils/save_pref.php
+++ b/program/actions/utils/save_pref.php
@@ -27,6 +27,7 @@ class rcmail_action_utils_save_pref extends rcmail_action
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/utils/spell.php
+++ b/program/actions/utils/spell.php
@@ -27,6 +27,7 @@ class rcmail_action_utils_spell extends rcmail_action
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         // read input

--- a/program/actions/utils/spell_html.php
+++ b/program/actions/utils/spell_html.php
@@ -27,6 +27,7 @@ class rcmail_action_utils_spell_html extends rcmail_action
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/utils/text2html.php
+++ b/program/actions/utils/text2html.php
@@ -26,6 +26,7 @@ class rcmail_action_utils_text2html extends rcmail_action
      *
      * @param array $args Arguments from the previous step(s)
      */
+    #[Override]
     public function run($args = [])
     {
         $text = file_get_contents(self::$source);

--- a/program/include/rcmail.php
+++ b/program/include/rcmail.php
@@ -75,6 +75,7 @@ class rcmail extends rcube
      *
      * @return rcmail The one and only instance
      */
+    #[Override]
     public static function get_instance($mode = 0, $env = '')
     {
         if (!self::$instance || !is_a(self::$instance, 'rcmail')) {
@@ -191,6 +192,7 @@ class rcmail extends rcube
      *
      * @param rcube_user $user Current user instance
      */
+    #[Override]
     public function set_user($user)
     {
         parent::set_user($user);
@@ -633,6 +635,7 @@ class rcmail extends rcube
     /**
      * Create session object and start the session.
      */
+    #[Override]
     public function session_init()
     {
         parent::session_init();
@@ -1066,6 +1069,7 @@ class rcmail extends rcube
      *
      * @return string Valid application URL
      */
+    #[Override]
     public function url($p, $absolute = false, $full = false, $secure = false)
     {
         if (!is_array($p)) {
@@ -1166,6 +1170,7 @@ class rcmail extends rcube
     /**
      * Function to be executed in script shutdown
      */
+    #[Override]
     public function shutdown()
     {
         parent::shutdown();

--- a/program/include/rcmail_html_page.php
+++ b/program/include/rcmail_html_page.php
@@ -29,6 +29,7 @@ class rcmail_html_page extends rcmail_output_html
      *
      * @param string $contents HTML page content
      */
+    #[Override]
     public function write($contents = '')
     {
         self::reset(true);

--- a/program/include/rcmail_output.php
+++ b/program/include/rcmail_output.php
@@ -65,6 +65,7 @@ abstract class rcmail_output extends rcube_output
     /**
      * Delete all stored env variables and commands
      */
+    #[Override]
     public function reset()
     {
         parent::reset();

--- a/program/include/rcmail_output_cli.php
+++ b/program/include/rcmail_output_cli.php
@@ -29,6 +29,7 @@ class rcmail_output_cli extends rcmail_output
      *
      * @see rcube_output::command()
      */
+    #[Override]
     public function command($cmd, ...$args)
     {
         // NOP
@@ -39,6 +40,7 @@ class rcmail_output_cli extends rcmail_output
      *
      * @see rcube_output::add_label()
      */
+    #[Override]
     public function add_label(...$args)
     {
         // NOP
@@ -49,6 +51,7 @@ class rcmail_output_cli extends rcmail_output
      *
      * @see rcube_output::show_message()
      */
+    #[Override]
     public function show_message($message, $type = 'notice', $vars = null, $override = true, $timeout = 0)
     {
         if ($this->app->text_exists($message)) {
@@ -63,6 +66,7 @@ class rcmail_output_cli extends rcmail_output
      *
      * @see rcube_output::redirect()
      */
+    #[Override]
     public function redirect($p = [], $delay = 1)
     {
         // NOP
@@ -71,6 +75,7 @@ class rcmail_output_cli extends rcmail_output
     /**
      * Send output to the client.
      */
+    #[Override]
     public function send()
     {
         // NOP

--- a/program/include/rcmail_output_html.php
+++ b/program/include/rcmail_output_html.php
@@ -174,6 +174,7 @@ class rcmail_output_html extends rcmail_output
      * @param bool   $addtojs True if this property should be added
      *                        to client environment
      */
+    #[Override]
     public function set_env($name, $value, $addtojs = true)
     {
         $this->env[$name] = $value;
@@ -276,6 +277,7 @@ class rcmail_output_html extends rcmail_output
     /**
      * Getter for the current skin path property
      */
+    #[Override]
     public function get_skin_path()
     {
         return $this->skin_paths[0];
@@ -496,6 +498,7 @@ class rcmail_output_html extends rcmail_output
      * @param string $cmd     Method to call
      * @param mixed  ...$args Method arguments
      */
+    #[Override]
     public function command($cmd, ...$args)
     {
         if (strpos($cmd, 'plugin.') !== false) {
@@ -512,6 +515,7 @@ class rcmail_output_html extends rcmail_output
      *
      * @param mixed ...$args Labels (an array of strings, or many string arguments)
      */
+    #[Override]
     public function add_label(...$args)
     {
         if (count($args) == 1 && is_array($args[0])) {
@@ -534,6 +538,7 @@ class rcmail_output_html extends rcmail_output
      *
      * @uses self::command()
      */
+    #[Override]
     public function show_message($message, $type = 'notice', $vars = null, $override = true, $timeout = 0)
     {
         if ($override || !$this->message) {
@@ -557,6 +562,7 @@ class rcmail_output_html extends rcmail_output
      *
      * @param bool $all Reset all env variables (including internal)
      */
+    #[Override]
     public function reset($all = false)
     {
         $framed = $this->framed;
@@ -613,6 +619,7 @@ class rcmail_output_html extends rcmail_output
      * @param int   $delay  Delay in seconds
      * @param bool  $secure Redirect to secure location (see rcmail::url())
      */
+    #[Override]
     public function redirect($p = [], $delay = 1, $secure = false)
     {
         if (!empty($this->env['extwin']) && !(is_string($p) && preg_match('#^https?://#', $p))) {
@@ -635,6 +642,7 @@ class rcmail_output_html extends rcmail_output
      * @param string $templ Template name
      * @param bool   $exit  True if script should terminate (default)
      */
+    #[Override]
     public function send($templ = null, $exit = true)
     {
         if ($templ != 'iframe') {
@@ -933,6 +941,7 @@ class rcmail_output_html extends rcmail_output
      * @param int    $code    Error code
      * @param string $message Error message
      */
+    #[Override]
     public function raise_error($code, $message)
     {
         $args = [

--- a/program/include/rcmail_output_json.php
+++ b/program/include/rcmail_output_json.php
@@ -54,6 +54,7 @@ class rcmail_output_json extends rcmail_output
      *
      * @param string $title New page title
      */
+    #[Override]
     public function set_pagetitle($title)
     {
         if ($this->config->get('devel_mode') && !empty($_SESSION['username'])) {
@@ -71,6 +72,7 @@ class rcmail_output_json extends rcmail_output
      * @param string   $obj  Object name
      * @param callable $func Function name to call
      */
+    #[Override]
     public function add_handler($obj, $func)
     {
         // ignore
@@ -81,6 +83,7 @@ class rcmail_output_json extends rcmail_output
      *
      * @param array $arr Hash array with object=>handler pairs
      */
+    #[Override]
     public function add_handlers($arr)
     {
         // ignore
@@ -92,6 +95,7 @@ class rcmail_output_json extends rcmail_output
      * @param string $cmd     Method to call
      * @param mixed  ...$args Additional arguments
      */
+    #[Override]
     public function command($cmd, ...$args)
     {
         array_unshift($args, $cmd);
@@ -108,6 +112,7 @@ class rcmail_output_json extends rcmail_output
      *
      * @param mixed ...$args Labels (an array of strings, or many string arguments)
      */
+    #[Override]
     public function add_label(...$args)
     {
         if (count($args) == 1 && is_array($args[0])) {
@@ -130,6 +135,7 @@ class rcmail_output_json extends rcmail_output
      *
      * @uses self::command()
      */
+    #[Override]
     public function show_message($message, $type = 'notice', $vars = null, $override = true, $timeout = 0)
     {
         if ($override || !$this->message) {
@@ -150,6 +156,7 @@ class rcmail_output_json extends rcmail_output
     /**
      * Delete all stored env variables and commands
      */
+    #[Override]
     public function reset()
     {
         parent::reset();
@@ -165,6 +172,7 @@ class rcmail_output_json extends rcmail_output
      *
      * @see rcmail::url()
      */
+    #[Override]
     public function redirect($p = [], $delay = 1)
     {
         $location = $this->app->url($p);
@@ -176,6 +184,7 @@ class rcmail_output_json extends rcmail_output
     /**
      * Send an AJAX response to the client.
      */
+    #[Override]
     public function send()
     {
         $this->remote_response();
@@ -188,6 +197,7 @@ class rcmail_output_json extends rcmail_output
      * @param int    $code    Error code
      * @param string $message Error message
      */
+    #[Override]
     public function raise_error($code, $message)
     {
         if ($code == 403) {

--- a/program/include/rcmail_resend_mail.php
+++ b/program/include/rcmail_resend_mail.php
@@ -49,6 +49,7 @@ class rcmail_resend_mail extends Mail_mime
     /**
      * Returns/Sets message headers
      */
+    #[Override]
     public function headers($headers = [], $overwrite = false, $skip_content = false)
     {
         // headers() wrapper that returns Resent-Cc, Resent-Bcc instead of Cc,Bcc
@@ -68,6 +69,7 @@ class rcmail_resend_mail extends Mail_mime
     /**
      * Returns all message headers as string
      */
+    #[Override]
     public function txtHeaders($headers = [], $overwrite = false, $skip_content = false)
     {
         // i.e. add Resent-* headers on top of the original message head
@@ -101,6 +103,7 @@ class rcmail_resend_mail extends Mail_mime
     /**
      * Save the message body to a file (if delay_file_io=true)
      */
+    #[Override]
     public function saveMessageBody($file, $params = null)
     {
         $this->init_message();
@@ -160,6 +163,7 @@ class rcmail_bounce_stream_filter extends php_user_filter
 
     protected $in_body = false;
 
+    #[Override]
     public function onCreate(): bool
     {
         self::$headers = '';
@@ -167,6 +171,7 @@ class rcmail_bounce_stream_filter extends php_user_filter
         return true;
     }
 
+    #[Override]
     #[ReturnTypeWillChange]
     public function filter($in, $out, &$consumed, $closing)
     {

--- a/program/include/rcmail_string_replacer.php
+++ b/program/include/rcmail_string_replacer.php
@@ -34,6 +34,7 @@ class rcmail_string_replacer extends rcube_string_replacer
      *
      * @see rcube_string_replacer::mailto_callback()
      */
+    #[Override]
     protected function mailto_callback($matches)
     {
         $href = $matches[1];

--- a/program/lib/Roundcube/cache/apc.php
+++ b/program/lib/Roundcube/cache/apc.php
@@ -45,6 +45,7 @@ class rcube_cache_apc extends rcube_cache
     /**
      * Remove cache records older than ttl
      */
+    #[Override]
     public function expunge()
     {
         // No need for GC, entries are expunged automatically
@@ -53,6 +54,7 @@ class rcube_cache_apc extends rcube_cache
     /**
      * Remove expired records of all caches
      */
+    #[Override]
     public static function gc()
     {
         // No need for GC, entries are expunged automatically
@@ -65,6 +67,7 @@ class rcube_cache_apc extends rcube_cache
      *
      * @return mixed Cached value
      */
+    #[Override]
     protected function get_item($key)
     {
         if (!$this->enabled) {
@@ -88,6 +91,7 @@ class rcube_cache_apc extends rcube_cache
      *
      * @return bool True on success, False on failure
      */
+    #[Override]
     protected function add_item($key, $data)
     {
         if (!$this->enabled) {
@@ -114,6 +118,7 @@ class rcube_cache_apc extends rcube_cache
      *
      * @return bool True on success, False on failure
      */
+    #[Override]
     protected function delete_item($key)
     {
         if (!$this->enabled) {

--- a/program/lib/Roundcube/cache/db.php
+++ b/program/lib/Roundcube/cache/db.php
@@ -54,6 +54,7 @@ class rcube_cache_db extends rcube_cache
     /**
      * Remove cache records older than ttl
      */
+    #[Override]
     public function expunge()
     {
         if ($this->ttl) {
@@ -69,6 +70,7 @@ class rcube_cache_db extends rcube_cache
     /**
      * Remove expired records of all caches
      */
+    #[Override]
     public static function gc()
     {
         $rcube = rcube::get_instance();
@@ -85,6 +87,7 @@ class rcube_cache_db extends rcube_cache
      *
      * @return mixed Cached value
      */
+    #[Override]
     protected function read_record($key)
     {
         $sql_result = $this->db->query(
@@ -119,6 +122,7 @@ class rcube_cache_db extends rcube_cache
      *
      * @return bool True on success, False on failure
      */
+    #[Override]
     protected function store_record($key, $data, $ts = null)
     {
         $value = $this->serialize($data);
@@ -166,6 +170,7 @@ class rcube_cache_db extends rcube_cache
      * @param bool   $prefix_mode Enable it to clear all keys starting
      *                            with prefix specified in $key
      */
+    #[Override]
     protected function remove_record($key = null, $prefix_mode = false)
     {
         // Remove all keys (in specified cache)
@@ -197,6 +202,7 @@ class rcube_cache_db extends rcube_cache
     /**
      * Serializes data for storing
      */
+    #[Override]
     protected function serialize($data)
     {
         return $this->db->encode($data, $this->packed);
@@ -205,6 +211,7 @@ class rcube_cache_db extends rcube_cache
     /**
      * Unserializes serialized data
      */
+    #[Override]
     protected function unserialize($data)
     {
         return $this->db->decode($data, $this->packed);
@@ -213,6 +220,7 @@ class rcube_cache_db extends rcube_cache
     /**
      * Determine the maximum size for cache data to be written
      */
+    #[Override]
     protected function max_packet_size()
     {
         if ($this->max_packet < 0) {

--- a/program/lib/Roundcube/cache/memcache.php
+++ b/program/lib/Roundcube/cache/memcache.php
@@ -117,6 +117,7 @@ class rcube_cache_memcache extends rcube_cache
     /**
      * Remove cache records older than ttl
      */
+    #[Override]
     public function expunge()
     {
         // No need for GC, entries are expunged automatically
@@ -125,6 +126,7 @@ class rcube_cache_memcache extends rcube_cache
     /**
      * Remove expired records of all caches
      */
+    #[Override]
     public static function gc()
     {
         // No need for GC, entries are expunged automatically
@@ -137,6 +139,7 @@ class rcube_cache_memcache extends rcube_cache
      *
      * @return mixed Cached value
      */
+    #[Override]
     protected function get_item($key)
     {
         if (!self::$memcache) {
@@ -160,6 +163,7 @@ class rcube_cache_memcache extends rcube_cache
      *
      * @return bool True on success, False on failure
      */
+    #[Override]
     protected function add_item($key, $data)
     {
         if (!self::$memcache) {
@@ -186,6 +190,7 @@ class rcube_cache_memcache extends rcube_cache
      *
      * @return bool True on success, False on failure
      */
+    #[Override]
     protected function delete_item($key)
     {
         if (!self::$memcache) {

--- a/program/lib/Roundcube/cache/memcached.php
+++ b/program/lib/Roundcube/cache/memcached.php
@@ -119,6 +119,7 @@ class rcube_cache_memcached extends rcube_cache
     /**
      * Remove cache records older than ttl
      */
+    #[Override]
     public function expunge()
     {
         // No need for GC, entries are expunged automatically
@@ -127,6 +128,7 @@ class rcube_cache_memcached extends rcube_cache
     /**
      * Remove expired records of all caches
      */
+    #[Override]
     public static function gc()
     {
         // No need for GC, entries are expunged automatically
@@ -139,6 +141,7 @@ class rcube_cache_memcached extends rcube_cache
      *
      * @return mixed Cached value
      */
+    #[Override]
     protected function get_item($key)
     {
         if (!self::$memcache) {
@@ -162,6 +165,7 @@ class rcube_cache_memcached extends rcube_cache
      *
      * @return bool True on success, False on failure
      */
+    #[Override]
     protected function add_item($key, $data)
     {
         if (!self::$memcache) {
@@ -184,6 +188,7 @@ class rcube_cache_memcached extends rcube_cache
      *
      * @return bool True on success, False on failure
      */
+    #[Override]
     protected function delete_item($key)
     {
         if (!self::$memcache) {

--- a/program/lib/Roundcube/cache/redis.php
+++ b/program/lib/Roundcube/cache/redis.php
@@ -147,6 +147,7 @@ class rcube_cache_redis extends rcube_cache
     /**
      * Remove cache records older than ttl
      */
+    #[Override]
     public function expunge()
     {
         // No need for GC, entries are expunged automatically
@@ -155,6 +156,7 @@ class rcube_cache_redis extends rcube_cache
     /**
      * Remove expired records
      */
+    #[Override]
     public static function gc()
     {
         // No need for GC, entries are expunged automatically
@@ -167,6 +169,7 @@ class rcube_cache_redis extends rcube_cache
      *
      * @return mixed Cached value
      */
+    #[Override]
     protected function get_item($key)
     {
         if (!self::$redis) {
@@ -195,6 +198,7 @@ class rcube_cache_redis extends rcube_cache
      *
      * @return bool True on success, False on failure
      */
+    #[Override]
     protected function add_item($key, $data)
     {
         if (!self::$redis) {
@@ -222,6 +226,7 @@ class rcube_cache_redis extends rcube_cache
      *
      * @return bool True on success, False on failure
      */
+    #[Override]
     protected function delete_item($key)
     {
         if (!self::$redis) {

--- a/program/lib/Roundcube/db/mysql.php
+++ b/program/lib/Roundcube/db/mysql.php
@@ -41,6 +41,7 @@ class rcube_db_mysql extends rcube_db
      *
      * @return string ...$args Values to concatenate
      */
+    #[Override]
     public function concat(...$args)
     {
         if (count($args) == 1 && is_array($args[0])) {
@@ -57,6 +58,7 @@ class rcube_db_mysql extends rcube_db
      *
      * @return string Connection string
      */
+    #[Override]
     protected function dsn_string($dsn)
     {
         $params = [];
@@ -89,6 +91,7 @@ class rcube_db_mysql extends rcube_db
      *
      * @return array Connection options
      */
+    #[Override]
     protected function dsn_options($dsn)
     {
         $result = parent::dsn_options($dsn);
@@ -138,6 +141,7 @@ class rcube_db_mysql extends rcube_db
      *
      * @return array List of all tables of the current database
      */
+    #[Override]
     public function list_tables()
     {
         // get tables if not cached
@@ -159,6 +163,7 @@ class rcube_db_mysql extends rcube_db
      *
      * @return array List of table cols
      */
+    #[Override]
     public function list_cols($table)
     {
         $q = $this->query('SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS'
@@ -180,6 +185,7 @@ class rcube_db_mysql extends rcube_db
      *
      * @return mixed Variable value or default
      */
+    #[Override]
     public function get_variable($varname, $default = null)
     {
         if (!isset($this->variables)) {
@@ -224,6 +230,7 @@ class rcube_db_mysql extends rcube_db
      *
      * @todo Multi-insert support
      */
+    #[Override]
     public function insert_or_update($table, $keys, $columns, $values)
     {
         $columns = array_map(static function ($i) {

--- a/program/lib/Roundcube/db/param.php
+++ b/program/lib/Roundcube/db/param.php
@@ -43,6 +43,7 @@ class rcube_db_param
     /**
      * Returns the value as string for inlining into SQL query
      */
+    #[Override]
     public function __toString()
     {
         if ($this->type === rcube_db::TYPE_SQL) {

--- a/program/lib/Roundcube/db/pgsql.php
+++ b/program/lib/Roundcube/db/pgsql.php
@@ -52,6 +52,7 @@ class rcube_db_pgsql extends rcube_db
      * @param array $dsn DSN for DB connections
      * @param PDO   $dbh Connection handler
      */
+    #[Override]
     protected function conn_configure($dsn, $dbh)
     {
         $dbh->query("SET NAMES 'utf8'");
@@ -70,6 +71,7 @@ class rcube_db_pgsql extends rcube_db
      *
      * @return mixed ID or false on failure
      */
+    #[Override]
     public function insert_id($table = null)
     {
         if (!$this->db_connected || $this->db_mode == 'r') {
@@ -113,6 +115,7 @@ class rcube_db_pgsql extends rcube_db
      *
      * @deprecated
      */
+    #[Override]
     public function unixtimestamp($field)
     {
         return "EXTRACT (EPOCH FROM {$field})";
@@ -125,6 +128,7 @@ class rcube_db_pgsql extends rcube_db
      *
      * @return string SQL function to use in query
      */
+    #[Override]
     public function now($interval = 0)
     {
         $result = 'now()';
@@ -146,6 +150,7 @@ class rcube_db_pgsql extends rcube_db
      *
      * @return string SQL statement to use in query
      */
+    #[Override]
     public function ilike($column, $value)
     {
         return $this->quote_identifier($column) . ' ILIKE ' . $this->quote($value);
@@ -159,6 +164,7 @@ class rcube_db_pgsql extends rcube_db
      *
      * @return mixed Variable value or default
      */
+    #[Override]
     public function get_variable($varname, $default = null)
     {
         // There's a known case when max_allowed_packet is queried
@@ -196,6 +202,7 @@ class rcube_db_pgsql extends rcube_db
      *
      * @todo Multi-insert support
      */
+    #[Override]
     public function insert_or_update($table, $keys, $columns, $values)
     {
         // Check if version >= 9.5, otherwise use fallback
@@ -223,6 +230,7 @@ class rcube_db_pgsql extends rcube_db
      *
      * @return array List of all tables of the current database
      */
+    #[Override]
     public function list_tables()
     {
         // get tables if not cached
@@ -250,6 +258,7 @@ class rcube_db_pgsql extends rcube_db
      *
      * @return array List of table cols
      */
+    #[Override]
     public function list_cols($table)
     {
         $args = [$table];
@@ -278,6 +287,7 @@ class rcube_db_pgsql extends rcube_db
      *
      * @return string DSN string
      */
+    #[Override]
     protected function dsn_string($dsn)
     {
         $params = [];
@@ -313,6 +323,7 @@ class rcube_db_pgsql extends rcube_db
     /**
      * Parse SQL file and fix table names according to table prefix
      */
+    #[Override]
     protected function fix_table_names($sql)
     {
         if (!$this->options['table_prefix']) {

--- a/program/lib/Roundcube/db/sqlite.php
+++ b/program/lib/Roundcube/db/sqlite.php
@@ -29,6 +29,7 @@ class rcube_db_sqlite extends rcube_db
     /**
      * Prepare connection
      */
+    #[Override]
     protected function conn_prepare($dsn)
     {
         // Create database file, required by PDO to exist on connection
@@ -45,6 +46,7 @@ class rcube_db_sqlite extends rcube_db
     /**
      * Configure connection, create database if not exists
      */
+    #[Override]
     protected function conn_configure($dsn, $dbh)
     {
         // Initialize database structure in file is empty
@@ -86,6 +88,7 @@ class rcube_db_sqlite extends rcube_db
      *
      * @deprecated
      */
+    #[Override]
     public function unixtimestamp($field)
     {
         return "strftime('%s', {$field})";
@@ -98,6 +101,7 @@ class rcube_db_sqlite extends rcube_db
      *
      * @return string SQL function to use in query
      */
+    #[Override]
     public function now($interval = 0)
     {
         $add = '';
@@ -114,6 +118,7 @@ class rcube_db_sqlite extends rcube_db
      *
      * @return array List of all tables of the current database
      */
+    #[Override]
     public function list_tables()
     {
         if ($this->tables === null) {
@@ -133,6 +138,7 @@ class rcube_db_sqlite extends rcube_db
      *
      * @return array List of table cols
      */
+    #[Override]
     public function list_cols($table)
     {
         $q = $this->query('PRAGMA table_info(?)', $table);
@@ -143,6 +149,7 @@ class rcube_db_sqlite extends rcube_db
     /**
      * Build DSN string for PDO constructor
      */
+    #[Override]
     protected function dsn_string($dsn)
     {
         return $dsn['phptype'] . ':' . $dsn['database'];
@@ -155,6 +162,7 @@ class rcube_db_sqlite extends rcube_db
      *
      * @return array Connection options
      */
+    #[Override]
     protected function dsn_options($dsn)
     {
         $result = parent::dsn_options($dsn);

--- a/program/lib/Roundcube/html.php
+++ b/program/lib/Roundcube/html.php
@@ -430,6 +430,7 @@ class html_inputfield extends html
      *
      * @return string HTML output
      */
+    #[Override]
     public function show($value = null, $attrib = null)
     {
         // overwrite object attributes
@@ -495,6 +496,7 @@ class html_hiddenfield extends html
      *
      * @return string Final HTML code
      */
+    #[Override]
     public function show()
     {
         $out = '';
@@ -522,6 +524,7 @@ class html_checkbox extends html_inputfield
      *
      * @return string HTML output
      */
+    #[Override]
     public function show($value = '', $attrib = null)
     {
         // overwrite object attributes
@@ -560,6 +563,7 @@ class html_button extends html_inputfield
      *
      * @return string HTML output
      */
+    #[Override]
     public function show($content = '', $attrib = null)
     {
         // overwrite object attributes
@@ -590,6 +594,7 @@ class html_textarea extends html
      *
      * @return string HTML output
      */
+    #[Override]
     public function show($value = '', $attrib = null)
     {
         // overwrite object attributes
@@ -655,6 +660,7 @@ class html_select extends html
      *
      * @return string HTML output
      */
+    #[Override]
     public function show($select = [], $attrib = null)
     {
         // overwrite object attributes
@@ -877,6 +883,7 @@ class html_table extends html
      *
      * @return string The final table HTML code
      */
+    #[Override]
     public function show($attrib = null)
     {
         if (is_array($attrib)) {

--- a/program/lib/Roundcube/rcube_addresses.php
+++ b/program/lib/Roundcube/rcube_addresses.php
@@ -55,6 +55,7 @@ class rcube_addresses extends rcube_contacts
      *
      * @return string
      */
+    #[Override]
     public function get_name()
     {
         if ($this->type == self::TYPE_RECIPIENT) {
@@ -77,6 +78,7 @@ class rcube_addresses extends rcube_contacts
      *
      * @return rcube_result_set Indexed list of contact records, each a hash array
      */
+    #[Override]
     public function list_records($cols = null, $subset = 0, $nocount = false)
     {
         if ($nocount || $this->list_page <= 1) {
@@ -136,6 +138,7 @@ class rcube_addresses extends rcube_contacts
      *
      * @return rcube_result_set Contact records and 'count' value
      */
+    #[Override]
     public function search($fields, $value, $mode = 0, $select = true, $nocount = false, $required = [])
     {
         if (!is_array($required) && !empty($required)) {
@@ -215,6 +218,7 @@ class rcube_addresses extends rcube_contacts
      *
      * @return int Contacts count
      */
+    #[Override]
     protected function _count()
     {
         // count contacts for this user
@@ -242,6 +246,7 @@ class rcube_addresses extends rcube_contacts
      *
      * @return rcube_result_set|array|null Result object with all record fields
      */
+    #[Override]
     public function get_record($id, $assoc = false)
     {
         // return cached result
@@ -276,6 +281,7 @@ class rcube_addresses extends rcube_contacts
      *
      * @return bool True if input is valid, False if not.
      */
+    #[Override]
     public function validate(&$save_data, $autofix = false)
     {
         $email = array_filter($this->get_col_values('email', $save_data, true));
@@ -307,6 +313,7 @@ class rcube_addresses extends rcube_contacts
      *
      * @return mixed The created record ID on success, False on error
      */
+    #[Override]
     public function insert($save_data, $check = false)
     {
         if ($check) {
@@ -339,6 +346,7 @@ class rcube_addresses extends rcube_contacts
      *
      * @return bool True on success, False on error
      */
+    #[Override]
     public function update($id, $save_cols)
     {
         return false;
@@ -352,6 +360,7 @@ class rcube_addresses extends rcube_contacts
      *
      * @return int|false Number of removed records
      */
+    #[Override]
     public function delete($ids, $force = true)
     {
         if (!is_array($ids)) {
@@ -379,6 +388,7 @@ class rcube_addresses extends rcube_contacts
      *
      * @return int Number of removed records
      */
+    #[Override]
     public function delete_all($with_groups = false)
     {
         $this->db->query('DELETE FROM ' . $this->db->table_name($this->db_name, true)

--- a/program/lib/Roundcube/rcube_contacts.php
+++ b/program/lib/Roundcube/rcube_contacts.php
@@ -79,6 +79,7 @@ class rcube_contacts extends rcube_addressbook
      *
      * @return string
      */
+    #[Override]
     public function get_name()
     {
         return $this->name;
@@ -89,6 +90,7 @@ class rcube_contacts extends rcube_addressbook
      *
      * @param mixed $filter SQL params to use in listing method
      */
+    #[Override]
     public function set_search_set($filter): void
     {
         $this->filter = $filter;
@@ -100,6 +102,7 @@ class rcube_contacts extends rcube_addressbook
      *
      * @return mixed Search properties used by this class
      */
+    #[Override]
     public function get_search_set()
     {
         return $this->filter;
@@ -109,6 +112,7 @@ class rcube_contacts extends rcube_addressbook
      * Setter for the current group
      * (empty, has to be re-implemented by extending class)
      */
+    #[Override]
     public function set_group($gid)
     {
         $this->group_id = $gid;
@@ -118,6 +122,7 @@ class rcube_contacts extends rcube_addressbook
     /**
      * Reset all saved results and search parameters
      */
+    #[Override]
     public function reset(): void
     {
         $this->result = null;
@@ -133,6 +138,7 @@ class rcube_contacts extends rcube_addressbook
      *
      * @return array Indexed list of contact groups, each a hash array
      */
+    #[Override]
     public function list_groups($search = null, $mode = 0)
     {
         $results = [];
@@ -177,6 +183,7 @@ class rcube_contacts extends rcube_addressbook
      *
      * @return ?array Group properties as hash array, null in case of error.
      */
+    #[Override]
     public function get_group($group_id)
     {
         $sql_result = $this->db->query(
@@ -202,6 +209,7 @@ class rcube_contacts extends rcube_addressbook
      *
      * @return rcube_result_set Indexed list of contact records, each a hash array
      */
+    #[Override]
     public function list_records($cols = null, $subset = 0, $nocount = false)
     {
         if ($nocount || $this->list_page <= 1) {
@@ -294,6 +302,7 @@ class rcube_contacts extends rcube_addressbook
      *
      * @return rcube_result_set Contact records and 'count' value
      */
+    #[Override]
     public function search($fields, $value, $mode = 0, $select = true, $nocount = false, $required = [])
     {
         if (!is_array($required) && !empty($required)) {
@@ -474,6 +483,7 @@ class rcube_contacts extends rcube_addressbook
      *
      * @return rcube_result_set Result object
      */
+    #[Override]
     public function count()
     {
         $count = $this->cache['count'] ?? $this->_count();
@@ -520,6 +530,7 @@ class rcube_contacts extends rcube_addressbook
      *
      * @return rcube_result_set|null Result array or NULL if nothing selected yet
      */
+    #[Override]
     public function get_result()
     {
         return $this->result;
@@ -533,6 +544,7 @@ class rcube_contacts extends rcube_addressbook
      *
      * @return rcube_result_set|array|null Result object with all record fields
      */
+    #[Override]
     public function get_record($id, $assoc = false)
     {
         // return cached result
@@ -567,6 +579,7 @@ class rcube_contacts extends rcube_addressbook
      *
      * @return array List of assigned groups, indexed by a group ID
      */
+    #[Override]
     public function get_record_groups($id)
     {
         $results = [];
@@ -600,6 +613,7 @@ class rcube_contacts extends rcube_addressbook
      *
      * @return bool True if input is valid, False if not.
      */
+    #[Override]
     public function validate(&$save_data, $autofix = false)
     {
         // validate e-mail addresses
@@ -628,6 +642,7 @@ class rcube_contacts extends rcube_addressbook
      *
      * @return mixed The created record ID on success, False on error
      */
+    #[Override]
     public function insert($save_data, $check = false)
     {
         $insert_id = $existing = false;
@@ -676,6 +691,7 @@ class rcube_contacts extends rcube_addressbook
      *
      * @return bool True on success, False on error
      */
+    #[Override]
     public function update($id, $save_cols)
     {
         $updated = false;
@@ -809,6 +825,7 @@ class rcube_contacts extends rcube_addressbook
      *
      * @return int|false Number of removed records, False on failure
      */
+    #[Override]
     public function delete($ids, $force = true)
     {
         if (!is_array($ids)) {
@@ -838,6 +855,7 @@ class rcube_contacts extends rcube_addressbook
      *
      * @return int Number of undeleted contact records
      */
+    #[Override]
     public function undelete($ids)
     {
         if (!is_array($ids)) {
@@ -867,6 +885,7 @@ class rcube_contacts extends rcube_addressbook
      *
      * @return int Number of removed records
      */
+    #[Override]
     public function delete_all($with_groups = false)
     {
         $this->cache = null;
@@ -897,6 +916,7 @@ class rcube_contacts extends rcube_addressbook
      *
      * @return array|false False on error, array with record props in success
      */
+    #[Override]
     public function create_group($name)
     {
         $result = false;
@@ -924,6 +944,7 @@ class rcube_contacts extends rcube_addressbook
      *
      * @return bool True on success, false if no data was changed
      */
+    #[Override]
     public function delete_group($gid)
     {
         // flag group record as deleted
@@ -949,6 +970,7 @@ class rcube_contacts extends rcube_addressbook
      *
      * @return string|false New name on success, false if no data was changed
      */
+    #[Override]
     public function rename_group($gid, $name, &$new_gid)
     {
         // make sure we have a unique name
@@ -973,6 +995,7 @@ class rcube_contacts extends rcube_addressbook
      *
      * @return int Number of contacts added
      */
+    #[Override]
     public function add_to_group($group_id, $ids)
     {
         if (!is_array($ids)) {
@@ -1024,6 +1047,7 @@ class rcube_contacts extends rcube_addressbook
      *
      * @return int Number of deleted group members
      */
+    #[Override]
     public function remove_from_group($group_id, $ids)
     {
         if (!is_array($ids)) {

--- a/program/lib/Roundcube/rcube_content_filter.php
+++ b/program/lib/Roundcube/rcube_content_filter.php
@@ -25,12 +25,14 @@ class rcube_content_filter extends php_user_filter
     private $buffer = '';
     private $cutoff = 2048;
 
+    #[Override]
     public function onCreate(): bool
     {
         $this->cutoff = rand(2048, 3027);
         return true;
     }
 
+    #[Override]
     #[ReturnTypeWillChange]
     public function filter($in, $out, &$consumed, $closing)
     {

--- a/program/lib/Roundcube/rcube_imap.php
+++ b/program/lib/Roundcube/rcube_imap.php
@@ -101,6 +101,7 @@ class rcube_imap extends rcube_storage
      *
      * @return bool True on success, False on failure
      */
+    #[Override]
     public function connect($host, $user, $pass, $port = 143, $use_ssl = null)
     {
         // check for OpenSSL support in PHP build
@@ -208,6 +209,7 @@ class rcube_imap extends rcube_storage
      * Close IMAP connection.
      * Usually done on script shutdown
      */
+    #[Override]
     public function close()
     {
         $this->connect_done = false;
@@ -223,6 +225,7 @@ class rcube_imap extends rcube_storage
      *
      * @return bool Connection state.
      */
+    #[Override]
     public function check_connection()
     {
         // Establish connection if it wasn't done yet
@@ -244,6 +247,7 @@ class rcube_imap extends rcube_storage
      *
      * @return bool True on success, False on failure
      */
+    #[Override]
     public function is_connected()
     {
         return $this->conn->connected();
@@ -254,6 +258,7 @@ class rcube_imap extends rcube_storage
      *
      * @return int Error code
      */
+    #[Override]
     public function get_error_code()
     {
         return $this->conn->errornum;
@@ -264,6 +269,7 @@ class rcube_imap extends rcube_storage
      *
      * @return string Error string
      */
+    #[Override]
     public function get_error_str()
     {
         return $this->conn->error;
@@ -274,6 +280,7 @@ class rcube_imap extends rcube_storage
      *
      * @return int Response code
      */
+    #[Override]
     public function get_response_code()
     {
         switch ($this->conn->resultcode) {
@@ -303,6 +310,7 @@ class rcube_imap extends rcube_storage
      *
      * @param bool $dbg True if IMAP conversation should be logged
      */
+    #[Override]
     public function set_debug($dbg = true)
     {
         $this->options['debug'] = $dbg;
@@ -315,6 +323,7 @@ class rcube_imap extends rcube_storage
      *
      * @param string $folder Folder name
      */
+    #[Override]
     public function set_folder($folder)
     {
         $this->folder = $folder;
@@ -330,6 +339,7 @@ class rcube_imap extends rcube_storage
      *                   3 - sorting field, string
      *                   4 - true if sorted, bool
      */
+    #[Override]
     public function set_search_set($set)
     {
         $set = (array) $set;
@@ -351,6 +361,7 @@ class rcube_imap extends rcube_storage
      *
      * @return array|null Search set
      */
+    #[Override]
     public function get_search_set()
     {
         if (empty($this->search_set)) {
@@ -373,6 +384,7 @@ class rcube_imap extends rcube_storage
      *
      * @return mixed Capability value or TRUE if supported, FALSE if not
      */
+    #[Override]
     public function get_capability($cap)
     {
         $cap = strtoupper($cap);
@@ -401,6 +413,7 @@ class rcube_imap extends rcube_storage
      *
      * @return bool True if this flag is supported
      */
+    #[Override]
     public function check_permflag($flag)
     {
         $flag = strtoupper($flag);
@@ -445,6 +458,7 @@ class rcube_imap extends rcube_storage
      *
      * @return string Delimiter string
      */
+    #[Override]
     public function get_hierarchy_delimiter()
     {
         return $this->delimiter;
@@ -457,6 +471,7 @@ class rcube_imap extends rcube_storage
      *
      * @return string|array|null Namespace data
      */
+    #[Override]
     public function get_namespace($name = null)
     {
         $ns = $this->namespace;
@@ -609,6 +624,7 @@ class rcube_imap extends rcube_storage
      *
      * @since 1.2
      */
+    #[Override]
     public function get_vendor()
     {
         if (isset($_SESSION['imap_vendor'])) {
@@ -664,6 +680,7 @@ class rcube_imap extends rcube_storage
      *
      * @return int Number of messages
      */
+    #[Override]
     public function count($folder = null, $mode = 'ALL', $force = false, $status = true)
     {
         if (!is_string($folder) || !strlen($folder)) {
@@ -801,6 +818,7 @@ class rcube_imap extends rcube_storage
      *
      * @return array Indexed array with message flags
      */
+    #[Override]
     public function list_flags($folder, $uids, $mod_seq = null)
     {
         if (!is_string($folder) || !strlen($folder)) {
@@ -837,6 +855,7 @@ class rcube_imap extends rcube_storage
      *
      * @return array<rcube_message_header> Indexed array with message header objects
      */
+    #[Override]
     public function list_messages($folder = null, $page = null, $sort_field = null, $sort_order = null, $slice = 0)
     {
         if (!is_string($folder) || !strlen($folder)) {
@@ -1256,6 +1275,7 @@ class rcube_imap extends rcube_storage
      *
      * @return array Messages headers indexed by UID
      */
+    #[Override]
     public function fetch_headers($folder, $msgs, $sort = true, $force = false)
     {
         if (empty($msgs)) {
@@ -1303,6 +1323,7 @@ class rcube_imap extends rcube_storage
      *
      * @return int Folder status
      */
+    #[Override]
     public function folder_status($folder = null, &$diff = [])
     {
         if (!is_string($folder) || !strlen($folder)) {
@@ -1382,6 +1403,7 @@ class rcube_imap extends rcube_storage
      *
      * @return rcube_result_index|rcube_result_thread List of messages (UIDs)
      */
+    #[Override]
     public function index($folder = null, $sort_field = null, $sort_order = null,
         $no_threads = false, $no_search = false
     ) {
@@ -1579,6 +1601,7 @@ class rcube_imap extends rcube_storage
      *
      * @todo: Search criteria should be provided in non-IMAP format, e.g. array
      */
+    #[Override]
     public function search($folder = '', $search = 'ALL', $charset = null, $sort_field = null)
     {
         if (!$search) {
@@ -1651,6 +1674,7 @@ class rcube_imap extends rcube_storage
      *
      * @return rcube_result_index|rcube_result_multifolder Search result (UIDs)
      */
+    #[Override]
     public function search_once($folder = null, $str = 'ALL')
     {
         if (!$this->check_connection()) {
@@ -1797,6 +1821,7 @@ class rcube_imap extends rcube_storage
      *
      * @return array Current search set
      */
+    #[Override]
     public function refresh_search()
     {
         if (!empty($this->search_string)) {
@@ -1833,6 +1858,7 @@ class rcube_imap extends rcube_storage
      *
      * @return rcube_message_header|false Message headers, False on error
      */
+    #[Override]
     public function get_message_headers($uid, $folder = null, $force = false)
     {
         // decode combined UID-folder identifier
@@ -1870,6 +1896,7 @@ class rcube_imap extends rcube_storage
      *
      * @return rcube_message_header|false Message data, False on error
      */
+    #[Override]
     public function get_message($uid, $folder = null)
     {
         if (!is_string($folder) || !strlen($folder)) {
@@ -2301,6 +2328,7 @@ class rcube_imap extends rcube_storage
      *
      * @return string|bool Message/part body if not printed
      */
+    #[Override]
     public function get_message_part($uid, $part, $o_part = null, $print = null, $fp = null,
         $skip_charset_conv = false, $max_bytes = 0, $formatted = true)
     {
@@ -2371,6 +2399,7 @@ class rcube_imap extends rcube_storage
      *
      * @return string|false Message source string
      */
+    #[Override]
     public function get_raw_body($uid, $fp = null, $part = null)
     {
         if (!$this->check_connection()) {
@@ -2389,6 +2418,7 @@ class rcube_imap extends rcube_storage
      *
      * @return string|false Message headers string
      */
+    #[Override]
     public function get_raw_headers($uid, $part = null)
     {
         if (!$this->check_connection()) {
@@ -2404,6 +2434,7 @@ class rcube_imap extends rcube_storage
      * @param int  $uid       Message UID
      * @param bool $formatted Enables line-ending formatting
      */
+    #[Override]
     public function print_raw_body($uid, $formatted = true)
     {
         if (!$this->check_connection()) {
@@ -2423,6 +2454,7 @@ class rcube_imap extends rcube_storage
      *
      * @return bool Operation status
      */
+    #[Override]
     public function set_flag($uids, $flag, $folder = null, $skip_cache = false)
     {
         if (!is_string($folder) || !strlen($folder)) {
@@ -2483,6 +2515,7 @@ class rcube_imap extends rcube_storage
      *
      * @return int|bool Appended message UID or True on success, False on error
      */
+    #[Override]
     public function save_message($folder, &$message, $headers = '', $is_file = false, $flags = [], $date = null, $binary = false)
     {
         if (!is_string($folder) || !strlen($folder)) {
@@ -2534,6 +2567,7 @@ class rcube_imap extends rcube_storage
      *
      * @return bool True on success, False on error
      */
+    #[Override]
     public function move_message($uids, $to_mbox, $from_mbox = '')
     {
         if (!strlen($from_mbox)) {
@@ -2611,6 +2645,7 @@ class rcube_imap extends rcube_storage
      *
      * @return bool True on success, False on error
      */
+    #[Override]
     public function copy_message($uids, $to_mbox, $from_mbox = '')
     {
         if (!strlen($from_mbox)) {
@@ -2646,6 +2681,7 @@ class rcube_imap extends rcube_storage
      *
      * @return bool True on success, False on error
      */
+    #[Override]
     public function delete_message($uids, $folder = null)
     {
         if (!is_string($folder) || !strlen($folder)) {
@@ -2702,6 +2738,7 @@ class rcube_imap extends rcube_storage
      *
      * @return bool True on success, False on failure
      */
+    #[Override]
     public function expunge_message($uids, $folder = null, $clear_cache = true)
     {
         if ($uids && $this->get_capability('UIDPLUS')) {
@@ -2756,6 +2793,7 @@ class rcube_imap extends rcube_storage
      *
      * @return array List of folders
      */
+    #[Override]
     public function list_folders_subscribed($root = '', $name = '*', $filter = null, $rights = null, $skip_sort = false)
     {
         $cache_key = rcube_cache::key_name('mailboxes', [$root, $name, $filter, $rights]);
@@ -2891,6 +2929,7 @@ class rcube_imap extends rcube_storage
      *
      * @return array Indexed array with folder names
      */
+    #[Override]
     public function list_folders($root = '', $name = '*', $filter = null, $rights = null, $skip_sort = false)
     {
         $cache_key = rcube_cache::key_name('mailboxes.list', [$root, $name, $filter, $rights]);
@@ -3092,6 +3131,7 @@ class rcube_imap extends rcube_storage
      *
      * @return mixed Quota info or False if not supported
      */
+    #[Override]
     public function get_quota($folder = null)
     {
         if ($this->get_capability('QUOTA') && $this->check_connection()) {
@@ -3108,6 +3148,7 @@ class rcube_imap extends rcube_storage
      *
      * @return int|false Folder size in bytes, False on error
      */
+    #[Override]
     public function folder_size($folder)
     {
         if (!strlen($folder)) {
@@ -3152,6 +3193,7 @@ class rcube_imap extends rcube_storage
      *
      * @return bool True on success, False on failure
      */
+    #[Override]
     public function subscribe($folders)
     {
         // let this common function do the main work
@@ -3165,6 +3207,7 @@ class rcube_imap extends rcube_storage
      *
      * @return bool True on success, False on failure
      */
+    #[Override]
     public function unsubscribe($folders)
     {
         // let this common function do the main work
@@ -3183,6 +3226,7 @@ class rcube_imap extends rcube_storage
      *
      * @return bool True on success, False on failure
      */
+    #[Override]
     public function create_folder($folder, $subscribe = false, $type = null, $noselect = false)
     {
         if (!$this->check_connection()) {
@@ -3222,6 +3266,7 @@ class rcube_imap extends rcube_storage
      *
      * @return bool True on success, False on failure
      */
+    #[Override]
     public function rename_folder($folder, $new_name)
     {
         if (!strlen($new_name)) {
@@ -3279,6 +3324,7 @@ class rcube_imap extends rcube_storage
      *
      * @return bool True on success, False on failure
      */
+    #[Override]
     public function delete_folder($folder)
     {
         if (!$this->check_connection()) {
@@ -3321,6 +3367,7 @@ class rcube_imap extends rcube_storage
     /**
      * Detect special folder associations stored in storage backend
      */
+    #[Override]
     public function get_special_folders($forced = false)
     {
         $result = parent::get_special_folders();
@@ -3377,6 +3424,7 @@ class rcube_imap extends rcube_storage
     /**
      * Set special folder associations stored in storage backend
      */
+    #[Override]
     public function set_special_folders($specials)
     {
         if (!$this->get_capability('SPECIAL-USE') || !$this->get_capability('METADATA')) {
@@ -3420,6 +3468,7 @@ class rcube_imap extends rcube_storage
      *
      * @return bool True or False
      */
+    #[Override]
     public function folder_exists($folder, $subscription = false)
     {
         if ($folder == 'INBOX') {
@@ -3469,6 +3518,7 @@ class rcube_imap extends rcube_storage
      *
      * @return string One of 'personal', 'other' or 'shared'
      */
+    #[Override]
     public function folder_namespace($folder)
     {
         if ($folder == 'INBOX') {
@@ -3503,6 +3553,7 @@ class rcube_imap extends rcube_storage
      *
      * @return string Folder name
      */
+    #[Override]
     public function mod_folder($folder, $mode = 'out')
     {
         $prefix = $this->namespace['prefix_' . $mode] ?? null;
@@ -3534,6 +3585,7 @@ class rcube_imap extends rcube_storage
      *
      * @return array Options list
      */
+    #[Override]
     public function folder_attributes($folder, $force = false)
     {
         // get attributes directly from LIST command
@@ -3574,6 +3626,7 @@ class rcube_imap extends rcube_storage
      *
      * @return array Folder properties
      */
+    #[Override]
     public function folder_data($folder)
     {
         if (!strlen((string) $folder)) {
@@ -3621,6 +3674,7 @@ class rcube_imap extends rcube_storage
      *
      * @return array Data
      */
+    #[Override]
     public function folder_info($folder)
     {
         if (!empty($this->icache['options']) && $this->icache['options']['name'] == $folder) {
@@ -3711,6 +3765,7 @@ class rcube_imap extends rcube_storage
      *
      * @param string $folder Folder name
      */
+    #[Override]
     public function folder_sync($folder)
     {
         if ($mcache = $this->get_mcache_engine()) {
@@ -3726,6 +3781,7 @@ class rcube_imap extends rcube_storage
      *
      * @return bool True if the name is valid, False otherwise
      */
+    #[Override]
     public function folder_validate($folder, &$char = null)
     {
         if (parent::folder_validate($folder, $char)) {
@@ -3782,6 +3838,7 @@ class rcube_imap extends rcube_storage
      *
      * @since 0.5-beta
      */
+    #[Override]
     public function set_acl($folder, $user, $acl)
     {
         if (!$this->get_capability('ACL')) {
@@ -3809,6 +3866,7 @@ class rcube_imap extends rcube_storage
      *
      * @since 0.5-beta
      */
+    #[Override]
     public function delete_acl($folder, $user)
     {
         if (!$this->get_capability('ACL')) {
@@ -3831,6 +3889,7 @@ class rcube_imap extends rcube_storage
      *
      * @since 0.5-beta
      */
+    #[Override]
     public function get_acl($folder)
     {
         if (!$this->get_capability('ACL')) {
@@ -3855,6 +3914,7 @@ class rcube_imap extends rcube_storage
      *
      * @since 0.5-beta
      */
+    #[Override]
     public function list_rights($folder, $user)
     {
         if (!$this->get_capability('ACL')) {
@@ -3878,6 +3938,7 @@ class rcube_imap extends rcube_storage
      *
      * @since 0.5-beta
      */
+    #[Override]
     public function my_rights($folder)
     {
         if (!$this->get_capability('ACL')) {
@@ -3901,6 +3962,7 @@ class rcube_imap extends rcube_storage
      *
      * @since 0.5-beta
      */
+    #[Override]
     public function set_metadata($folder, $entries)
     {
         if (!$this->check_connection()) {
@@ -3937,6 +3999,7 @@ class rcube_imap extends rcube_storage
      *
      * @since 0.5-beta
      */
+    #[Override]
     public function delete_metadata($folder, $entries)
     {
         if (!$this->check_connection()) {
@@ -3975,6 +4038,7 @@ class rcube_imap extends rcube_storage
      *
      * @since 0.5-beta
      */
+    #[Override]
     public function get_metadata($folder, $entries, $options = [], $force = false)
     {
         $entries = (array) $entries;
@@ -4065,6 +4129,7 @@ class rcube_imap extends rcube_storage
      *
      * @param string $type Cache type (@see rcube::get_cache)
      */
+    #[Override]
     public function set_caching($type)
     {
         if ($type) {
@@ -4101,6 +4166,7 @@ class rcube_imap extends rcube_storage
      *
      * @return mixed
      */
+    #[Override]
     public function get_cache($key)
     {
         if ($cache = $this->get_cache_engine()) {
@@ -4130,6 +4196,7 @@ class rcube_imap extends rcube_storage
      * @param bool   $prefix_mode Enable it to clear all keys starting
      *                            with prefix specified in $key
      */
+    #[Override]
     public function clear_cache($key = null, $prefix_mode = false)
     {
         if ($cache = $this->get_cache_engine()) {
@@ -4147,6 +4214,7 @@ class rcube_imap extends rcube_storage
      * @param bool $set  Flag
      * @param int  $mode Cache mode
      */
+    #[Override]
     public function set_messages_caching($set, $mode = null)
     {
         if ($set) {
@@ -4199,6 +4267,7 @@ class rcube_imap extends rcube_storage
     /**
      * Delete outdated cache entries
      */
+    #[Override]
     public function cache_gc()
     {
         rcube_imap_cache::gc();

--- a/program/lib/Roundcube/rcube_ldap.php
+++ b/program/lib/Roundcube/rcube_ldap.php
@@ -508,6 +508,7 @@ class rcube_ldap extends rcube_addressbook
     /**
      * Close connection to LDAP server
      */
+    #[Override]
     public function close()
     {
         if ($this->ldap) {
@@ -520,6 +521,7 @@ class rcube_ldap extends rcube_addressbook
      *
      * @return string Address book name
      */
+    #[Override]
     public function get_name()
     {
         return $this->prop['name'];
@@ -530,6 +532,7 @@ class rcube_ldap extends rcube_addressbook
      *
      * @param number $page Page number to list
      */
+    #[Override]
     public function set_page($page)
     {
         $this->list_page = (int) $page;
@@ -541,6 +544,7 @@ class rcube_ldap extends rcube_addressbook
      *
      * @param number $size Number of records to display on one page
      */
+    #[Override]
     public function set_pagesize($size)
     {
         $this->page_size = (int) $size;
@@ -553,6 +557,7 @@ class rcube_ldap extends rcube_addressbook
      * @param ?string $sort_col   Sort column
      * @param ?string $sort_order Sort order
      */
+    #[Override]
     public function set_sort_order($sort_col = null, $sort_order = null)
     {
         if (!empty($this->coltypes[$sort_col]['attributes'])) {
@@ -565,6 +570,7 @@ class rcube_ldap extends rcube_addressbook
      *
      * @param mixed $filter Filter string
      */
+    #[Override]
     public function set_search_set($filter): void
     {
         $this->filter = $filter;
@@ -575,6 +581,7 @@ class rcube_ldap extends rcube_addressbook
      *
      * @return mixed Search properties used by this class
      */
+    #[Override]
     public function get_search_set()
     {
         return $this->filter;
@@ -583,6 +590,7 @@ class rcube_ldap extends rcube_addressbook
     /**
      * Reset all saved results and search parameters
      */
+    #[Override]
     public function reset(): void
     {
         $this->result = null;
@@ -599,6 +607,7 @@ class rcube_ldap extends rcube_addressbook
      *
      * @return rcube_result_set Indexed list of contact records, each a hash array
      */
+    #[Override]
     public function list_records($cols = null, $subset = 0, $nocount = false)
     {
         if (!empty($this->prop['searchonly']) && empty($this->filter) && !$this->group_id) {
@@ -803,6 +812,7 @@ class rcube_ldap extends rcube_addressbook
      *
      * @return rcube_result_set List of contact records
      */
+    #[Override]
     public function search($fields, $value, $mode = 0, $select = true, $nocount = false, $required = [])
     {
         $mode = intval($mode);
@@ -968,6 +978,7 @@ class rcube_ldap extends rcube_addressbook
      *
      * @return rcube_result_set Resultset with values for 'count' and 'first'
      */
+    #[Override]
     public function count()
     {
         $count = 0;
@@ -1074,6 +1085,7 @@ class rcube_ldap extends rcube_addressbook
      *
      * @return rcube_result_set Current resultset or NULL if nothing selected yet
      */
+    #[Override]
     public function get_result()
     {
         return $this->result;
@@ -1087,6 +1099,7 @@ class rcube_ldap extends rcube_addressbook
      *
      * @return array|rcube_result_set|null Hash array or rcube_result_set with all record fields
      */
+    #[Override]
     public function get_record($dn, $assoc = false)
     {
         $res = $this->result = null;
@@ -1125,6 +1138,7 @@ class rcube_ldap extends rcube_addressbook
      *
      * @return array Hash array with the following fields: type, message
      */
+    #[Override]
     public function get_error()
     {
         $err = $this->error;
@@ -1146,6 +1160,7 @@ class rcube_ldap extends rcube_addressbook
      *
      * @return bool True if input is valid, False if not.
      */
+    #[Override]
     public function validate(&$save_data, $autofix = false)
     {
         // validate e-mail addresses
@@ -1220,6 +1235,7 @@ class rcube_ldap extends rcube_addressbook
      *
      * @return mixed The created record ID on success, False on error
      */
+    #[Override]
     public function insert($save_cols, $check = false)
     {
         // Map out the column names to their LDAP ones to build the new entry.
@@ -1291,6 +1307,7 @@ class rcube_ldap extends rcube_addressbook
      *
      * @return bool True on success, False on error
      */
+    #[Override]
     public function update($id, $save_cols)
     {
         $record = $this->get_record($id, true);
@@ -1472,6 +1489,7 @@ class rcube_ldap extends rcube_addressbook
      *
      * @return int|false Number of deleted records on success, False on error
      */
+    #[Override]
     public function delete($ids, $force = true)
     {
         if (!is_array($ids)) {
@@ -1519,6 +1537,7 @@ class rcube_ldap extends rcube_addressbook
      *
      * @param bool $with_groups Delete also groups if enabled
      */
+    #[Override]
     public function delete_all($with_groups = false)
     {
         // searching for contact entries
@@ -1809,6 +1828,7 @@ class rcube_ldap extends rcube_addressbook
      *
      * @param mixed $group_id Group identifier
      */
+    #[Override]
     public function set_group($group_id)
     {
         if ($group_id) {
@@ -1828,6 +1848,7 @@ class rcube_ldap extends rcube_addressbook
      *
      * @return array Indexed list of contact groups, each a hash array
      */
+    #[Override]
     public function list_groups($search = null, $mode = 0)
     {
         if (!$this->groups) {
@@ -2028,6 +2049,7 @@ class rcube_ldap extends rcube_addressbook
      *
      * @return array Group properties as hash array
      */
+    #[Override]
     public function get_group($group_id)
     {
         $group_data = $this->get_group_entry($group_id);
@@ -2043,6 +2065,7 @@ class rcube_ldap extends rcube_addressbook
      *
      * @return array|false False on error, array with record props in success
      */
+    #[Override]
     public function create_group($group_name)
     {
         $new_dn = 'cn=' . rcube_ldap_generic::quote_string($group_name, true) . ',' . $this->groups_base_dn;
@@ -2074,6 +2097,7 @@ class rcube_ldap extends rcube_addressbook
      *
      * @return bool True on success, false if no data was changed
      */
+    #[Override]
     public function delete_group($group_id)
     {
         $group_cache = $this->_fetch_groups();
@@ -2101,6 +2125,7 @@ class rcube_ldap extends rcube_addressbook
      *
      * @return string|false New name on success, false if no data was changed
      */
+    #[Override]
     public function rename_group($group_id, $new_name, &$new_gid)
     {
         $group_cache = $this->_fetch_groups();
@@ -2128,6 +2153,7 @@ class rcube_ldap extends rcube_addressbook
      *
      * @return int Number of contacts added
      */
+    #[Override]
     public function add_to_group($group_id, $contact_ids)
     {
         $group_cache = $this->_fetch_groups();
@@ -2163,6 +2189,7 @@ class rcube_ldap extends rcube_addressbook
      *
      * @return int Number of deleted group members
      */
+    #[Override]
     public function remove_from_group($group_id, $contact_ids)
     {
         $group_cache = $this->_fetch_groups();
@@ -2199,6 +2226,7 @@ class rcube_ldap extends rcube_addressbook
      *
      * @since 0.5-beta
      */
+    #[Override]
     public function get_record_groups($contact_id)
     {
         if (!$this->groups) {

--- a/program/lib/Roundcube/rcube_ldap_generic.php
+++ b/program/lib/Roundcube/rcube_ldap_generic.php
@@ -45,6 +45,7 @@ class rcube_ldap_generic extends Net_LDAP3
     /**
      * Establish a connection to the LDAP server
      */
+    #[Override]
     public function connect($host = null)
     {
         // Net_LDAP3 does not support IDNA yet
@@ -276,6 +277,7 @@ class rcube_ldap_generic extends Net_LDAP3
      *
      * @return array Hash array with attributes as keys
      */
+    #[Override]
     public static function normalize_entry($entry, $flat = false)
     {
         if (!isset($entry['count'])) {

--- a/program/lib/Roundcube/rcube_result_set.php
+++ b/program/lib/Roundcube/rcube_result_set.php
@@ -84,6 +84,7 @@ class rcube_result_set implements Iterator, ArrayAccess
 
     // Implement PHP ArrayAccess interface
 
+    #[Override]
     public function offsetSet($offset, $value): void
     {
         if ($offset === null) {
@@ -94,16 +95,19 @@ class rcube_result_set implements Iterator, ArrayAccess
         }
     }
 
+    #[Override]
     public function offsetExists($offset): bool
     {
         return isset($this->records[$offset]);
     }
 
+    #[Override]
     public function offsetUnset($offset): void
     {
         unset($this->records[$offset]);
     }
 
+    #[Override]
     #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
@@ -112,29 +116,34 @@ class rcube_result_set implements Iterator, ArrayAccess
 
     // PHP 5 Iterator interface
 
+    #[Override]
     public function rewind(): void
     {
         $this->current = 0;
     }
 
+    #[Override]
     #[ReturnTypeWillChange]
     public function current()
     {
         return $this->records[$this->current] ?? null;
     }
 
+    #[Override]
     #[ReturnTypeWillChange]
     public function key()
     {
         return $this->current;
     }
 
+    #[Override]
     #[ReturnTypeWillChange]
     public function next()
     {
         $this->current++;
     }
 
+    #[Override]
     public function valid(): bool
     {
         return isset($this->records[$this->current]);

--- a/program/lib/Roundcube/rcube_session.php
+++ b/program/lib/Roundcube/rcube_session.php
@@ -130,15 +130,19 @@ abstract class rcube_session implements SessionHandlerInterface
     /**
      * Abstract methods should be implemented by driver classes
      */
+    #[Override]
     #[ReturnTypeWillChange]
     abstract public function open($save_path, $session_name);
 
+    #[Override]
     #[ReturnTypeWillChange]
     abstract public function close();
 
+    #[Override]
     #[ReturnTypeWillChange]
     abstract public function destroy($key);
 
+    #[Override]
     #[ReturnTypeWillChange]
     abstract public function read($key);
 
@@ -171,6 +175,7 @@ abstract class rcube_session implements SessionHandlerInterface
      *
      * @return bool True on success, False on failure
      */
+    #[Override]
     #[ReturnTypeWillChange]
     public function write($key, $vars)
     {
@@ -197,6 +202,7 @@ abstract class rcube_session implements SessionHandlerInterface
      *
      * @return int|false Number of deleted sessions on success, False on failure
      */
+    #[Override]
     #[ReturnTypeWillChange]
     public function gc($maxlifetime)
     {

--- a/program/lib/Roundcube/session/db.php
+++ b/program/lib/Roundcube/session/db.php
@@ -61,6 +61,7 @@ class rcube_session_db extends rcube_session
      *
      * @return bool True on success, False on failure
      */
+    #[Override]
     public function open($save_path, $session_name)
     {
         return true;
@@ -71,6 +72,7 @@ class rcube_session_db extends rcube_session
      *
      * @return bool True on success, False on failure
      */
+    #[Override]
     public function close()
     {
         return true;
@@ -83,6 +85,7 @@ class rcube_session_db extends rcube_session
      *
      * @return bool True on success, False on failure
      */
+    #[Override]
     public function destroy($key)
     {
         if ($key) {
@@ -99,6 +102,7 @@ class rcube_session_db extends rcube_session
      *
      * @return string Session vars (serialized string)
      */
+    #[Override]
     public function read($key)
     {
         if ($this->lifetime) {
@@ -142,6 +146,7 @@ class rcube_session_db extends rcube_session
      *
      * @return bool True on success, False on failure
      */
+    #[Override]
     protected function save($key, $vars)
     {
         if ($this->ignore_write) {
@@ -168,6 +173,7 @@ class rcube_session_db extends rcube_session
      *
      * @return bool True on success, False on failure
      */
+    #[Override]
     protected function update($key, $newvars, $oldvars)
     {
         $now = $this->db->now();

--- a/program/lib/Roundcube/session/memcache.php
+++ b/program/lib/Roundcube/session/memcache.php
@@ -63,6 +63,7 @@ class rcube_session_memcache extends rcube_session
      *
      * @return bool True on success, False on failure
      */
+    #[Override]
     public function open($save_path, $session_name)
     {
         return true;
@@ -73,6 +74,7 @@ class rcube_session_memcache extends rcube_session
      *
      * @return bool True on success, False on failure
      */
+    #[Override]
     public function close()
     {
         return true;
@@ -85,6 +87,7 @@ class rcube_session_memcache extends rcube_session
      *
      * @return bool True on success, False on failure
      */
+    #[Override]
     public function destroy($key)
     {
         if ($key) {
@@ -106,6 +109,7 @@ class rcube_session_memcache extends rcube_session
      *
      * @return string Serialized data string
      */
+    #[Override]
     public function read($key)
     {
         if ($value = $this->memcache->get($key)) {
@@ -131,6 +135,7 @@ class rcube_session_memcache extends rcube_session
      *
      * @return bool True on success, False on failure
      */
+    #[Override]
     protected function save($key, $vars)
     {
         if ($this->ignore_write) {
@@ -156,6 +161,7 @@ class rcube_session_memcache extends rcube_session
      *
      * @return bool True on success, False on failure
      */
+    #[Override]
     protected function update($key, $newvars, $oldvars)
     {
         $ts = microtime(true);

--- a/program/lib/Roundcube/session/memcached.php
+++ b/program/lib/Roundcube/session/memcached.php
@@ -63,6 +63,7 @@ class rcube_session_memcached extends rcube_session
      *
      * @return bool True on success, False on failure
      */
+    #[Override]
     public function open($save_path, $session_name)
     {
         return true;
@@ -73,6 +74,7 @@ class rcube_session_memcached extends rcube_session
      *
      * @return bool True on success, False on failure
      */
+    #[Override]
     public function close()
     {
         return true;
@@ -85,6 +87,7 @@ class rcube_session_memcached extends rcube_session
      *
      * @return bool True on success, False on failure
      */
+    #[Override]
     public function destroy($key)
     {
         if ($key) {
@@ -106,6 +109,7 @@ class rcube_session_memcached extends rcube_session
      *
      * @return string Serialized data string
      */
+    #[Override]
     public function read($key)
     {
         if ($arr = $this->memcache->get($key)) {
@@ -130,6 +134,7 @@ class rcube_session_memcached extends rcube_session
      *
      * @return bool True on success, False on failure
      */
+    #[Override]
     protected function save($key, $vars)
     {
         if ($this->ignore_write) {
@@ -155,6 +160,7 @@ class rcube_session_memcached extends rcube_session
      *
      * @return bool True on success, False on failure
      */
+    #[Override]
     protected function update($key, $newvars, $oldvars)
     {
         $ts = microtime(true);

--- a/program/lib/Roundcube/session/php.php
+++ b/program/lib/Roundcube/session/php.php
@@ -29,31 +29,37 @@ class rcube_session_php extends rcube_session
      * Native php sessions don't need a save handler.
      * We do need to define abstract function implementations but they are not used.
      */
+    #[Override]
     public function open($save_path, $session_name)
     {
         return true;
     }
 
+    #[Override]
     public function close()
     {
         return true;
     }
 
+    #[Override]
     public function destroy($key)
     {
         return true;
     }
 
+    #[Override]
     public function read($key)
     {
         return '';
     }
 
+    #[Override]
     protected function save($key, $vars)
     {
         return true;
     }
 
+    #[Override]
     protected function update($key, $newvars, $oldvars)
     {
         return true;
@@ -72,6 +78,7 @@ class rcube_session_php extends rcube_session
     /**
      * Wrapper for session_write_close()
      */
+    #[Override]
     public function write_close()
     {
         $_SESSION['__IP'] = $this->ip;
@@ -83,6 +90,7 @@ class rcube_session_php extends rcube_session
     /**
      * Wrapper for session_start()
      */
+    #[Override]
     public function start()
     {
         parent::start();

--- a/program/lib/Roundcube/session/redis.php
+++ b/program/lib/Roundcube/session/redis.php
@@ -61,6 +61,7 @@ class rcube_session_redis extends rcube_session
      *
      * @return bool True on success, False on failure
      */
+    #[Override]
     public function open($save_path, $session_name)
     {
         return true;
@@ -71,6 +72,7 @@ class rcube_session_redis extends rcube_session
      *
      * @return bool True on success, False on failure
      */
+    #[Override]
     public function close()
     {
         return true;
@@ -83,6 +85,7 @@ class rcube_session_redis extends rcube_session
      *
      * @return bool True on success, False on failure
      */
+    #[Override]
     public function destroy($key)
     {
         if ($key) {
@@ -110,6 +113,7 @@ class rcube_session_redis extends rcube_session
      *
      * @return string Serialized data string
      */
+    #[Override]
     public function read($key)
     {
         $value = null;
@@ -144,6 +148,7 @@ class rcube_session_redis extends rcube_session
      *
      * @return bool True on success, False on failure
      */
+    #[Override]
     protected function update($key, $newvars, $oldvars)
     {
         $ts = microtime(true);
@@ -176,6 +181,7 @@ class rcube_session_redis extends rcube_session
      *
      * @return bool True on success, False on failure
      */
+    #[Override]
     protected function save($key, $vars)
     {
         if ($this->ignore_write) {

--- a/program/lib/Roundcube/spellchecker/atd.php
+++ b/program/lib/Roundcube/spellchecker/atd.php
@@ -39,6 +39,7 @@ class rcube_spellchecker_atd extends rcube_spellchecker_engine
      *
      * @see rcube_spellchecker_engine::languages()
      */
+    #[Override]
     public function languages()
     {
         $langs = array_values($this->langhosts);
@@ -52,6 +53,7 @@ class rcube_spellchecker_atd extends rcube_spellchecker_engine
      *
      * @see rcube_spellchecker_engine::check()
      */
+    #[Override]
     public function check($text)
     {
         $this->content = $text;
@@ -168,6 +170,7 @@ class rcube_spellchecker_atd extends rcube_spellchecker_engine
      *
      * @see rcube_spellchecker_engine::get_words()
      */
+    #[Override]
     public function get_suggestions($word)
     {
         $this->check($word);
@@ -184,6 +187,7 @@ class rcube_spellchecker_atd extends rcube_spellchecker_engine
      *
      * @see rcube_spellchecker_engine::get_suggestions()
      */
+    #[Override]
     public function get_words($text = null)
     {
         if ($text) {

--- a/program/lib/Roundcube/spellchecker/enchant.php
+++ b/program/lib/Roundcube/spellchecker/enchant.php
@@ -42,6 +42,7 @@ class rcube_spellchecker_enchant extends rcube_spellchecker_engine
      *
      * @see rcube_spellchecker_engine::languages()
      */
+    #[Override]
     public function languages()
     {
         $this->init();
@@ -87,6 +88,7 @@ class rcube_spellchecker_enchant extends rcube_spellchecker_engine
      *
      * @see rcube_spellchecker_engine::check()
      */
+    #[Override]
     public function check($text)
     {
         $this->init();
@@ -131,6 +133,7 @@ class rcube_spellchecker_enchant extends rcube_spellchecker_engine
      *
      * @see rcube_spellchecker_engine::get_words()
      */
+    #[Override]
     public function get_suggestions($word)
     {
         $this->init();
@@ -153,6 +156,7 @@ class rcube_spellchecker_enchant extends rcube_spellchecker_engine
      *
      * @see rcube_spellchecker_engine::get_suggestions()
      */
+    #[Override]
     public function get_words($text = null)
     {
         $result = [];

--- a/program/lib/Roundcube/spellchecker/googie.php
+++ b/program/lib/Roundcube/spellchecker/googie.php
@@ -32,6 +32,7 @@ class rcube_spellchecker_googie extends rcube_spellchecker_engine
      *
      * @see rcube_spellchecker_engine::languages()
      */
+    #[Override]
     public function languages()
     {
         return [
@@ -49,6 +50,7 @@ class rcube_spellchecker_googie extends rcube_spellchecker_engine
      *
      * @see rcube_spellchecker_engine::check()
      */
+    #[Override]
     public function check($text)
     {
         $this->content = $text;
@@ -123,6 +125,7 @@ class rcube_spellchecker_googie extends rcube_spellchecker_engine
      *
      * @see rcube_spellchecker_engine::get_words()
      */
+    #[Override]
     public function get_suggestions($word)
     {
         $this->check($word);
@@ -144,6 +147,7 @@ class rcube_spellchecker_googie extends rcube_spellchecker_engine
      *
      * @see rcube_spellchecker_engine::get_suggestions()
      */
+    #[Override]
     public function get_words($text = null)
     {
         if ($text) {

--- a/program/lib/Roundcube/spellchecker/pspell.php
+++ b/program/lib/Roundcube/spellchecker/pspell.php
@@ -30,6 +30,7 @@ class rcube_spellchecker_pspell extends rcube_spellchecker_engine
      *
      * @see rcube_spellchecker_engine::languages()
      */
+    #[Override]
     public function languages()
     {
         $defaults = ['en'];
@@ -81,6 +82,7 @@ class rcube_spellchecker_pspell extends rcube_spellchecker_engine
      *
      * @see rcube_spellchecker_engine::check()
      */
+    #[Override]
     public function check($text)
     {
         $this->init();
@@ -125,6 +127,7 @@ class rcube_spellchecker_pspell extends rcube_spellchecker_engine
      *
      * @see rcube_spellchecker_engine::get_words()
      */
+    #[Override]
     public function get_suggestions($word)
     {
         $this->init();
@@ -147,6 +150,7 @@ class rcube_spellchecker_pspell extends rcube_spellchecker_engine
      *
      * @see rcube_spellchecker_engine::get_suggestions()
      */
+    #[Override]
     public function get_words($text = null)
     {
         $result = [];

--- a/tests/ActionTestCase.php
+++ b/tests/ActionTestCase.php
@@ -9,6 +9,7 @@ class ActionTestCase extends TestCase
 {
     private static $files = [];
 
+    #[Override]
     public static function setUpBeforeClass(): void
     {
         // reset some interfering globals set in other tests
@@ -18,6 +19,7 @@ class ActionTestCase extends TestCase
         $rcmail->load_gui();
     }
 
+    #[Override]
     public static function tearDownAfterClass(): void
     {
         foreach (self::$files as $file) {
@@ -32,6 +34,7 @@ class ActionTestCase extends TestCase
         html::$doctype = 'xhtml';
     }
 
+    #[Override]
     protected function setUp(): void
     {
         $_GET = [];

--- a/tests/Browser/Components/App.php
+++ b/tests/Browser/Components/App.php
@@ -13,6 +13,7 @@ class App extends Component
      *
      * @return string
      */
+    #[\Override]
     public function selector()
     {
         return '';
@@ -23,6 +24,7 @@ class App extends Component
      *
      * @param Browser $browser
      */
+    #[\Override]
     public function assert($browser): void
     {
         // Assume the app (window.rcmail) is always available
@@ -36,6 +38,7 @@ class App extends Component
      *
      * @return array
      */
+    #[\Override]
     public function elements()
     {
         return [];

--- a/tests/Browser/Components/Dialog.php
+++ b/tests/Browser/Components/Dialog.php
@@ -23,6 +23,7 @@ class Dialog extends Component
      *
      * @return string
      */
+    #[\Override]
     public function selector()
     {
         // work with the specified dialog (in case there's more than one)
@@ -35,6 +36,7 @@ class Dialog extends Component
      *
      * @param Browser $browser
      */
+    #[\Override]
     public function assert($browser): void
     {
         $browser->waitFor($this->selector());
@@ -45,6 +47,7 @@ class Dialog extends Component
      *
      * @return array
      */
+    #[\Override]
     public function elements()
     {
         return [

--- a/tests/Browser/Components/HtmlEditor.php
+++ b/tests/Browser/Components/HtmlEditor.php
@@ -25,6 +25,7 @@ class HtmlEditor extends Component
      *
      * @return string
      */
+    #[\Override]
     public function selector()
     {
         return '#' . $this->id;
@@ -35,6 +36,7 @@ class HtmlEditor extends Component
      *
      * @param Browser $browser
      */
+    #[\Override]
     public function assert($browser): void
     {
         $browser->waitFor($this->selector() . '.html-editor');
@@ -45,6 +47,7 @@ class HtmlEditor extends Component
      *
      * @return array
      */
+    #[\Override]
     public function elements()
     {
         return [

--- a/tests/Browser/Components/Popupmenu.php
+++ b/tests/Browser/Components/Popupmenu.php
@@ -22,6 +22,7 @@ class Popupmenu extends Component
      *
      * @return string
      */
+    #[\Override]
     public function selector()
     {
         return '#' . $this->id;
@@ -32,6 +33,7 @@ class Popupmenu extends Component
      *
      * @param Browser $browser
      */
+    #[\Override]
     public function assert($browser): void
     {
         $browser->waitFor($this->selector());
@@ -42,6 +44,7 @@ class Popupmenu extends Component
      *
      * @return array
      */
+    #[\Override]
     public function elements()
     {
         return [];

--- a/tests/Browser/Components/RecipientInput.php
+++ b/tests/Browser/Components/RecipientInput.php
@@ -23,6 +23,7 @@ class RecipientInput extends Component
      *
      * @return string
      */
+    #[\Override]
     public function selector()
     {
         return $this->selector;
@@ -33,6 +34,7 @@ class RecipientInput extends Component
      *
      * @param Browser $browser
      */
+    #[\Override]
     public function assert($browser): void
     {
         $browser->waitFor($this->selector() . ' @input');
@@ -43,6 +45,7 @@ class RecipientInput extends Component
      *
      * @return array
      */
+    #[\Override]
     public function elements()
     {
         return [

--- a/tests/Browser/Components/Taskmenu.php
+++ b/tests/Browser/Components/Taskmenu.php
@@ -14,6 +14,7 @@ class Taskmenu extends Component
      *
      * @return string
      */
+    #[\Override]
     public function selector()
     {
         return '#taskmenu';
@@ -24,6 +25,7 @@ class Taskmenu extends Component
      *
      * @param Browser $browser
      */
+    #[\Override]
     public function assert($browser): void
     {
         if ($browser->isPhone()) {
@@ -38,6 +40,7 @@ class Taskmenu extends Component
      *
      * @return array
      */
+    #[\Override]
     public function elements()
     {
         return [

--- a/tests/Browser/Components/Toolbarmenu.php
+++ b/tests/Browser/Components/Toolbarmenu.php
@@ -12,6 +12,7 @@ class Toolbarmenu extends Component
      *
      * @return string
      */
+    #[\Override]
     public function selector()
     {
         return '#toolbar-menu';
@@ -22,6 +23,7 @@ class Toolbarmenu extends Component
      *
      * @param Browser $browser
      */
+    #[\Override]
     public function assert($browser): void
     {
         if ($browser->isPhone()) {
@@ -36,6 +38,7 @@ class Toolbarmenu extends Component
      *
      * @return array
      */
+    #[\Override]
     public function elements()
     {
         return [

--- a/tests/Browser/Contacts/ContactsTest.php
+++ b/tests/Browser/Contacts/ContactsTest.php
@@ -7,6 +7,7 @@ use Tests\Browser\TestCase;
 
 class ContactsTest extends TestCase
 {
+    #[\Override]
     public static function setUpBeforeClass(): void
     {
         \bootstrap::init_db();

--- a/tests/Browser/Contacts/ExportTest.php
+++ b/tests/Browser/Contacts/ExportTest.php
@@ -6,6 +6,7 @@ use Tests\Browser\TestCase;
 
 class ExportTest extends TestCase
 {
+    #[\Override]
     public static function setUpBeforeClass(): void
     {
         \bootstrap::init_db();

--- a/tests/Browser/Contacts/GroupsTest.php
+++ b/tests/Browser/Contacts/GroupsTest.php
@@ -8,6 +8,7 @@ use Tests\Browser\TestCase;
 
 class GroupsTest extends TestCase
 {
+    #[\Override]
     public static function setUpBeforeClass(): void
     {
         \bootstrap::init_db();

--- a/tests/Browser/Contacts/ImportTest.php
+++ b/tests/Browser/Contacts/ImportTest.php
@@ -8,6 +8,7 @@ use Tests\Browser\TestCase;
 
 class ImportTest extends TestCase
 {
+    #[\Override]
     public static function setUpBeforeClass(): void
     {
         \bootstrap::init_db();

--- a/tests/Browser/Contacts/PrintTest.php
+++ b/tests/Browser/Contacts/PrintTest.php
@@ -7,6 +7,7 @@ use Tests\Browser\TestCase;
 
 class PrintTest extends TestCase
 {
+    #[\Override]
     public static function setUpBeforeClass(): void
     {
         \bootstrap::init_db();

--- a/tests/Browser/Logon/LoginTest.php
+++ b/tests/Browser/Logon/LoginTest.php
@@ -6,6 +6,7 @@ use Tests\Browser\Components\App;
 
 class LoginTest extends TestCase
 {
+    #[\Override]
     protected function setUp(): void
     {
         parent::setUp();

--- a/tests/Browser/Mail/ComposeTest.php
+++ b/tests/Browser/Mail/ComposeTest.php
@@ -10,6 +10,7 @@ use Tests\Browser\TestCase;
 
 class ComposeTest extends TestCase
 {
+    #[\Override]
     public static function setUpBeforeClass(): void
     {
         \bootstrap::init_db();

--- a/tests/Browser/Mail/GetunreadTest.php
+++ b/tests/Browser/Mail/GetunreadTest.php
@@ -8,6 +8,7 @@ class GetunreadTest extends TestCase
 {
     protected static $msgcount = 0;
 
+    #[\Override]
     public static function setUpBeforeClass(): void
     {
         \bootstrap::init_imap(true);

--- a/tests/Browser/Mail/ListTest.php
+++ b/tests/Browser/Mail/ListTest.php
@@ -9,6 +9,7 @@ class ListTest extends TestCase
 {
     protected static $msgcount = 0;
 
+    #[\Override]
     public static function setUpBeforeClass(): void
     {
         \bootstrap::init_imap(true);

--- a/tests/Browser/Mail/OpenTest.php
+++ b/tests/Browser/Mail/OpenTest.php
@@ -8,6 +8,7 @@ use Tests\Browser\TestCase;
 
 class OpenTest extends TestCase
 {
+    #[\Override]
     public static function setUpBeforeClass(): void
     {
         \bootstrap::init_imap(true);

--- a/tests/Browser/Mail/PreviewTest.php
+++ b/tests/Browser/Mail/PreviewTest.php
@@ -7,6 +7,7 @@ use Tests\Browser\TestCase;
 
 class PreviewTest extends TestCase
 {
+    #[\Override]
     public static function setUpBeforeClass(): void
     {
         \bootstrap::init_imap(true);

--- a/tests/Browser/Mail/PrintTest.php
+++ b/tests/Browser/Mail/PrintTest.php
@@ -8,6 +8,7 @@ use Tests\Browser\TestCase;
 
 class PrintTest extends TestCase
 {
+    #[\Override]
     public static function setUpBeforeClass(): void
     {
         \bootstrap::init_imap(true);

--- a/tests/Browser/Settings/FoldersTest.php
+++ b/tests/Browser/Settings/FoldersTest.php
@@ -7,6 +7,7 @@ use Tests\Browser\TestCase;
 
 class FoldersTest extends TestCase
 {
+    #[\Override]
     public static function setUpBeforeClass(): void
     {
         \bootstrap::init_imap(true);

--- a/tests/Browser/Settings/IdentitiesTest.php
+++ b/tests/Browser/Settings/IdentitiesTest.php
@@ -8,6 +8,7 @@ use Tests\Browser\TestCase;
 
 class IdentitiesTest extends TestCase
 {
+    #[\Override]
     public static function setUpBeforeClass(): void
     {
         \bootstrap::init_db();

--- a/tests/Browser/Settings/Preferences/GeneralTest.php
+++ b/tests/Browser/Settings/Preferences/GeneralTest.php
@@ -9,6 +9,7 @@ class GeneralTest extends TestCase
 {
     private $settings;
 
+    #[\Override]
     public static function setUpBeforeClass(): void
     {
         \bootstrap::init_db();

--- a/tests/Browser/Settings/Preferences/ServerTest.php
+++ b/tests/Browser/Settings/Preferences/ServerTest.php
@@ -9,6 +9,7 @@ class ServerTest extends TestCase
 {
     private $settings;
 
+    #[\Override]
     public static function setUpBeforeClass(): void
     {
         \bootstrap::init_db();

--- a/tests/Browser/Settings/ResponsesTest.php
+++ b/tests/Browser/Settings/ResponsesTest.php
@@ -9,6 +9,7 @@ use Tests\Browser\TestCase;
 
 class ResponsesTest extends TestCase
 {
+    #[\Override]
     public static function setUpBeforeClass(): void
     {
         \bootstrap::init_db();

--- a/tests/Browser/TestCase.php
+++ b/tests/Browser/TestCase.php
@@ -44,6 +44,7 @@ abstract class TestCase extends PHPUnitTestCase
      *
      * @return RemoteWebDriver
      */
+    #[\Override]
     protected function driver()
     {
         $options = (new ChromeOptions())->addArguments([
@@ -98,6 +99,7 @@ abstract class TestCase extends PHPUnitTestCase
     /**
      * Set up the test run
      */
+    #[\Override]
     protected function setUp(): void
     {
         parent::setUp();

--- a/tests/Browser/install.php
+++ b/tests/Browser/install.php
@@ -66,6 +66,7 @@ class Installer extends ChromeDriverCommand
      *
      * @return string
      */
+    #[Override]
     protected function getUrl(string $url)
     {
         return file_get_contents($url) ?: '';

--- a/tests/Framework/DBTest.php
+++ b/tests/Framework/DBTest.php
@@ -277,21 +277,25 @@ class rcube_db_test_wrapper extends rcube_db
 {
     public $queries = [];
 
+    #[Override]
     protected function query_execute($query)
     {
         $this->queries[] = $query;
     }
 
+    #[Override]
     public function db_connect($mode, $force = false)
     {
         $this->dbh = new rcube_db_test_dbh();
     }
 
+    #[Override]
     public function is_connected()
     {
         return true;
     }
 
+    #[Override]
     protected function debug($data) {}
 }
 

--- a/tests/OutputHtmlMock.php
+++ b/tests/OutputHtmlMock.php
@@ -38,6 +38,7 @@ class OutputHtmlMock extends rcmail_output_html
      * @param int   $delay  Delay in seconds
      * @param bool  $secure Redirect to secure location (see rcmail::url())
      */
+    #[Override]
     public function redirect($p = [], $delay = 1, $secure = false)
     {
         if (!empty($this->env['extwin'])) {
@@ -57,6 +58,7 @@ class OutputHtmlMock extends rcmail_output_html
      * @param string $templ Template name
      * @param bool   $exit  True if script should terminate (default)
      */
+    #[Override]
     public function send($templ = null, $exit = true)
     {
         $this->template = $templ;
@@ -74,6 +76,7 @@ class OutputHtmlMock extends rcmail_output_html
      * @param string $body    The output body
      * @param array  $headers Headers
      */
+    #[Override]
     public function sendExit($body = '', $headers = [])
     {
         foreach ($headers as $header) {
@@ -91,6 +94,7 @@ class OutputHtmlMock extends rcmail_output_html
      * @param int    $code    The HTTP error code
      * @param string $message The HTTP error message
      */
+    #[Override]
     public function sendExitError($code, $message = '')
     {
         $this->errorCode = $code;
@@ -104,6 +108,7 @@ class OutputHtmlMock extends rcmail_output_html
      *
      * @param string $template HTML template content
      */
+    #[Override]
     public function write($template = '')
     {
         ob_start();
@@ -121,6 +126,7 @@ class OutputHtmlMock extends rcmail_output_html
      *
      * @see http://php.net/manual/en/function.exit.php
      */
+    #[Override]
     public function parse($name = 'main', $exit = true, $write = true)
     {
         // ob_start();
@@ -136,6 +142,7 @@ class OutputHtmlMock extends rcmail_output_html
     /**
      * Delete all stored env variables and commands
      */
+    #[Override]
     public function reset($all = false)
     {
         parent::reset($all);
@@ -154,6 +161,7 @@ class OutputHtmlMock extends rcmail_output_html
      * @param string $header  The header string
      * @param bool   $replace Replace previously set header?
      */
+    #[Override]
     public function header($header, $replace = true)
     {
         $this->headers[] = $header;

--- a/tests/OutputJsonMock.php
+++ b/tests/OutputJsonMock.php
@@ -38,6 +38,7 @@ class OutputJsonMock extends rcmail_output_json
      *
      * @see rcmail::url()
      */
+    #[Override]
     public function redirect($p = [], $delay = 1)
     {
         $location = $this->app->url($p);
@@ -53,6 +54,7 @@ class OutputJsonMock extends rcmail_output_json
     /**
      * Send an AJAX response to the client.
      */
+    #[Override]
     public function send()
     {
         ob_start();
@@ -69,6 +71,7 @@ class OutputJsonMock extends rcmail_output_json
      * @param string $body    The output body
      * @param array  $headers Headers
      */
+    #[Override]
     public function sendExit($body = '', $headers = [])
     {
         foreach ($headers as $header) {
@@ -86,6 +89,7 @@ class OutputJsonMock extends rcmail_output_json
      * @param int    $code    The HTTP error code
      * @param string $message The HTTP error message
      */
+    #[Override]
     public function sendExitError($code, $message = '')
     {
         $this->errorCode = $code;
@@ -100,6 +104,7 @@ class OutputJsonMock extends rcmail_output_json
      * @param int    $code    Error code
      * @param string $message Error message
      */
+    #[Override]
     public function raise_error($code, $message)
     {
         if ($code == 403) {
@@ -119,6 +124,7 @@ class OutputJsonMock extends rcmail_output_json
     /**
      * Delete all stored env variables and commands
      */
+    #[Override]
     public function reset()
     {
         parent::reset();
@@ -137,6 +143,7 @@ class OutputJsonMock extends rcmail_output_json
      * @param string $header  The header string
      * @param bool   $replace Replace previously set header?
      */
+    #[Override]
     public function header($header, $replace = true)
     {
         $this->headers[] = $header;

--- a/tests/Rcmail/RcmailTest.php
+++ b/tests/Rcmail/RcmailTest.php
@@ -5,6 +5,7 @@
  */
 class Rcmail_Rcmail extends ActionTestCase
 {
+    #[Override]
     protected function setUp(): void
     {
         // set some HTTP env vars

--- a/tests/StderrMock.php
+++ b/tests/StderrMock.php
@@ -26,6 +26,7 @@ class StderrMock extends php_user_filter
     public static $redirect;
     public static $output = '';
 
+    #[Override]
     #[ReturnTypeWillChange]
     public function filter($in, $out, &$consumed, $closing)
     {


### PR DESCRIPTION
Helpful to detect removed/renamed parent methods of parent, possibly external, classes.

Generated based on phpstan data.

https://stitcher.io/blog/override-in-php-83 describes the advantages, for more details see https://wiki.php.net/rfc/marking_overriden_methods RFC