### PR TITLE
Bound upper PHP version in composer.json

### DIFF
--- a/composer.json-dist
+++ b/composer.json-dist
@@ -3,7 +3,7 @@
     "description": "The Roundcube Webmail suite",
     "license": "GPL-3.0-or-later",
     "require": {
-        "php": ">=7.3.0",
+        "php": ">=7.3 <8.4",
         "bacon/bacon-qr-code": "^2.0.8",
         "guzzlehttp/guzzle": "^7.3.0",
         "masterminds/html5": "~2.8.0",

--- a/installer/index.php
+++ b/installer/index.php
@@ -140,9 +140,9 @@ if ($RCI->configured && !$RCI->getprop('enable_installer') && empty($_SESSION['a
 <ol id="progress">
 <?php
 $include_steps = [
-    1 => './check.php',
-    2 => './config.php',
-    3 => './test.php',
+    1 => __DIR__ . '/check.php',
+    2 => __DIR__ . '/config.php',
+    3 => __DIR__ . '/test.php',
 ];
 
 if (!in_array($RCI->step, array_keys($include_steps))) {

--- a/plugins/password/drivers/tinycp.php
+++ b/plugins/password/drivers/tinycp.php
@@ -31,7 +31,7 @@ class rcube_tinycp_password
 {
     public function save($currpass, $newpass, $username)
     {
-        require_once 'TinyCPConnector.php';
+        require_once __DIR__ . '/TinyCPConnector.php';
 
         $tinycp_host   = rcmail::get_instance()->config->get('password_tinycp_host');
         $tinycp_port   = rcmail::get_instance()->config->get('password_tinycp_port');


### PR DESCRIPTION
Make sure Rouncube cannot be installed if not supported/tested for actual PHP version.

extracted from #9279