### PR TITLE
Don't render quota if it's unlimited

### DIFF
--- a/program/actions/mail/index.php
+++ b/program/actions/mail/index.php
@@ -114,7 +114,7 @@ class rcmail_action_mail_index extends rcmail_action
             $rcmail->output->set_env('threads', $threading || $rcmail->storage->get_capability('THREAD'));
             $rcmail->output->set_env('reply_all_mode', (int) $rcmail->config->get('reply_all_mode'));
             $rcmail->output->set_env('layout', $rcmail->config->get('layout') ?: 'widescreen');
-            $rcmail->output->set_env('quota', $rcmail->storage->get_capability('QUOTA'));
+            self::quota_set_env();
 
             // set special folders
             foreach (['drafts', 'trash', 'junk'] as $mbox) {

--- a/program/actions/settings/folders.php
+++ b/program/actions/settings/folders.php
@@ -34,7 +34,7 @@ class rcmail_action_settings_folders extends rcmail_action_settings_index
 
         $rcmail->output->set_pagetitle($rcmail->gettext('folders'));
         $rcmail->output->set_env('prefix_ns', $storage->get_namespace('prefix'));
-        $rcmail->output->set_env('quota', (bool) $storage->get_capability('QUOTA'));
+        self::quota_set_env();
         $rcmail->output->include_script('treelist.js');
 
         // add some labels to client

--- a/program/include/rcmail_action.php
+++ b/program/include/rcmail_action.php
@@ -165,6 +165,10 @@ abstract class rcmail_action
         // need to do that manually (the return value is `false` if the server
         // doesn't support it).
         $quota = $rcmail->storage->get_quota();
+        // Return early if the server doesn't support quotas anyway.
+        if ($quota === false) {
+            $rcmail->output->set_env('quota', false);
+        }
         $zero_as_unlimited = (bool) $rcmail->config->get('quota_zero_as_unlimited');
         // Show the quota display only if it's not unlimited.
         $show_quota = is_array($quota) && !($quota['total'] === 0 && $zero_as_unlimited);

--- a/program/include/rcmail_action.php
+++ b/program/include/rcmail_action.php
@@ -168,6 +168,7 @@ abstract class rcmail_action
         // Return early if the server doesn't support quotas anyway.
         if ($quota === false) {
             $rcmail->output->set_env('quota', false);
+            return;
         }
         $zero_as_unlimited = (bool) $rcmail->config->get('quota_zero_as_unlimited');
         // Show the quota display only if it's not unlimited.

--- a/program/include/rcmail_action.php
+++ b/program/include/rcmail_action.php
@@ -152,6 +152,26 @@ abstract class rcmail_action
     }
 
     /**
+     * Set env-flag for quota. It is used in templates to determine if quota
+     * data should be displayed.
+     * In case the quota is zero and the config option
+     * `quota_zero_as_unlimited` is true, then the account has no quota and
+     * should not be shown a meaningless (or even wrong) quota-display.
+     */
+    public static function quota_set_env()
+    {
+        $rcmail = rcmail::get_instance();
+        // This call also checks the QUOTA capability of the server, we don't
+        // need to do that manually (the return value is `false` if the server
+        // doesn't support it).
+        $quota = $rcmail->storage->get_quota();
+        $zero_as_unlimited = (bool) $rcmail->config->get("quota_zero_as_unlimited");
+        // Show the quota display only if it's not unlimited.
+        $show_quota = is_array($quota) && !($quota['total'] === 0 && $zero_as_unlimited);
+        $rcmail->output->set_env('quota', $show_quota);
+    }
+    
+    /**
      * Return HTML for quota indicator object
      *
      * @param array $attrib Named parameters

--- a/program/include/rcmail_action.php
+++ b/program/include/rcmail_action.php
@@ -171,6 +171,11 @@ abstract class rcmail_action
             return;
         }
         $zero_as_unlimited = (bool) $rcmail->config->get('quota_zero_as_unlimited');
+        
+        if($zero_as_unlimited === false) {
+        	$rcmail->output->set_env('quota', true);
+        	return;
+        }
         // Show the quota display only if it's not unlimited.
         $show_quota = is_array($quota) && !($quota['total'] === 0 && $zero_as_unlimited);
         $rcmail->output->set_env('quota', $show_quota);

--- a/program/include/rcmail_action.php
+++ b/program/include/rcmail_action.php
@@ -165,12 +165,12 @@ abstract class rcmail_action
         // need to do that manually (the return value is `false` if the server
         // doesn't support it).
         $quota = $rcmail->storage->get_quota();
-        $zero_as_unlimited = (bool) $rcmail->config->get("quota_zero_as_unlimited");
+        $zero_as_unlimited = (bool) $rcmail->config->get('quota_zero_as_unlimited');
         // Show the quota display only if it's not unlimited.
         $show_quota = is_array($quota) && !($quota['total'] === 0 && $zero_as_unlimited);
         $rcmail->output->set_env('quota', $show_quota);
     }
-    
+
     /**
      * Return HTML for quota indicator object
      *

--- a/program/include/rcmail_action.php
+++ b/program/include/rcmail_action.php
@@ -154,9 +154,6 @@ abstract class rcmail_action
     /**
      * Set env-flag for quota. It is used in templates to determine if quota
      * data should be displayed.
-     * In case the quota is zero and the config option
-     * `quota_zero_as_unlimited` is true, then the account has no quota and
-     * should not be shown a meaningless (or even wrong) quota-display.
      */
     public static function quota_set_env()
     {

--- a/tests/Actions/Mail/Index.php
+++ b/tests/Actions/Mail/Index.php
@@ -74,7 +74,8 @@ class Actions_Mail_Index extends ActionTestCase
             ->registerFunction('get_capability', false)
             ->registerFunction('set_folder')
             ->registerFunction('set_page')
-            ->registerFunction('set_threading');
+            ->registerFunction('set_threading')
+            ->registerFunction('get_quota');
 
         $action->run();
 

--- a/tests/Browser/Mail/MailTest.php
+++ b/tests/Browser/Mail/MailTest.php
@@ -21,7 +21,6 @@ class MailTest extends TestCase
                     'qsearchbox',
                     'mailboxlist',
                     'messagelist',
-                    'quotadisplay',
                     'search_filter',
                     'countdisplay',
                 ]);

--- a/tests/Browser/Settings/FoldersTest.php
+++ b/tests/Browser/Settings/FoldersTest.php
@@ -27,7 +27,7 @@ class FoldersTest extends TestCase
                 $browser->assertEnv('action', 'folders');
 
                 // these objects should be there always
-                $browser->assertObjects(['quotadisplay', 'subscriptionlist']);
+                $browser->assertObjects(['subscriptionlist']);
             });
 
             if ($browser->isDesktop()) {


### PR DESCRIPTION
In case an accounts's quota is zero and the config option `quota_zero_as_unlimited` is true, then the account has no quota and should not be shown a meaningless (or even wrong) quota-display.

This introduces a new function to avoid repeating identical code in two places.

If a template doesn't check for the env-flag it still can render quota details.

This PR closes #8994.

One question and two notes:
* This doesn't include a Changelog-entry yet – should I add one or do you rather compile those yourselves?
* Also I didn't touch the templates, so the `.footer`-element of the column remains even if it is blank (because the `if`-clauses in the templates are inside that element) – I'm not sure if that needs to stay like that but didn't feel comfortable changing the template without knowing why it was written like this. And I think it looks okay, event with an empty element. If you want the footer gone, please let me know.
* And since there's no test case for this feature I didn't change any. Adding a fresh one is a little out of my time budget currently, because I'd need to dive into the setup first.