### PR TITLE
Fix "phpdoc_no_empty_return" CS

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -81,7 +81,6 @@ return (new PhpCsFixer\Config())
             'style' => 'post',
         ],
         'no_useless_else' => false,
-        'phpdoc_no_empty_return' => false,
         'psr_autoloading' => false,
         'strict_comparison' => false,
         'string_length_to_empty' => false,

--- a/plugins/example_addressbook/example_addressbook_backend.php
+++ b/plugins/example_addressbook/example_addressbook_backend.php
@@ -74,7 +74,7 @@ class example_addressbook_backend extends rcube_addressbook
         return $this->name;
     }
 
-    public function set_search_set($filter)
+    public function set_search_set($filter): void
     {
         $this->filter = $filter;
     }
@@ -84,7 +84,7 @@ class example_addressbook_backend extends rcube_addressbook
         return $this->filter;
     }
 
-    public function reset()
+    public function reset(): void
     {
         $this->result = null;
         $this->filter = null;

--- a/plugins/password/drivers/plesk.php
+++ b/plugins/password/drivers/plesk.php
@@ -103,10 +103,8 @@ class plesk_rpc
      * @param string $path plesk rpc path
      * @param string $user plesk user
      * @param string $user plesk password
-     *
-     * @return void
      */
-    public function init($host, $port, $path, $user, $pass)
+    public function init($host, $port, $path, $user, $pass): void
     {
         $headers = [
             sprintf('HTTP_AUTH_LOGIN: %s', $user),

--- a/program/include/rcmail_oauth.php
+++ b/program/include/rcmail_oauth.php
@@ -109,10 +109,8 @@ class rcmail_oauth
 
     /**
      * Helper to log oauth
-     *
-     * @return void
      */
-    private function logger($level, $message)
+    private function logger($level, $message): void
     {
         $token = $this->login_phase['token'] ?? $_SESSION['oauth_token'] ?? [];
         $sub = $token['identity']['sub'] ?? '-';
@@ -124,10 +122,8 @@ class rcmail_oauth
      * Helper to log oauth debug message (only if `oauth_debug`is true)
      *
      * XXX for debug only, please use rcube::raise_error to raise errors in a centralized place
-     *
-     * @return void
      */
-    public function log_debug(...$args)
+    public function log_debug(...$args): void
     {
         if ($this->options['debug']) {
             $this->logger('DEBUG', sprintf(...$args));
@@ -215,11 +211,9 @@ class rcmail_oauth
      *
      * use cache if defined
      *
-     * @return void
-     *
      * @see https://datatracker.ietf.org/doc/html/rfc8414
      */
-    protected function discover()
+    protected function discover(): void
     {
         $config_uri = $this->options['config_uri'];
         if (empty($config_uri)) {
@@ -279,10 +273,8 @@ class rcmail_oauth
 
     /**
      * Fetch JWKS certificates (use cache if active)
-     *
-     * @return void
      */
-    protected function fetch_jwks()
+    protected function fetch_jwks(): void
     {
         if (!$this->options['jwks_uri']) {
             // not activated
@@ -319,10 +311,8 @@ class rcmail_oauth
 
     /**
      * Initialize this instance
-     *
-     * @return void
      */
-    public function init()
+    public function init(): void
     {
         // important must be called before is_enabled()
         $this->discover();
@@ -381,8 +371,6 @@ class rcmail_oauth
      *
      * Append Oauth button on login page if defined (this is a hook)
      * can also hide default user/pass form if flag oauth_login_redirect is true
-     *
-     * @return void
      */
     public function loginform_content(array $form_content)
     {
@@ -506,10 +494,8 @@ class rcmail_oauth
      * Authorization Code Request
      *
      * @see https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.1
-     *
-     * @return void
      */
-    public function login_redirect()
+    public function login_redirect(): void
     {
         if (empty($this->options['auth_uri']) || empty($this->options['client_id'])) {
             // log error about missing config options
@@ -809,10 +795,8 @@ class rcmail_oauth
      * Warning: cache TTL should be at least > refresh_token frequency
      *
      * @param string $sub the sub of the identity
-     *
-     * @return void
      */
-    public function schedule_token_revocation($sub)
+    public function schedule_token_revocation($sub): void
     {
         if ($this->cache === null) {
             rcube::raise_error(['message' => 'received a token revocation request, you must activate `oauth_cache` to enable this feature'], true, false);
@@ -943,10 +927,8 @@ class rcmail_oauth
      * Modify some properties of the received auth response
      *
      * @param array $data
-     *
-     * @return void
      */
-    protected function mask_auth_data(&$data)
+    protected function mask_auth_data(&$data): void
     {
         // remove by security access_token as it is crypted in $_SESSION['password']
         unset($data['access_token']);
@@ -1010,10 +992,8 @@ class rcmail_oauth
      * Callback for 'refresh' hook
      *
      * @param array $options
-     *
-     * @return void
      */
-    public function refresh($options)
+    public function refresh($options): void
     {
         if (!isset($_SESSION['oauth_token'])) {
             return;
@@ -1271,11 +1251,9 @@ class rcmail_oauth
      * will generate during the logout task the RP-initiated Logout URL and
      * store it in `logout_redirect_url`
      *
-     * @return void
-     *
      * @see https://openid.net/specs/openid-connect-rpinitiated-1_0.html
      */
-    public function handle_logout()
+    public function handle_logout(): void
     {
         // if no logout URI, or no refresh token, safe to give up
         if (!$this->options['logout_uri'] || !isset($_SESSION['oauth_token'])) {

--- a/program/include/rcmail_output.php
+++ b/program/include/rcmail_output.php
@@ -94,8 +94,6 @@ abstract class rcmail_output extends rcube_output
      *
      * @param string   $name Object name
      * @param callable $func Function name to call
-     *
-     * @return void
      */
     public function add_handler($name, $func)
     {
@@ -106,8 +104,6 @@ abstract class rcmail_output extends rcube_output
      * Register a list of template object handlers
      *
      * @param array $handlers Hash array with object=>handler pairs
-     *
-     * @return void
      */
     public function add_handlers($handlers)
     {
@@ -119,8 +115,6 @@ abstract class rcmail_output extends rcube_output
      *
      * @param string $header  The header string
      * @param bool   $replace Replace previously set header?
-     *
-     * @return void
      */
     public function header($header, $replace = true)
     {

--- a/program/include/rcmail_output.php
+++ b/program/include/rcmail_output.php
@@ -133,7 +133,7 @@ abstract class rcmail_output extends rcube_output
      * @param string $body    The output body
      * @param array  $headers Headers
      *
-     * @return void
+     * @return never
      */
     public function sendExit($body = '', $headers = [])
     {
@@ -151,7 +151,7 @@ abstract class rcmail_output extends rcube_output
      * @param int    $code    The HTTP error code
      * @param string $message The HTTP error message
      *
-     * @return void
+     * @return never
      */
     public function sendExitError($code, $message = '')
     {

--- a/program/include/rcmail_output_html.php
+++ b/program/include/rcmail_output_html.php
@@ -2407,10 +2407,8 @@ class rcmail_output_html extends rcmail_output
      * Loads javascript code for images preloading
      *
      * @param array $attrib Named parameters
-     *
-     * @return void
      */
-    protected function preloader($attrib)
+    protected function preloader($attrib): void
     {
         $images = preg_split('/[\s\t\n,]+/', $attrib['images'], -1, \PREG_SPLIT_NO_EMPTY);
         $images = array_map([$this, 'abs_url'], $images);

--- a/program/lib/Roundcube/rcube_addressbook.php
+++ b/program/lib/Roundcube/rcube_addressbook.php
@@ -127,10 +127,8 @@ abstract class rcube_addressbook
      * operation.
      *
      * @param mixed $filter Search params to use in listing method, obtained by get_search_set()
-     *
-     * @return void
      */
-    abstract public function set_search_set($filter);
+    abstract public function set_search_set($filter): void;
 
     /**
      * Getter for saved search properties.
@@ -143,10 +141,8 @@ abstract class rcube_addressbook
 
     /**
      * Reset saved results and search parameters
-     *
-     * @return void
      */
-    abstract public function reset();
+    abstract public function reset(): void;
 
     /**
      * Refresh saved search set after data has changed

--- a/program/lib/Roundcube/rcube_contacts.php
+++ b/program/lib/Roundcube/rcube_contacts.php
@@ -90,7 +90,7 @@ class rcube_contacts extends rcube_addressbook
      *
      * @param string $filter SQL params to use in listing method
      */
-    public function set_search_set($filter)
+    public function set_search_set($filter): void
     {
         $this->filter = $filter;
         $this->cache  = null;
@@ -119,7 +119,7 @@ class rcube_contacts extends rcube_addressbook
     /**
      * Reset all saved results and search parameters
      */
-    public function reset()
+    public function reset(): void
     {
         $this->result = null;
         $this->filter = null;

--- a/program/lib/Roundcube/rcube_ldap.php
+++ b/program/lib/Roundcube/rcube_ldap.php
@@ -566,7 +566,7 @@ class rcube_ldap extends rcube_addressbook
      *
      * @param string $filter Filter string
      */
-    public function set_search_set($filter)
+    public function set_search_set($filter): void
     {
         $this->filter = $filter;
     }
@@ -584,7 +584,7 @@ class rcube_ldap extends rcube_addressbook
     /**
      * Reset all saved results and search parameters
      */
-    public function reset()
+    public function reset(): void
     {
         $this->result      = null;
         $this->ldap_result = null;

--- a/tests/Browser/Components/App.php
+++ b/tests/Browser/Components/App.php
@@ -22,10 +22,8 @@ class App extends Component
      * Assert that the browser page contains the component.
      *
      * @param Browser $browser
-     *
-     * @return void
      */
-    public function assert($browser)
+    public function assert($browser): void
     {
         // Assume the app (window.rcmail) is always available
         // we can't assert that before we visit the page

--- a/tests/Browser/Components/Dialog.php
+++ b/tests/Browser/Components/Dialog.php
@@ -33,10 +33,8 @@ class Dialog extends Component
      * Assert that the browser page contains the component.
      *
      * @param Browser $browser
-     *
-     * @return void
      */
-    public function assert($browser)
+    public function assert($browser): void
     {
         $browser->waitFor($this->selector());
     }

--- a/tests/Browser/Components/HtmlEditor.php
+++ b/tests/Browser/Components/HtmlEditor.php
@@ -34,10 +34,8 @@ class HtmlEditor extends Component
      * Assert that the browser page contains the component.
      *
      * @param Browser $browser
-     *
-     * @return void
      */
-    public function assert($browser)
+    public function assert($browser): void
     {
         $browser->waitFor($this->selector() . '.html-editor');
     }

--- a/tests/Browser/Components/Popupmenu.php
+++ b/tests/Browser/Components/Popupmenu.php
@@ -31,10 +31,8 @@ class Popupmenu extends Component
      * Assert that the browser page contains the component.
      *
      * @param Browser $browser
-     *
-     * @return void
      */
-    public function assert($browser)
+    public function assert($browser): void
     {
         $browser->waitFor($this->selector());
     }

--- a/tests/Browser/Components/RecipientInput.php
+++ b/tests/Browser/Components/RecipientInput.php
@@ -32,10 +32,8 @@ class RecipientInput extends Component
      * Assert that the browser page contains the component.
      *
      * @param Browser $browser
-     *
-     * @return void
      */
-    public function assert($browser)
+    public function assert($browser): void
     {
         $browser->waitFor($this->selector() . ' @input');
     }

--- a/tests/Browser/Components/Taskmenu.php
+++ b/tests/Browser/Components/Taskmenu.php
@@ -23,10 +23,8 @@ class Taskmenu extends Component
      * Assert that the browser page contains the component.
      *
      * @param Browser $browser
-     *
-     * @return void
      */
-    public function assert($browser)
+    public function assert($browser): void
     {
         if ($browser->isPhone()) {
             $browser->assertPresent($this->selector());

--- a/tests/Browser/Components/Toolbarmenu.php
+++ b/tests/Browser/Components/Toolbarmenu.php
@@ -21,10 +21,8 @@ class Toolbarmenu extends Component
      * Assert that the browser page contains the component.
      *
      * @param Browser $browser
-     *
-     * @return void
      */
-    public function assert($browser)
+    public function assert($browser): void
     {
         if ($browser->isPhone()) {
             $browser->assertPresent($this->selector());

--- a/tests/Browser/TestCase.php
+++ b/tests/Browser/TestCase.php
@@ -32,10 +32,8 @@ abstract class TestCase extends PHPUnitTestCase
      * Prepare for Dusk test execution.
      *
      * @beforeClass
-     *
-     * @return void
      */
-    public static function prepare()
+    public static function prepare(): void
     {
         static::startWebServer();
         static::startChromeDriver();

--- a/tests/Browser/install.php
+++ b/tests/Browser/install.php
@@ -33,10 +33,8 @@ class Installer extends Laravel\Dusk\Console\ChromeDriverCommand
      * Execute the console command.
      *
      * @param string $version
-     *
-     * @return void
      */
-    public function install($version = '')
+    public function install($version = ''): void
     {
         $os = Laravel\Dusk\OperatingSystem::id();
         $version = trim($version);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -106,10 +106,8 @@ function getProperty($object, $name, $class = null)
  * @param string               $name   Property name
  * @param mixed                $value  Property value
  * @param string               $class  Object  class
- *
- * @return void
  */
-function setProperty($object, $name, $value, $class = null)
+function setProperty($object, $name, $value, $class = null): void
 {
     $reflection = new ReflectionClass($class ?: get_class($object));
 


### PR DESCRIPTION
The rule enforces developers to use native `void` return type.

In tests, this is easy to do, in other places, I reviewed the fixes to be back compatible as much as possible.