### PR TITLE
oauth: security: add support of nonce

### DIFF
--- a/tests/Rcmail/Oauth.php
+++ b/tests/Rcmail/Oauth.php
@@ -46,6 +46,7 @@ class Rcmail_RcmailOauth extends ActionTestCase
             "azp"                   => $this->config['client_id'],
             "session_state"         => "fake-session",
             "acr"                   => "1",
+            "nonce"                 => "fake-nonce",
             "sid"                   => "65f8d42c-dbbd-4f76-b5f3-44b540e4253a",
         ] + $this->identity;
 
@@ -200,6 +201,7 @@ class Rcmail_RcmailOauth extends ActionTestCase
         $this->assertSame($this->config['client_id'], $map['client_id']);
         $this->assertSame('code', $map['response_type']);
         $this->assertSame($_SESSION['oauth_state'], $map['state']);
+        $this->assertSame($_SESSION['oauth_nonce'], $map['nonce']);
         $this->assertMatchesRegularExpression('!http.*/login/oauth!', $map['redirect_uri']);
     }
 
@@ -222,6 +224,41 @@ class Rcmail_RcmailOauth extends ActionTestCase
 
         $this->assertSame("ERROR: OAuth token request failed: state parameter mismatch", trim(StderrMock::$output));
     }
+
+    /**
+     * Test request_access_token()
+     */
+    function test_request_access_token_with_wrong_nonce()
+    {
+        $payload = [
+          'token_type'          => 'Bearer',
+          'access_token'        => 'FAKE-ACCESS-TOKEN',
+          'expires_in'          => 300,
+          'refresh_token'       => 'FAKE-REFRESH-TOKEN',
+          'refresh_expires_in'  => 1800,
+          'id_token'            => $this->generate_fake_id_token(), // inject a generated identity
+          'not-before-policy'   => 0,
+          'session_state'       => 'fake-session',
+          'scope'               => 'openid profile email',
+        ];
+
+        $mock = new MockHandler([
+            new Response(200, ['Content-Type' => 'application/json'], json_encode($payload)),
+        ]);
+        $handler = HandlerStack::create($mock);
+        $oauth = new rcmail_oauth((array) $this->config + [
+            'http_options'  => ['handler' => $handler],
+        ]);
+        $oauth->init();
+
+        $_SESSION['oauth_state'] = "random-state"; // ensure state identiquals
+        $_SESSION['oauth_nonce'] = "wrong-nonce";
+        $response = $oauth->request_access_token('fake-code', 'random-state');
+
+        $this->assertFalse($response);
+
+    }
+
 
     /**
      * Test request_access_token() method
@@ -250,6 +287,7 @@ class Rcmail_RcmailOauth extends ActionTestCase
         $oauth->init();
 
         $_SESSION['oauth_state'] = "random-state"; // ensure state identiquals
+        $_SESSION['oauth_nonce'] = "fake-nonce";
         $response = $oauth->request_access_token('fake-code', 'random-state');
 
         $this->assertTrue(is_array($response));
@@ -288,6 +326,7 @@ class Rcmail_RcmailOauth extends ActionTestCase
         $oauth->init();
 
         $_SESSION['oauth_state'] = "random-state"; // ensure state identiquals
+        $_SESSION['oauth_nonce'] = "fake-nonce"; // ensure nonce identiquals
         $response = $oauth->request_access_token('fake-code', 'random-state');
 
         $this->assertTrue(is_array($response));


### PR DESCRIPTION
Hello please find the `nonce` security implemented from OIDC flow
(https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest)
It ensures that identity's answer from server belongs to the initial client's request