### PR TITLE
Fix "php_unit_test_case_static_method_calls" CS

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -90,7 +90,6 @@ return (new Config())
             'suffix' => '_cases',
         ],
         'php_unit_method_casing' => false,
-        'php_unit_test_case_static_method_calls' => false,
         'psr_autoloading' => false,
         'strict_comparison' => false,
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -16,8 +16,7 @@ parameters:
         - '~^Variable variables are not allowed.~'
         - '~^Variable .* might not be defined\.~'
         - '~Call to function array_filter\(\) requires parameter #2 to be passed to avoid loose comparison semantics.~'
-        # relax strict rules - move to phpstan baseline once almost all l6 errors are fixed
-        - '~^Dynamic call to static method .+\.~' # TODO in https://github.com/roundcube/roundcubemail/pull/9314
+        - '~^Dynamic call to static method .+\.~'
         - '~^Construct empty\(\) is not allowed\. Use more strict comparison\.~'
         - '~^Loose comparison via "[=!]=" is not allowed\.~'
         - '~^Casting to .+ something that''s already .+\.~'

--- a/plugins/acl/tests/AclTest.php
+++ b/plugins/acl/tests/AclTest.php
@@ -10,8 +10,8 @@ class Acl_Plugin extends ActionTestCase
         $rcube = rcube::get_instance();
         $plugin = new acl($rcube->plugins);
 
-        $this->assertInstanceOf('acl', $plugin);
-        $this->assertInstanceOf('rcube_plugin', $plugin);
+        self::assertInstanceOf('acl', $plugin);
+        self::assertInstanceOf('rcube_plugin', $plugin);
 
         $plugin->init();
     }

--- a/plugins/additional_message_headers/tests/AdditionalMessageHeadersTest.php
+++ b/plugins/additional_message_headers/tests/AdditionalMessageHeadersTest.php
@@ -10,8 +10,8 @@ class AdditionalMessageHeaders_Plugin extends ActionTestCase
         $rcube = rcube::get_instance();
         $plugin = new additional_message_headers($rcube->plugins);
 
-        $this->assertInstanceOf('additional_message_headers', $plugin);
-        $this->assertInstanceOf('rcube_plugin', $plugin);
+        self::assertInstanceOf('additional_message_headers', $plugin);
+        self::assertInstanceOf('rcube_plugin', $plugin);
 
         $plugin->init();
 
@@ -19,12 +19,12 @@ class AdditionalMessageHeaders_Plugin extends ActionTestCase
 
         $result = $plugin->message_headers($args);
 
-        $this->assertSame("MIME-Version: 1.0\r\n", $result['message']->txtHeaders());
+        self::assertSame("MIME-Version: 1.0\r\n", $result['message']->txtHeaders());
 
         $rcube->config->set('additional_message_headers', ['X-Test' => 'Test']);
 
         $result = $plugin->message_headers($args);
 
-        $this->assertSame("MIME-Version: 1.0\r\nX-Test: Test\r\n", $result['message']->txtHeaders());
+        self::assertSame("MIME-Version: 1.0\r\nX-Test: Test\r\n", $result['message']->txtHeaders());
     }
 }

--- a/plugins/archive/tests/ArchiveTest.php
+++ b/plugins/archive/tests/ArchiveTest.php
@@ -12,8 +12,8 @@ class Archive_Plugin extends TestCase
         $rcube = rcube::get_instance();
         $plugin = new archive($rcube->plugins);
 
-        $this->assertInstanceOf('archive', $plugin);
-        $this->assertInstanceOf('rcube_plugin', $plugin);
+        self::assertInstanceOf('archive', $plugin);
+        self::assertInstanceOf('rcube_plugin', $plugin);
 
         $plugin->init();
     }
@@ -30,12 +30,12 @@ class Archive_Plugin extends TestCase
 
         $result = $plugin->prefs_table($args);
 
-        $this->assertSame(
+        self::assertSame(
             '<label for="ff_read_on_archive">Mark the message as read on archive</label>',
             $result['blocks']['main']['options']['read_on_archive']['title']
         );
 
-        $this->assertSame(
+        self::assertSame(
             '<input name="_read_on_archive" id="ff_read_on_archive" value="1" type="checkbox">',
             $result['blocks']['main']['options']['read_on_archive']['content']
         );
@@ -56,27 +56,27 @@ class Archive_Plugin extends TestCase
 
         $result = $plugin->prefs_save($args);
 
-        $this->assertSame('', $result['prefs']['archive_type']);
+        self::assertSame('', $result['prefs']['archive_type']);
 
         $_POST = ['_archive_type' => 'aaa'];
         $args = ['section' => 'folders', 'prefs' => []];
 
         $result = $plugin->prefs_save($args);
 
-        $this->assertSame('aaa', $result['prefs']['archive_type']);
+        self::assertSame('aaa', $result['prefs']['archive_type']);
 
         $_POST = [];
         $args = ['section' => 'server', 'prefs' => []];
 
         $result = $plugin->prefs_save($args);
 
-        $this->assertFalse($result['prefs']['read_on_archive']);
+        self::assertFalse($result['prefs']['read_on_archive']);
 
         $_POST = ['_read_on_archive' => 1];
         $args = ['section' => 'server', 'prefs' => []];
 
         $result = $plugin->prefs_save($args);
 
-        $this->assertTrue($result['prefs']['read_on_archive']);
+        self::assertTrue($result['prefs']['read_on_archive']);
     }
 }

--- a/plugins/attachment_reminder/tests/AttachmentReminderTest.php
+++ b/plugins/attachment_reminder/tests/AttachmentReminderTest.php
@@ -12,8 +12,8 @@ class AttachmentReminder_Plugin extends TestCase
         $rcube = rcube::get_instance();
         $plugin = new attachment_reminder($rcube->plugins);
 
-        $this->assertInstanceOf('attachment_reminder', $plugin);
-        $this->assertInstanceOf('rcube_plugin', $plugin);
+        self::assertInstanceOf('attachment_reminder', $plugin);
+        self::assertInstanceOf('rcube_plugin', $plugin);
 
         $plugin->init();
     }
@@ -30,11 +30,11 @@ class AttachmentReminder_Plugin extends TestCase
 
         $result = $plugin->prefs_list($args);
 
-        $this->assertSame(
+        self::assertSame(
             '<label for="rcmfd_attachment_reminder">Remind about forgotten attachments</label>',
             $result['blocks']['main']['options']['attachment_reminder']['title']
         );
-        $this->assertSame(
+        self::assertSame(
             '<input name="_attachment_reminder" id="rcmfd_attachment_reminder" value="1" type="checkbox">',
             $result['blocks']['main']['options']['attachment_reminder']['content']
         );
@@ -53,13 +53,13 @@ class AttachmentReminder_Plugin extends TestCase
 
         $result = $plugin->prefs_save($args);
 
-        $this->assertFalse($result['prefs']['attachment_reminder']);
+        self::assertFalse($result['prefs']['attachment_reminder']);
 
         $_POST = ['_attachment_reminder' => 1];
         $args = ['section' => 'compose', 'prefs' => []];
 
         $result = $plugin->prefs_save($args);
 
-        $this->assertTrue($result['prefs']['attachment_reminder']);
+        self::assertTrue($result['prefs']['attachment_reminder']);
     }
 }

--- a/plugins/autologon/tests/AutologonTest.php
+++ b/plugins/autologon/tests/AutologonTest.php
@@ -12,8 +12,8 @@ class Autologon_Plugin extends TestCase
         $rcube = rcube::get_instance();
         $plugin = new autologon($rcube->plugins);
 
-        $this->assertInstanceOf('autologon', $plugin);
-        $this->assertInstanceOf('rcube_plugin', $plugin);
+        self::assertInstanceOf('autologon', $plugin);
+        self::assertInstanceOf('rcube_plugin', $plugin);
 
         // TODO
         $plugin->startup([]);

--- a/plugins/autologout/tests/AutologoutTest.php
+++ b/plugins/autologout/tests/AutologoutTest.php
@@ -12,8 +12,8 @@ class Autologout_Plugin extends TestCase
         $rcube = rcube::get_instance();
         $plugin = new autologout($rcube->plugins);
 
-        $this->assertInstanceOf('autologout', $plugin);
-        $this->assertInstanceOf('rcube_plugin', $plugin);
+        self::assertInstanceOf('autologout', $plugin);
+        self::assertInstanceOf('rcube_plugin', $plugin);
 
         // TODO
         $plugin->startup([]);

--- a/plugins/database_attachments/tests/DatabaseAttachmentsTest.php
+++ b/plugins/database_attachments/tests/DatabaseAttachmentsTest.php
@@ -12,7 +12,7 @@ class DatabaseAttachments_Plugin extends TestCase
         $rcube = rcube::get_instance();
         $plugin = new database_attachments($rcube->plugins);
 
-        $this->assertInstanceOf('database_attachments', $plugin);
-        $this->assertInstanceOf('rcube_plugin', $plugin);
+        self::assertInstanceOf('database_attachments', $plugin);
+        self::assertInstanceOf('rcube_plugin', $plugin);
     }
 }

--- a/plugins/debug_logger/tests/DebugLoggerTest.php
+++ b/plugins/debug_logger/tests/DebugLoggerTest.php
@@ -12,7 +12,7 @@ class DebugLogger_Plugin extends TestCase
         $rcube = rcube::get_instance();
         $plugin = new debug_logger($rcube->plugins);
 
-        $this->assertInstanceOf('debug_logger', $plugin);
-        $this->assertInstanceOf('rcube_plugin', $plugin);
+        self::assertInstanceOf('debug_logger', $plugin);
+        self::assertInstanceOf('rcube_plugin', $plugin);
     }
 }

--- a/plugins/emoticons/tests/EmoticonsTest.php
+++ b/plugins/emoticons/tests/EmoticonsTest.php
@@ -12,7 +12,7 @@ class Emoticons_Plugin extends TestCase
         $rcube = rcube::get_instance();
         $plugin = new emoticons($rcube->plugins);
 
-        $this->assertInstanceOf('emoticons', $plugin);
-        $this->assertInstanceOf('rcube_plugin', $plugin);
+        self::assertInstanceOf('emoticons', $plugin);
+        self::assertInstanceOf('rcube_plugin', $plugin);
     }
 }

--- a/plugins/enigma/tests/EnigmaDriverGnupgTest.php
+++ b/plugins/enigma/tests/EnigmaDriverGnupgTest.php
@@ -12,6 +12,6 @@ class Enigma_EnigmaDriverGnupg extends TestCase
         $rcube = rcube::get_instance();
         $plugin = new enigma_driver_gnupg($rcube->user);
 
-        $this->assertInstanceOf('enigma_driver', $plugin);
+        self::assertInstanceOf('enigma_driver', $plugin);
     }
 }

--- a/plugins/enigma/tests/EnigmaEngineTest.php
+++ b/plugins/enigma/tests/EnigmaEngineTest.php
@@ -16,8 +16,8 @@ class Enigma_EnigmaEngine extends TestCase
 
         $engine->password_handler();
 
-        $this->assertTrue(!array_key_exists('enigma_pass', $_SESSION));
-        $this->assertSame([], $engine->get_passwords());
+        self::assertTrue(!array_key_exists('enigma_pass', $_SESSION));
+        self::assertSame([], $engine->get_passwords());
 
         $_POST = ['_keyid' => 'abc', '_passwd' => '123<a>456'];
 
@@ -26,9 +26,9 @@ class Enigma_EnigmaEngine extends TestCase
 
         $store = unserialize($rcube->decrypt($_SESSION['enigma_pass']));
 
-        $this->assertCount(2, $store['ABC']);
-        $this->assertSame('123<a>456', $store['ABC'][0]);
-        $this->assertEqualsWithDelta($time, $store['ABC'][1], 1);
-        $this->assertSame(['ABC' => '123<a>456'], $engine->get_passwords());
+        self::assertCount(2, $store['ABC']);
+        self::assertSame('123<a>456', $store['ABC'][0]);
+        self::assertEqualsWithDelta($time, $store['ABC'][1], 1);
+        self::assertSame(['ABC' => '123<a>456'], $engine->get_passwords());
     }
 }

--- a/plugins/enigma/tests/EnigmaErrorTest.php
+++ b/plugins/enigma/tests/EnigmaErrorTest.php
@@ -11,10 +11,10 @@ class Enigma_EnigmaError extends TestCase
     {
         $error = new enigma_error(enigma_error::EXPIRED, 'message', ['test1' => 'test2']);
 
-        $this->assertInstanceOf('enigma_error', $error);
-        $this->assertSame(enigma_error::EXPIRED, $error->getCode());
-        $this->assertSame('message', $error->getMessage());
-        $this->assertSame('test2', $error->getData('test1'));
-        $this->assertSame(['test1' => 'test2'], $error->getData());
+        self::assertInstanceOf('enigma_error', $error);
+        self::assertSame(enigma_error::EXPIRED, $error->getCode());
+        self::assertSame('message', $error->getMessage());
+        self::assertSame('test2', $error->getData('test1'));
+        self::assertSame(['test1' => 'test2'], $error->getData());
     }
 }

--- a/plugins/enigma/tests/EnigmaKeyTest.php
+++ b/plugins/enigma/tests/EnigmaKeyTest.php
@@ -11,14 +11,14 @@ class Enigma_EnigmaKey extends TestCase
     {
         $key = new enigma_key();
 
-        $this->assertInstanceOf('enigma_key', $key);
-        $this->assertSame(enigma_key::TYPE_UNKNOWN, $key->get_type());
-        $this->assertFalse($key->is_revoked());
-        $this->assertFalse($key->is_valid());
-        $this->assertFalse($key->is_private());
-        $this->assertNull($key->find_subkey('test@domain.com', enigma_key::CAN_SIGN));
+        self::assertInstanceOf('enigma_key', $key);
+        self::assertSame(enigma_key::TYPE_UNKNOWN, $key->get_type());
+        self::assertFalse($key->is_revoked());
+        self::assertFalse($key->is_valid());
+        self::assertFalse($key->is_private());
+        self::assertNull($key->find_subkey('test@domain.com', enigma_key::CAN_SIGN));
 
-        $this->assertSame('89E037A5', $key::format_id('04622F2089E037A5'));
+        self::assertSame('89E037A5', $key::format_id('04622F2089E037A5'));
         // TODO: format_fingerprint();
     }
 }

--- a/plugins/enigma/tests/EnigmaMimeMessageTest.php
+++ b/plugins/enigma/tests/EnigmaMimeMessageTest.php
@@ -12,16 +12,16 @@ class Enigma_EnigmaMimeMessage extends TestCase
         $mime = new Mail_mime();
         $message1 = new enigma_mime_message($mime, enigma_mime_message::PGP_SIGNED);
 
-        $this->assertFalse($message1->isMultipart());
+        self::assertFalse($message1->isMultipart());
 
         $mime->setHTMLBody('<html></html>');
         $message = new enigma_mime_message($mime, enigma_mime_message::PGP_SIGNED);
 
-        $this->assertTrue($message->isMultipart());
+        self::assertTrue($message->isMultipart());
 
         $message = new enigma_mime_message($message1, enigma_mime_message::PGP_SIGNED);
 
-        $this->assertTrue($message->isMultipart());
+        self::assertTrue($message->isMultipart());
     }
 
     /**
@@ -32,12 +32,12 @@ class Enigma_EnigmaMimeMessage extends TestCase
         $mime = new Mail_mime();
         $message = new enigma_mime_message($mime, enigma_mime_message::PGP_SIGNED);
 
-        $this->assertNull($message->getFromAddress());
+        self::assertNull($message->getFromAddress());
 
         $mime->setFrom('test@domain.com');
         $message = new enigma_mime_message($mime, enigma_mime_message::PGP_SIGNED);
 
-        $this->assertSame('test@domain.com', $message->getFromAddress());
+        self::assertSame('test@domain.com', $message->getFromAddress());
     }
 
     /**
@@ -55,7 +55,7 @@ class Enigma_EnigmaMimeMessage extends TestCase
 
         $message = new enigma_mime_message($mime, enigma_mime_message::PGP_SIGNED);
 
-        $this->assertSame($expected, $message->getRecipients());
+        self::assertSame($expected, $message->getRecipients());
     }
 
     /**
@@ -72,7 +72,7 @@ class Enigma_EnigmaMimeMessage extends TestCase
             . "\r\n"
             . "test body\r\n";
 
-        $this->assertSame($expected, $message->getOrigBody());
+        self::assertSame($expected, $message->getOrigBody());
     }
 
     /**
@@ -102,11 +102,11 @@ class Enigma_EnigmaMimeMessage extends TestCase
 
         // Note: The str_replace() below is for phpunit <= 6.5
 
-        $this->assertStringMatchesFormat(
+        self::assertStringMatchesFormat(
             str_replace("\r\n", "\n", $expected),
             str_replace("\r\n", "\n", $message->get())
         );
-        $this->assertStringMatchesFormat(
+        self::assertStringMatchesFormat(
             str_replace("\r\n", "\n", $signed_headers),
             str_replace("\r\n", "\n", $message->txtHeaders())
         );
@@ -143,11 +143,11 @@ class Enigma_EnigmaMimeMessage extends TestCase
 
         // Note: The str_replace() below is for phpunit <= 6.5
 
-        $this->assertStringMatchesFormat(
+        self::assertStringMatchesFormat(
             str_replace("\r\n", "\n", $signed),
             str_replace("\r\n", "\n", $message->get())
         );
-        $this->assertStringMatchesFormat(
+        self::assertStringMatchesFormat(
             str_replace("\r\n", "\n", $signed_headers),
             str_replace("\r\n", "\n", $message->txtHeaders())
         );
@@ -182,11 +182,11 @@ class Enigma_EnigmaMimeMessage extends TestCase
 
         // Note: The str_replace() below is for phpunit <= 6.5
 
-        $this->assertStringMatchesFormat(
+        self::assertStringMatchesFormat(
             str_replace("\r\n", "\n", $encrypted),
             str_replace("\r\n", "\n", $message->get())
         );
-        $this->assertStringMatchesFormat(
+        self::assertStringMatchesFormat(
             str_replace("\r\n", "\n", $encrypted_headers),
             str_replace("\r\n", "\n", $message->txtHeaders())
         );

--- a/plugins/enigma/tests/EnigmaSignatureTest.php
+++ b/plugins/enigma/tests/EnigmaSignatureTest.php
@@ -11,6 +11,6 @@ class Enigma_EnigmaSignature extends TestCase
     {
         $error = new enigma_signature();
 
-        $this->assertInstanceOf('enigma_signature', $error);
+        self::assertInstanceOf('enigma_signature', $error);
     }
 }

--- a/plugins/enigma/tests/EnigmaSubkeyTest.php
+++ b/plugins/enigma/tests/EnigmaSubkeyTest.php
@@ -11,6 +11,6 @@ class Enigma_EnigmaSubkey extends TestCase
     {
         $error = new enigma_subkey();
 
-        $this->assertInstanceOf('enigma_subkey', $error);
+        self::assertInstanceOf('enigma_subkey', $error);
     }
 }

--- a/plugins/enigma/tests/EnigmaTest.php
+++ b/plugins/enigma/tests/EnigmaTest.php
@@ -12,7 +12,7 @@ class Enigma_Plugin extends TestCase
         $rcube = rcube::get_instance();
         $plugin = new enigma($rcube->plugins);
 
-        $this->assertInstanceOf('enigma', $plugin);
-        $this->assertInstanceOf('rcube_plugin', $plugin);
+        self::assertInstanceOf('enigma', $plugin);
+        self::assertInstanceOf('rcube_plugin', $plugin);
     }
 }

--- a/plugins/enigma/tests/EnigmaUseridTest.php
+++ b/plugins/enigma/tests/EnigmaUseridTest.php
@@ -11,6 +11,6 @@ class Enigma_EnigmaUserid extends TestCase
     {
         $error = new enigma_userid();
 
-        $this->assertInstanceOf('enigma_userid', $error);
+        self::assertInstanceOf('enigma_userid', $error);
     }
 }

--- a/plugins/example_addressbook/tests/ExampleAddressbookTest.php
+++ b/plugins/example_addressbook/tests/ExampleAddressbookTest.php
@@ -12,8 +12,8 @@ class ExampleAddressbook_Plugin extends TestCase
         $rcube = rcube::get_instance();
         $plugin = new example_addressbook($rcube->plugins);
 
-        $this->assertInstanceOf('example_addressbook', $plugin);
-        $this->assertInstanceOf('rcube_plugin', $plugin);
+        self::assertInstanceOf('example_addressbook', $plugin);
+        self::assertInstanceOf('rcube_plugin', $plugin);
 
         $plugin->init();
     }
@@ -28,6 +28,6 @@ class ExampleAddressbook_Plugin extends TestCase
 
         $result = $plugin->address_sources(['sources' => []]);
 
-        $this->assertSame('static', $result['sources']['static']['id']);
+        self::assertSame('static', $result['sources']['static']['id']);
     }
 }

--- a/plugins/filesystem_attachments/tests/FilesystemAttachmentsTest.php
+++ b/plugins/filesystem_attachments/tests/FilesystemAttachmentsTest.php
@@ -12,7 +12,7 @@ class FilesystemAttachments_Plugin extends TestCase
         $rcube = rcube::get_instance();
         $plugin = new filesystem_attachments($rcube->plugins);
 
-        $this->assertInstanceOf('filesystem_attachments', $plugin);
-        $this->assertInstanceOf('rcube_plugin', $plugin);
+        self::assertInstanceOf('filesystem_attachments', $plugin);
+        self::assertInstanceOf('rcube_plugin', $plugin);
     }
 }

--- a/plugins/help/tests/HelpTest.php
+++ b/plugins/help/tests/HelpTest.php
@@ -12,8 +12,8 @@ class Help_Plugin extends TestCase
         $rcube = rcube::get_instance();
         $plugin = new help($rcube->plugins);
 
-        $this->assertInstanceOf('help', $plugin);
-        $this->assertInstanceOf('rcube_plugin', $plugin);
+        self::assertInstanceOf('help', $plugin);
+        self::assertInstanceOf('rcube_plugin', $plugin);
     }
 
     /**
@@ -26,9 +26,9 @@ class Help_Plugin extends TestCase
 
         $result = $plugin->help_metadata();
 
-        $this->assertCount(3, $result);
-        $this->assertMatchesRegularExpression('|\?_task=settings&_action=about&_framed=1$|', $result['about']);
-        $this->assertSame('self', $result['license']);
-        $this->assertSame('http://docs.roundcube.net/doc/help/1.1/en_US/', $result['index']);
+        self::assertCount(3, $result);
+        self::assertMatchesRegularExpression('|\?_task=settings&_action=about&_framed=1$|', $result['about']);
+        self::assertSame('self', $result['license']);
+        self::assertSame('http://docs.roundcube.net/doc/help/1.1/en_US/', $result['index']);
     }
 }

--- a/plugins/hide_blockquote/tests/HideBlockquoteTest.php
+++ b/plugins/hide_blockquote/tests/HideBlockquoteTest.php
@@ -12,8 +12,8 @@ class HideBlockquote_Plugin extends TestCase
         $rcube = rcube::get_instance();
         $plugin = new hide_blockquote($rcube->plugins);
 
-        $this->assertInstanceOf('hide_blockquote', $plugin);
-        $this->assertInstanceOf('rcube_plugin', $plugin);
+        self::assertInstanceOf('hide_blockquote', $plugin);
+        self::assertInstanceOf('rcube_plugin', $plugin);
 
         $plugin->init();
     }
@@ -30,12 +30,12 @@ class HideBlockquote_Plugin extends TestCase
 
         $result = $plugin->prefs_table($args);
 
-        $this->assertSame(
+        self::assertSame(
             '<label for="hide_blockquote_limit">Hide citation when lines count is greater than</label>',
             $result['blocks']['main']['options']['hide_blockquote_limit']['title']
         );
 
-        $this->assertSame(
+        self::assertSame(
             '<input name="_hide_blockquote_limit" id="hide_blockquote_limit" size="5" class="form-control" value="" type="text">',
             $result['blocks']['main']['options']['hide_blockquote_limit']['content']
         );
@@ -54,13 +54,13 @@ class HideBlockquote_Plugin extends TestCase
 
         $result = $plugin->prefs_save($args);
 
-        $this->assertSame(0, $result['prefs']['hide_blockquote_limit']);
+        self::assertSame(0, $result['prefs']['hide_blockquote_limit']);
 
         $_POST = ['_hide_blockquote_limit' => '10'];
         $args = ['section' => 'mailview', 'prefs' => []];
 
         $result = $plugin->prefs_save($args);
 
-        $this->assertSame(10, $result['prefs']['hide_blockquote_limit']);
+        self::assertSame(10, $result['prefs']['hide_blockquote_limit']);
     }
 }

--- a/plugins/http_authentication/tests/HttpAuthenticationTest.php
+++ b/plugins/http_authentication/tests/HttpAuthenticationTest.php
@@ -12,7 +12,7 @@ class HttpAuthentication_Plugin extends TestCase
         $rcube = rcube::get_instance();
         $plugin = new http_authentication($rcube->plugins);
 
-        $this->assertInstanceOf('http_authentication', $plugin);
-        $this->assertInstanceOf('rcube_plugin', $plugin);
+        self::assertInstanceOf('http_authentication', $plugin);
+        self::assertInstanceOf('rcube_plugin', $plugin);
     }
 }

--- a/plugins/identicon/tests/IdenticonEngineTest.php
+++ b/plugins/identicon/tests/IdenticonEngineTest.php
@@ -10,14 +10,14 @@ class Identicon_IdenticonEngine extends TestCase
     public function test_icon_generation()
     {
         if (!function_exists('imagepng')) {
-            $this->markTestSkipped();
+            self::markTestSkipped();
         }
 
         $engine = new identicon_engine('test@domain.com', 10);
 
         $icon = $engine->getBinary();
 
-        $this->assertMatchesRegularExpression('/^\x89\x50\x4E\x47/', $icon);
-        $this->assertSame('image/png', $engine->getMimetype());
+        self::assertMatchesRegularExpression('/^\x89\x50\x4E\x47/', $icon);
+        self::assertSame('image/png', $engine->getMimetype());
     }
 }

--- a/plugins/identicon/tests/IdenticonTest.php
+++ b/plugins/identicon/tests/IdenticonTest.php
@@ -12,7 +12,7 @@ class Identicon_Plugin extends TestCase
         $rcube = rcube::get_instance();
         $plugin = new identicon($rcube->plugins);
 
-        $this->assertInstanceOf('identicon', $plugin);
-        $this->assertInstanceOf('rcube_plugin', $plugin);
+        self::assertInstanceOf('identicon', $plugin);
+        self::assertInstanceOf('rcube_plugin', $plugin);
     }
 }

--- a/plugins/identity_select/tests/IdentitySelectTest.php
+++ b/plugins/identity_select/tests/IdentitySelectTest.php
@@ -12,7 +12,7 @@ class IdentitySelect_Plugin extends TestCase
         $rcube = rcube::get_instance();
         $plugin = new identity_select($rcube->plugins);
 
-        $this->assertInstanceOf('identity_select', $plugin);
-        $this->assertInstanceOf('rcube_plugin', $plugin);
+        self::assertInstanceOf('identity_select', $plugin);
+        self::assertInstanceOf('rcube_plugin', $plugin);
     }
 }

--- a/plugins/jqueryui/tests/JqueryuiTest.php
+++ b/plugins/jqueryui/tests/JqueryuiTest.php
@@ -12,7 +12,7 @@ class Jqueryui_Plugin extends TestCase
         $rcube = rcube::get_instance();
         $plugin = new jqueryui($rcube->plugins);
 
-        $this->assertInstanceOf('jqueryui', $plugin);
-        $this->assertInstanceOf('rcube_plugin', $plugin);
+        self::assertInstanceOf('jqueryui', $plugin);
+        self::assertInstanceOf('rcube_plugin', $plugin);
     }
 }

--- a/plugins/krb_authentication/tests/KrbAuthenticationTest.php
+++ b/plugins/krb_authentication/tests/KrbAuthenticationTest.php
@@ -12,7 +12,7 @@ class KrbAuthentication_Plugin extends TestCase
         $rcube = rcube::get_instance();
         $plugin = new krb_authentication($rcube->plugins);
 
-        $this->assertInstanceOf('krb_authentication', $plugin);
-        $this->assertInstanceOf('rcube_plugin', $plugin);
+        self::assertInstanceOf('krb_authentication', $plugin);
+        self::assertInstanceOf('rcube_plugin', $plugin);
     }
 }

--- a/plugins/managesieve/tests/EngineTest.php
+++ b/plugins/managesieve/tests/EngineTest.php
@@ -30,11 +30,11 @@ class Managesieve_Engine extends ActionTestCase
 
         $result = $engine->filter_form([]);
 
-        $this->assertFalse($output->get_env('rule_disabled'));
-        $this->assertTrue(strpos($result, '<form name="filterform"') === 0);
-        $this->assertTrue(strpos($result, '<input type="hidden" name="_action" value="plugin.managesieve-save">') !== false);
-        $this->assertTrue(strpos($result, '<div id="rules">') !== false);
-        $this->assertTrue(strpos($result, '<div id="actions">') !== false);
+        self::assertFalse($output->get_env('rule_disabled'));
+        self::assertTrue(strpos($result, '<form name="filterform"') === 0);
+        self::assertTrue(strpos($result, '<input type="hidden" name="_action" value="plugin.managesieve-save">') !== false);
+        self::assertTrue(strpos($result, '<div id="rules">') !== false);
+        self::assertTrue(strpos($result, '<div id="actions">') !== false);
 
         // TODO: Test it for real
     }
@@ -67,7 +67,7 @@ class Managesieve_Engine extends ActionTestCase
         $plugin = new managesieve($rcube->plugins);
         $engine = new rcube_sieve_engine($plugin);
 
-        $this->assertSame($expected, invokeMethod($engine, 'strip_value', $args));
+        self::assertSame($expected, invokeMethod($engine, 'strip_value', $args));
     }
 
     /**
@@ -83,6 +83,6 @@ class Managesieve_Engine extends ActionTestCase
         $args = [1, 'n', '<p>'];
         $expected = '<textarea data-type="list" name="_n[1]" style="display:none" id="n1">&lt;p&gt;</textarea>';
 
-        $this->assertSame($expected, invokeMethod($engine, 'list_input', $args));
+        self::assertSame($expected, invokeMethod($engine, 'list_input', $args));
     }
 }

--- a/plugins/managesieve/tests/ForwardTest.php
+++ b/plugins/managesieve/tests/ForwardTest.php
@@ -18,7 +18,7 @@ class Managesieve_Forward extends ActionTestCase
 
         $result = $forward->forward_form([]);
 
-        $this->assertTrue(strpos($result, '<form id="form"') === 0);
-        $this->assertTrue(strpos($result, '<input type="hidden" name="_action" value="plugin.managesieve-forward">') !== false);
+        self::assertTrue(strpos($result, '<form id="form"') === 0);
+        self::assertTrue(strpos($result, '<input type="hidden" name="_action" value="plugin.managesieve-forward">') !== false);
     }
 }

--- a/plugins/managesieve/tests/ManagesieveTest.php
+++ b/plugins/managesieve/tests/ManagesieveTest.php
@@ -12,7 +12,7 @@ class Managesieve_Plugin extends TestCase
         $rcube = rcube::get_instance();
         $plugin = new managesieve($rcube->plugins);
 
-        $this->assertInstanceOf('managesieve', $plugin);
-        $this->assertInstanceOf('rcube_plugin', $plugin);
+        self::assertInstanceOf('managesieve', $plugin);
+        self::assertInstanceOf('rcube_plugin', $plugin);
     }
 }

--- a/plugins/managesieve/tests/ScriptTest.php
+++ b/plugins/managesieve/tests/ScriptTest.php
@@ -22,7 +22,7 @@ class Managesieve_Script extends TestCase
         $script = new rcube_sieve_script($input, $caps);
         $result = $script->as_text();
 
-        $this->assertSame(trim($output), trim($result), $message);
+        self::assertSame(trim($output), trim($result), $message);
     }
 
     /**
@@ -77,6 +77,6 @@ class Managesieve_Script extends TestCase
     {
         $res = json_encode(rcube_sieve_script::tokenize($input, $num));
 
-        $this->assertSame(trim($output), trim($res));
+        self::assertSame(trim($output), trim($res));
     }
 }

--- a/plugins/managesieve/tests/VacationTest.php
+++ b/plugins/managesieve/tests/VacationTest.php
@@ -18,9 +18,9 @@ class Managesieve_Vacation extends ActionTestCase
 
         $result = $vacation->vacation_form([]);
 
-        $this->assertSame('H:i', $output->get_env('time_format'));
-        $this->assertTrue(strpos($result, '<form id="form"') === 0);
-        $this->assertTrue(strpos($result, '<input type="hidden" name="_action" value="plugin.managesieve-vacation">') !== false);
+        self::assertSame('H:i', $output->get_env('time_format'));
+        self::assertTrue(strpos($result, '<form id="form"') === 0);
+        self::assertTrue(strpos($result, '<input type="hidden" name="_action" value="plugin.managesieve-vacation">') !== false);
     }
 
     public function test_build_regexp_tests()
@@ -29,20 +29,20 @@ class Managesieve_Vacation extends ActionTestCase
         $vacation = new rcube_sieve_vacation(true);
         $tests = invokeMethod($vacation, 'build_regexp_tests', ['2014-02-20', '2014-03-05', &$error]);
 
-        $this->assertCount(2, $tests);
-        $this->assertSame('header', $tests[0]['test']);
-        $this->assertSame('regex', $tests[0]['type']);
-        $this->assertSame('received', $tests[0]['arg1']);
-        $this->assertSame('(20|21|22|23|24|25|26|27|28) Feb 2014', $tests[0]['arg2']);
-        $this->assertSame('header', $tests[1]['test']);
-        $this->assertSame('regex', $tests[1]['type']);
-        $this->assertSame('received', $tests[1]['arg1']);
-        $this->assertSame('([ 0]1|[ 0]2|[ 0]3|[ 0]4|[ 0]5) Mar 2014', $tests[1]['arg2']);
+        self::assertCount(2, $tests);
+        self::assertSame('header', $tests[0]['test']);
+        self::assertSame('regex', $tests[0]['type']);
+        self::assertSame('received', $tests[0]['arg1']);
+        self::assertSame('(20|21|22|23|24|25|26|27|28) Feb 2014', $tests[0]['arg2']);
+        self::assertSame('header', $tests[1]['test']);
+        self::assertSame('regex', $tests[1]['type']);
+        self::assertSame('received', $tests[1]['arg1']);
+        self::assertSame('([ 0]1|[ 0]2|[ 0]3|[ 0]4|[ 0]5) Mar 2014', $tests[1]['arg2']);
 
         $tests = invokeMethod($vacation, 'build_regexp_tests', ['2014-02-20', '2014-01-05', &$error]);
 
-        $this->assertNull($tests);
-        $this->assertSame('managesieve.invaliddateformat', $error);
+        self::assertNull($tests);
+        self::assertSame('managesieve.invaliddateformat', $error);
     }
 
     public function test_parse_regexp_tests()
@@ -65,8 +65,8 @@ class Managesieve_Vacation extends ActionTestCase
         $vacation = new rcube_sieve_vacation(true);
         $result = invokeMethod($vacation, 'parse_regexp_tests', [$tests]);
 
-        $this->assertCount(2, $result);
-        $this->assertSame('20 Feb 2014', $result['from']);
-        $this->assertSame('05 Mar 2014', $result['to']);
+        self::assertCount(2, $result);
+        self::assertSame('20 Feb 2014', $result['from']);
+        self::assertSame('05 Mar 2014', $result['to']);
     }
 }

--- a/plugins/markasjunk/tests/MarkasjunkTest.php
+++ b/plugins/markasjunk/tests/MarkasjunkTest.php
@@ -12,8 +12,8 @@ class Markasjunk_Plugin extends TestCase
         $rcube = rcube::get_instance();
         $plugin = new markasjunk($rcube->plugins);
 
-        $this->assertInstanceOf('markasjunk', $plugin);
-        $this->assertInstanceOf('rcube_plugin', $plugin);
+        self::assertInstanceOf('markasjunk', $plugin);
+        self::assertInstanceOf('rcube_plugin', $plugin);
     }
 
     /**
@@ -36,7 +36,7 @@ class Markasjunk_Plugin extends TestCase
             invokeMethod($plugin, '_init_driver');
 
             $driver = getProperty($plugin, 'driver');
-            $this->assertInstanceOf("markasjunk_{$driver_name}", $driver);
+            self::assertInstanceOf("markasjunk_{$driver_name}", $driver);
         }
     }
 }

--- a/plugins/new_user_dialog/tests/NewUserDialogTest.php
+++ b/plugins/new_user_dialog/tests/NewUserDialogTest.php
@@ -12,7 +12,7 @@ class NewUserDialog_Plugin extends TestCase
         $rcube = rcube::get_instance();
         $plugin = new new_user_dialog($rcube->plugins);
 
-        $this->assertInstanceOf('new_user_dialog', $plugin);
-        $this->assertInstanceOf('rcube_plugin', $plugin);
+        self::assertInstanceOf('new_user_dialog', $plugin);
+        self::assertInstanceOf('rcube_plugin', $plugin);
     }
 }

--- a/plugins/new_user_identity/tests/NewUserIdentityTest.php
+++ b/plugins/new_user_identity/tests/NewUserIdentityTest.php
@@ -12,7 +12,7 @@ class NewUserIdentity_Plugin extends TestCase
         $rcube = rcube::get_instance();
         $plugin = new new_user_identity($rcube->plugins);
 
-        $this->assertInstanceOf('new_user_identity', $plugin);
-        $this->assertInstanceOf('rcube_plugin', $plugin);
+        self::assertInstanceOf('new_user_identity', $plugin);
+        self::assertInstanceOf('rcube_plugin', $plugin);
     }
 }

--- a/plugins/newmail_notifier/tests/NewmailNotifierTest.php
+++ b/plugins/newmail_notifier/tests/NewmailNotifierTest.php
@@ -12,7 +12,7 @@ class NewmailNotifier_Plugin extends TestCase
         $rcube = rcube::get_instance();
         $plugin = new newmail_notifier($rcube->plugins);
 
-        $this->assertInstanceOf('newmail_notifier', $plugin);
-        $this->assertInstanceOf('rcube_plugin', $plugin);
+        self::assertInstanceOf('newmail_notifier', $plugin);
+        self::assertInstanceOf('rcube_plugin', $plugin);
     }
 }

--- a/plugins/password/tests/PasswordTest.php
+++ b/plugins/password/tests/PasswordTest.php
@@ -12,8 +12,8 @@ class Password_Plugin extends TestCase
         $rcube = rcube::get_instance();
         $plugin = new password($rcube->plugins);
 
-        $this->assertInstanceOf('password', $plugin);
-        $this->assertInstanceOf('rcube_plugin', $plugin);
+        self::assertInstanceOf('password', $plugin);
+        self::assertInstanceOf('rcube_plugin', $plugin);
     }
 
     /**
@@ -38,19 +38,19 @@ class Password_Plugin extends TestCase
         $driver_class = $this->load_driver('cpanel');
 
         $error_result = $driver_class::decode_response(false);
-        $this->assertSame($error_result, PASSWORD_CONNECT_ERROR);
+        self::assertSame($error_result, PASSWORD_CONNECT_ERROR);
 
         $bad_result = $driver_class::decode_response(null);
-        $this->assertSame($bad_result, PASSWORD_CONNECT_ERROR);
+        self::assertSame($bad_result, PASSWORD_CONNECT_ERROR);
 
         $null_result = $driver_class::decode_response('null');
-        $this->assertSame($null_result, PASSWORD_ERROR);
+        self::assertSame($null_result, PASSWORD_ERROR);
 
         $malformed_result = $driver_class::decode_response('random {string]!');
-        $this->assertSame($malformed_result, PASSWORD_ERROR);
+        self::assertSame($malformed_result, PASSWORD_ERROR);
 
         $other_result = $driver_class::decode_response('{"a":"b"}');
-        $this->assertSame($other_result, PASSWORD_ERROR);
+        self::assertSame($other_result, PASSWORD_ERROR);
 
         $fail_response = '{"data":null,"errors":["Execution of Email::passwdp'
                 . 'op (api version:3) is not permitted inside of webmail"],"sta'
@@ -62,12 +62,12 @@ class Password_Plugin extends TestCase
             'message' => $error_message,
         ];
         $fail_result = $driver_class::decode_response($fail_response);
-        $this->assertSame($expected_result, $fail_result);
+        self::assertSame($expected_result, $fail_result);
 
         $success_response = '{"metadata":{},"data":null,"messages":null,"errors'
                 . '":null,"status":1}';
         $good_result = $driver_class::decode_response($success_response);
-        $this->assertSame($good_result, PASSWORD_SUCCESS);
+        self::assertSame($good_result, PASSWORD_SUCCESS);
     }
 
     /**
@@ -81,7 +81,7 @@ class Password_Plugin extends TestCase
     protected function load_driver($driver)
     {
         $driver_class = "rcube_{$driver}_password";
-        $this->assertTrue(class_exists($driver_class));
+        self::assertTrue(class_exists($driver_class));
         return $driver_class;
     }
 
@@ -91,22 +91,22 @@ class Password_Plugin extends TestCase
     public function test_hash_password()
     {
         $pass = password::hash_password('test', 'clear');
-        $this->assertSame('test', $pass);
+        self::assertSame('test', $pass);
 
         $pass = password::hash_password('test', 'ad');
-        $this->assertSame("\"\0t\0e\0s\0t\0\"\0", $pass);
+        self::assertSame("\"\0t\0e\0s\0t\0\"\0", $pass);
 
         $pass = password::hash_password('test', 'ssha');
-        $this->assertMatchesRegularExpression('/^\{SSHA\}[a-zA-Z0-9+\/]{32}$/', $pass);
+        self::assertMatchesRegularExpression('/^\{SSHA\}[a-zA-Z0-9+\/]{32}$/', $pass);
 
         $pass = password::hash_password('test', 'ssha256');
-        $this->assertMatchesRegularExpression('/^\{SSHA256\}[a-zA-Z0-9+\/=]{48}$/', $pass);
+        self::assertMatchesRegularExpression('/^\{SSHA256\}[a-zA-Z0-9+\/=]{48}$/', $pass);
 
         $pass = password::hash_password('test', 'sha256-crypt');
-        $this->assertMatchesRegularExpression('/^\{SHA256-CRYPT\}\$5\$[a-zA-Z0-9]{16}\$[a-zA-Z0-9.\/]{43}$/', $pass);
+        self::assertMatchesRegularExpression('/^\{SHA256-CRYPT\}\$5\$[a-zA-Z0-9]{16}\$[a-zA-Z0-9.\/]{43}$/', $pass);
 
         $pass = password::hash_password('test', 'hash-bcrypt');
-        $this->assertMatchesRegularExpression('/^\{BLF-CRYPT\}\$2y\$10\$[a-zA-Z0-9.\/]{53}$/', $pass);
+        self::assertMatchesRegularExpression('/^\{BLF-CRYPT\}\$2y\$10\$[a-zA-Z0-9.\/]{53}$/', $pass);
 
         // TODO: Test all algos
     }

--- a/plugins/reconnect/tests/ReconnectTest.php
+++ b/plugins/reconnect/tests/ReconnectTest.php
@@ -12,7 +12,7 @@ class Reconnect_Plugin extends TestCase
         $rcube = rcube::get_instance();
         $plugin = new reconnect($rcube->plugins);
 
-        $this->assertInstanceOf('reconnect', $plugin);
-        $this->assertInstanceOf('rcube_plugin', $plugin);
+        self::assertInstanceOf('reconnect', $plugin);
+        self::assertInstanceOf('rcube_plugin', $plugin);
     }
 }

--- a/plugins/redundant_attachments/tests/RedundantAttachmentsTest.php
+++ b/plugins/redundant_attachments/tests/RedundantAttachmentsTest.php
@@ -12,7 +12,7 @@ class RedundantAttachments_Plugin extends TestCase
         $rcube = rcube::get_instance();
         $plugin = new redundant_attachments($rcube->plugins);
 
-        $this->assertInstanceOf('redundant_attachments', $plugin);
-        $this->assertInstanceOf('rcube_plugin', $plugin);
+        self::assertInstanceOf('redundant_attachments', $plugin);
+        self::assertInstanceOf('rcube_plugin', $plugin);
     }
 }

--- a/plugins/show_additional_headers/tests/ShowAdditionalHeadersTest.php
+++ b/plugins/show_additional_headers/tests/ShowAdditionalHeadersTest.php
@@ -12,7 +12,7 @@ class ShowAdditionalHeaders_Plugin extends TestCase
         $rcube = rcube::get_instance();
         $plugin = new show_additional_headers($rcube->plugins);
 
-        $this->assertInstanceOf('show_additional_headers', $plugin);
-        $this->assertInstanceOf('rcube_plugin', $plugin);
+        self::assertInstanceOf('show_additional_headers', $plugin);
+        self::assertInstanceOf('rcube_plugin', $plugin);
     }
 }

--- a/plugins/squirrelmail_usercopy/tests/SquirrelmailUsercopyTest.php
+++ b/plugins/squirrelmail_usercopy/tests/SquirrelmailUsercopyTest.php
@@ -12,7 +12,7 @@ class SquirrelmailUsercopy_Plugin extends TestCase
         $rcube = rcube::get_instance();
         $plugin = new squirrelmail_usercopy($rcube->plugins);
 
-        $this->assertInstanceOf('squirrelmail_usercopy', $plugin);
-        $this->assertInstanceOf('rcube_plugin', $plugin);
+        self::assertInstanceOf('squirrelmail_usercopy', $plugin);
+        self::assertInstanceOf('rcube_plugin', $plugin);
     }
 }

--- a/plugins/subscriptions_option/tests/SubscriptionsOptionTest.php
+++ b/plugins/subscriptions_option/tests/SubscriptionsOptionTest.php
@@ -10,8 +10,8 @@ class SubscriptionsOption_Plugin extends ActionTestCase
         $rcube = rcube::get_instance();
         $plugin = new subscriptions_option($rcube->plugins);
 
-        $this->assertInstanceOf('subscriptions_option', $plugin);
-        $this->assertInstanceOf('rcube_plugin', $plugin);
+        self::assertInstanceOf('subscriptions_option', $plugin);
+        self::assertInstanceOf('rcube_plugin', $plugin);
     }
 
     /**
@@ -28,12 +28,12 @@ class SubscriptionsOption_Plugin extends ActionTestCase
 
         $result = $plugin->prefs_list($args);
 
-        $this->assertSame(
+        self::assertSame(
             '<label for="rcmfd_use_subscriptions">Use IMAP Subscriptions</label>',
             $result['blocks']['main']['options']['use_subscriptions']['title']
         );
 
-        $this->assertSame(
+        self::assertSame(
             '<input name="_use_subscriptions" id="rcmfd_use_subscriptions" value="1" checked type="checkbox">',
             $result['blocks']['main']['options']['use_subscriptions']['content']
         );
@@ -52,7 +52,7 @@ class SubscriptionsOption_Plugin extends ActionTestCase
 
         $result = $plugin->prefs_save($args);
 
-        $this->assertTrue($result['prefs']['use_subscriptions']);
+        self::assertTrue($result['prefs']['use_subscriptions']);
 
         $storage = self::mockStorage()->registerFunction('clear_cache', true);
 
@@ -61,9 +61,9 @@ class SubscriptionsOption_Plugin extends ActionTestCase
 
         $result = $plugin->prefs_save($args);
 
-        $this->assertFalse($result['prefs']['use_subscriptions']);
-        $this->assertCount(1, $storage->methodCalls);
-        $this->assertSame('clear_cache', $storage->methodCalls[0]['name']);
-        $this->assertSame(['mailboxes'], $storage->methodCalls[0]['args']);
+        self::assertFalse($result['prefs']['use_subscriptions']);
+        self::assertCount(1, $storage->methodCalls);
+        self::assertSame('clear_cache', $storage->methodCalls[0]['name']);
+        self::assertSame(['mailboxes'], $storage->methodCalls[0]['args']);
     }
 }

--- a/plugins/userinfo/tests/UserinfoTest.php
+++ b/plugins/userinfo/tests/UserinfoTest.php
@@ -12,7 +12,7 @@ class Userinfo_Plugin extends TestCase
         $rcube = rcube::get_instance();
         $plugin = new userinfo($rcube->plugins);
 
-        $this->assertInstanceOf('userinfo', $plugin);
-        $this->assertInstanceOf('rcube_plugin', $plugin);
+        self::assertInstanceOf('userinfo', $plugin);
+        self::assertInstanceOf('rcube_plugin', $plugin);
     }
 }

--- a/plugins/vcard_attachments/tests/VcardAttachmentsTest.php
+++ b/plugins/vcard_attachments/tests/VcardAttachmentsTest.php
@@ -12,8 +12,8 @@ class VcardAttachments_Plugin extends TestCase
         $rcube = rcube::get_instance();
         $plugin = new vcard_attachments($rcube->plugins);
 
-        $this->assertInstanceOf('vcard_attachments', $plugin);
-        $this->assertInstanceOf('rcube_plugin', $plugin);
+        self::assertInstanceOf('vcard_attachments', $plugin);
+        self::assertInstanceOf('rcube_plugin', $plugin);
     }
 
     /**
@@ -25,22 +25,22 @@ class VcardAttachments_Plugin extends TestCase
         $plugin = new vcard_attachments($rcube->plugins);
 
         $part = new rcube_message_part();
-        $this->assertFalse(invokeMethod($plugin, 'is_vcard', [$part]));
+        self::assertFalse(invokeMethod($plugin, 'is_vcard', [$part]));
 
         $part->mimetype = 'text/vcard';
-        $this->assertTrue(invokeMethod($plugin, 'is_vcard', [$part]));
+        self::assertTrue(invokeMethod($plugin, 'is_vcard', [$part]));
 
         $part->mimetype = 'text/x-vcard';
-        $this->assertTrue(invokeMethod($plugin, 'is_vcard', [$part]));
+        self::assertTrue(invokeMethod($plugin, 'is_vcard', [$part]));
 
         $part->mimetype = 'text/directory';
-        $this->assertFalse(invokeMethod($plugin, 'is_vcard', [$part]));
+        self::assertFalse(invokeMethod($plugin, 'is_vcard', [$part]));
 
         $part->ctype_parameters['profile'] = 'vcard';
-        $this->assertTrue(invokeMethod($plugin, 'is_vcard', [$part]));
+        self::assertTrue(invokeMethod($plugin, 'is_vcard', [$part]));
 
         $part->ctype_parameters['profile'] = 'unknown';
         $part->filename = 'vcard.vcf';
-        $this->assertTrue(invokeMethod($plugin, 'is_vcard', [$part]));
+        self::assertTrue(invokeMethod($plugin, 'is_vcard', [$part]));
     }
 }

--- a/plugins/virtuser_file/tests/VirtuserFileTest.php
+++ b/plugins/virtuser_file/tests/VirtuserFileTest.php
@@ -12,7 +12,7 @@ class VirtuserFile_Plugin extends TestCase
         $rcube = rcube::get_instance();
         $plugin = new virtuser_file($rcube->plugins);
 
-        $this->assertInstanceOf('virtuser_file', $plugin);
-        $this->assertInstanceOf('rcube_plugin', $plugin);
+        self::assertInstanceOf('virtuser_file', $plugin);
+        self::assertInstanceOf('rcube_plugin', $plugin);
     }
 }

--- a/plugins/virtuser_query/tests/VirtuserQueryTest.php
+++ b/plugins/virtuser_query/tests/VirtuserQueryTest.php
@@ -12,7 +12,7 @@ class VirtuserQuery_Plugin extends TestCase
         $rcube = rcube::get_instance();
         $plugin = new virtuser_query($rcube->plugins);
 
-        $this->assertInstanceOf('virtuser_query', $plugin);
-        $this->assertInstanceOf('rcube_plugin', $plugin);
+        self::assertInstanceOf('virtuser_query', $plugin);
+        self::assertInstanceOf('rcube_plugin', $plugin);
     }
 }

--- a/plugins/zipdownload/tests/Browser/MailTest.php
+++ b/plugins/zipdownload/tests/Browser/MailTest.php
@@ -32,7 +32,7 @@ class MailTest extends TestCase
                 ->with(new Popupmenu('message-menu'), static function ($browser) {
                     $browser->clickMenuItem('download', null, false);
                 })
-                ->with(new Popupmenu('zipdownload-menu'), function ($browser) {
+                ->with(new Popupmenu('zipdownload-menu'), static function ($browser) {
                     $browser->assertVisible('a.download.eml:not(.disabled)')
                         ->assertSeeIn('a.download.eml', 'Source (.eml)')
                         ->assertVisible('a.download.mbox.disabled')
@@ -44,7 +44,7 @@ class MailTest extends TestCase
                     $filename = 'Test HTML with local and remote image.eml';
                     $email = $browser->readDownloadedFile($filename);
                     $browser->removeDownloadedFile($filename);
-                    $this->assertTrue(strpos($email, 'Subject: Test HTML with local and remote image') !== false);
+                    self::assertTrue(strpos($email, 'Subject: Test HTML with local and remote image') !== false);
                 });
 
             // Test More > Download > Mailbox format (two messages selected)
@@ -63,7 +63,7 @@ class MailTest extends TestCase
                     $files = $this->getFilesFromZip($filename);
                     $browser->removeDownloadedFile($filename);
 
-                    $this->assertSame(['INBOX.mbox'], $files);
+                    self::assertSame(['INBOX.mbox'], $files);
                 });
 
             // Test More > Download > Maildir format (two messages selected)
@@ -77,7 +77,7 @@ class MailTest extends TestCase
                     $filename = 'INBOX.zip';
                     $files = $this->getFilesFromZip($filename);
                     $browser->removeDownloadedFile($filename);
-                    $this->assertCount(2, $files);
+                    self::assertCount(2, $files);
                 });
 
             // Test attachments download
@@ -94,7 +94,7 @@ class MailTest extends TestCase
             $files = $this->getFilesFromZip($filename);
             $browser->removeDownloadedFile($filename);
             $expected = ['lines.txt', 'lines_lf.txt'];
-            $this->assertSame($expected, $files);
+            self::assertSame($expected, $files);
         });
     }
 

--- a/plugins/zipdownload/tests/ZipdownloadTest.php
+++ b/plugins/zipdownload/tests/ZipdownloadTest.php
@@ -12,7 +12,7 @@ class Zipdownload_Plugin extends TestCase
         $rcube = rcube::get_instance();
         $plugin = new zipdownload($rcube->plugins);
 
-        $this->assertInstanceOf('zipdownload', $plugin);
-        $this->assertInstanceOf('rcube_plugin', $plugin);
+        self::assertInstanceOf('zipdownload', $plugin);
+        self::assertInstanceOf('rcube_plugin', $plugin);
     }
 }

--- a/tests/ActionTestCase.php
+++ b/tests/ActionTestCase.php
@@ -238,7 +238,7 @@ class ActionTestCase extends TestCase
 
         $upload = rcmail::get_instance()->get_uploaded_file($file['id']);
 
-        $this->assertTrue(is_array($upload));
+        self::assertTrue(is_array($upload));
 
         return $upload;
     }
@@ -278,7 +278,7 @@ class ActionTestCase extends TestCase
             $action->run($args);
             StderrMock::stop();
         } catch (ExitException $e) {
-            $this->assertSame($expected_code, $e->getCode());
+            self::assertSame($expected_code, $e->getCode());
         } catch (Exception $e) {
             if ($e->getMessage() == 'Error raised' && $expected_code == OutputHtmlMock::E_EXIT) {
                 return;

--- a/tests/Actions/Contacts/CopyTest.php
+++ b/tests/Actions/Contacts/CopyTest.php
@@ -13,8 +13,8 @@ class Actions_Contacts_Copy extends ActionTestCase
         $action = new rcmail_action_contacts_copy();
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'contacts', 'copy');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         // Missing target addressbook
         $_POST = [
@@ -26,9 +26,9 @@ class Actions_Contacts_Copy extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('copy', $result['action']);
-        $this->assertSame('this.display_message("Could not copy any contacts.","error",0);', trim($result['exec']));
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('copy', $result['action']);
+        self::assertSame('this.display_message("Could not copy any contacts.","error",0);', trim($result['exec']));
 
         // target = source
         $_POST['_to'] = '0';
@@ -37,9 +37,9 @@ class Actions_Contacts_Copy extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('copy', $result['action']);
-        $this->assertSame('this.display_message("Could not copy any contacts.","error",0);', trim($result['exec']));
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('copy', $result['action']);
+        self::assertSame('this.display_message("Could not copy any contacts.","error",0);', trim($result['exec']));
 
         // target readonly
         $_POST['_to'] = rcube_addressbook::TYPE_RECIPIENT;
@@ -48,9 +48,9 @@ class Actions_Contacts_Copy extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('copy', $result['action']);
-        $this->assertSame('this.display_message("Could not copy any contacts.","error",0);', trim($result['exec']));
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('copy', $result['action']);
+        self::assertSame('this.display_message("Could not copy any contacts.","error",0);', trim($result['exec']));
 
         // Non-existing contact
         $_POST = [
@@ -63,9 +63,9 @@ class Actions_Contacts_Copy extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('copy', $result['action']);
-        $this->assertSame('this.display_message("Could not copy any contacts.","error",0);', trim($result['exec']));
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('copy', $result['action']);
+        self::assertSame('this.display_message("Could not copy any contacts.","error",0);', trim($result['exec']));
     }
 
     /**
@@ -76,7 +76,7 @@ class Actions_Contacts_Copy extends ActionTestCase
         $action = new rcmail_action_contacts_copy();
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'contacts', 'copy');
 
-        $this->assertTrue($action->checks());
+        self::assertTrue($action->checks());
 
         self::initDB('contacts');
 
@@ -95,16 +95,16 @@ class Actions_Contacts_Copy extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('copy', $result['action']);
-        $this->assertSame('this.display_message("Successfully copied 1 contacts.","confirmation",0);', trim($result['exec']));
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('copy', $result['action']);
+        self::assertSame('this.display_message("Successfully copied 1 contacts.","confirmation",0);', trim($result['exec']));
 
         // Check that the contact has been really added to the contacts db
         $db = $rcmail->get_dbh();
         $query = $db->query('SELECT count(*) AS cnt FROM `contacts` WHERE `user_id` = 1 AND `email` = ?', 'test@recipient.com');
         $result = $db->fetch_assoc($query);
 
-        $this->assertSame('1', $result['cnt']);
+        self::assertSame('1', $result['cnt']);
     }
 
     /**
@@ -112,6 +112,6 @@ class Actions_Contacts_Copy extends ActionTestCase
      */
     public function test_copy_with_group()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 }

--- a/tests/Actions/Contacts/DeleteTest.php
+++ b/tests/Actions/Contacts/DeleteTest.php
@@ -13,8 +13,8 @@ class Actions_Contacts_Delete extends ActionTestCase
         $action = new rcmail_action_contacts_delete();
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'contacts', 'delete');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         self::initDB('contacts');
 
@@ -32,16 +32,16 @@ class Actions_Contacts_Delete extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('delete', $result['action']);
-        $this->assertSame(1, $result['env']['pagecount']);
-        $this->assertTrue(strpos($result['exec'], 'this.display_message("Contact(s) deleted successfully.","confirmation",0);') !== false);
-        $this->assertTrue(strpos($result['exec'], 'this.set_rowcount("Contacts 1 to 5 of 5")') !== false);
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('delete', $result['action']);
+        self::assertSame(1, $result['env']['pagecount']);
+        self::assertTrue(strpos($result['exec'], 'this.display_message("Contact(s) deleted successfully.","confirmation",0);') !== false);
+        self::assertTrue(strpos($result['exec'], 'this.set_rowcount("Contacts 1 to 5 of 5")') !== false);
 
         $query = $db->query('SELECT * FROM `contacts` WHERE `contact_id` = ?', $cid);
         $result = $db->fetch_assoc($query);
 
-        $this->assertTrue(!empty($result['del']));
+        self::assertTrue(!empty($result['del']));
     }
 
     /**
@@ -49,6 +49,6 @@ class Actions_Contacts_Delete extends ActionTestCase
      */
     public function test_delete_from_search()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 }

--- a/tests/Actions/Contacts/EditTest.php
+++ b/tests/Actions/Contacts/EditTest.php
@@ -13,8 +13,8 @@ class Actions_Contacts_Edit extends ActionTestCase
         $action = new rcmail_action_contacts_edit();
         $output = $this->initOutput(rcmail_action::MODE_HTTP, 'contacts', 'edit');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         self::initDB('contacts');
 
@@ -31,11 +31,11 @@ class Actions_Contacts_Edit extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame('contactedit', $output->template);
-        $this->assertSame('Edit contact', $output->getProperty('pagetitle'));
-        $this->assertSame($contact['contact_id'], $output->get_env('cid'));
-        $this->assertTrue(stripos($result, '<!DOCTYPE html>') === 0);
-        $this->assertTrue(strpos($result, "rcmail.gui_object('contactphoto', 'contactpic');") !== false);
+        self::assertSame('contactedit', $output->template);
+        self::assertSame('Edit contact', $output->getProperty('pagetitle'));
+        self::assertSame($contact['contact_id'], $output->get_env('cid'));
+        self::assertTrue(stripos($result, '<!DOCTYPE html>') === 0);
+        self::assertTrue(strpos($result, "rcmail.gui_object('contactphoto', 'contactpic');") !== false);
     }
 
     /**
@@ -43,7 +43,7 @@ class Actions_Contacts_Edit extends ActionTestCase
      */
     public function test_run_add_mode()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -51,7 +51,7 @@ class Actions_Contacts_Edit extends ActionTestCase
      */
     public function test_contact_edithead()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -59,7 +59,7 @@ class Actions_Contacts_Edit extends ActionTestCase
      */
     public function test_contact_editform()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -67,7 +67,7 @@ class Actions_Contacts_Edit extends ActionTestCase
      */
     public function test_get_form_tags()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -75,7 +75,7 @@ class Actions_Contacts_Edit extends ActionTestCase
      */
     public function test_upload_photo_form()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -86,7 +86,7 @@ class Actions_Contacts_Edit extends ActionTestCase
         $output = $this->initOutput(rcmail_action::MODE_HTTP, 'contacts', 'edit');
         $result = rcmail_action_contacts_edit::photo_drop_area([]);
 
-        $this->assertNull($output->get_env('filedrop'));
+        self::assertNull($output->get_env('filedrop'));
 
         $output = $this->initOutput(rcmail_action::MODE_HTTP, 'contacts', 'edit');
         $result = rcmail_action_contacts_edit::photo_drop_area(['id' => 'test']);
@@ -94,10 +94,10 @@ class Actions_Contacts_Edit extends ActionTestCase
         $scripts = $output->getProperty('scripts');
         $filedrop = $output->get_env('filedrop');
 
-        $this->assertSame("rcmail.gui_object('filedrop', 'test');", trim($scripts['head']));
-        $this->assertSame('upload-photo', $filedrop['action']);
-        $this->assertSame('_photo', $filedrop['fieldname']);
-        $this->assertSame(1, $filedrop['single']);
-        $this->assertSame('^image/.+', $filedrop['filter']);
+        self::assertSame("rcmail.gui_object('filedrop', 'test');", trim($scripts['head']));
+        self::assertSame('upload-photo', $filedrop['action']);
+        self::assertSame('_photo', $filedrop['fieldname']);
+        self::assertSame(1, $filedrop['single']);
+        self::assertSame('^image/.+', $filedrop['filter']);
     }
 }

--- a/tests/Actions/Contacts/ExportTest.php
+++ b/tests/Actions/Contacts/ExportTest.php
@@ -13,8 +13,8 @@ class Actions_Contacts_Export extends ActionTestCase
         $action = new rcmail_action_contacts_export();
         $output = $this->initOutput(rcmail_action::MODE_HTTP, 'contacts', 'export');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         self::initDB('contacts');
 
@@ -24,7 +24,7 @@ class Actions_Contacts_Export extends ActionTestCase
         // Here we expect request security check error
         $this->runAndAssert($action, OutputHtmlMock::E_EXIT);
 
-        $this->assertSame('ERROR: Request security check failed', trim(StderrMock::$output));
+        self::assertSame('ERROR: Request security check failed', trim(StderrMock::$output));
 
         // Now we'll try with the proper token
         $_SESSION['request_token'] = 'secure';
@@ -35,14 +35,14 @@ class Actions_Contacts_Export extends ActionTestCase
         $vcf = ob_get_contents();
         ob_end_clean();
 
-        $this->assertSame([
+        self::assertSame([
                 'Content-Type: text/vcard; charset=UTF-8',
                 'Content-Disposition: attachment; filename="contacts.vcf"',
             ], $output->headers
         );
-        $this->assertSame(6, substr_count($vcf, 'BEGIN:VCARD'));
-        $this->assertSame(6, substr_count($vcf, 'END:VCARD'));
-        $this->assertSame(1, substr_count($vcf, 'FN:Jane Stalone'));
+        self::assertSame(6, substr_count($vcf, 'BEGIN:VCARD'));
+        self::assertSame(6, substr_count($vcf, 'END:VCARD'));
+        self::assertSame(1, substr_count($vcf, 'FN:Jane Stalone'));
     }
 
     /**
@@ -55,7 +55,7 @@ class Actions_Contacts_Export extends ActionTestCase
         $action = new rcmail_action_contacts_export();
         $output = $this->initOutput(rcmail_action::MODE_HTTP, 'contacts', 'export');
 
-        $this->assertTrue($action->checks());
+        self::assertTrue($action->checks());
 
         $cids = [];
         $db = rcmail::get_instance()->get_dbh();
@@ -76,16 +76,16 @@ class Actions_Contacts_Export extends ActionTestCase
         $vcf = ob_get_contents();
         ob_end_clean();
 
-        $this->assertSame([
+        self::assertSame([
                 'Content-Type: text/vcard; charset=UTF-8',
                 'Content-Disposition: attachment; filename="contacts.vcf"',
             ], $output->headers
         );
-        $this->assertSame(2, substr_count($vcf, 'BEGIN:VCARD'));
-        $this->assertSame(2, substr_count($vcf, 'END:VCARD'));
-        $this->assertSame(0, substr_count($vcf, 'FN:Jane Stalone'));
-        $this->assertSame(1, substr_count($vcf, 'FN:Jack Rian'));
-        $this->assertSame(1, substr_count($vcf, 'FN:George Bush'));
+        self::assertSame(2, substr_count($vcf, 'BEGIN:VCARD'));
+        self::assertSame(2, substr_count($vcf, 'END:VCARD'));
+        self::assertSame(0, substr_count($vcf, 'FN:Jane Stalone'));
+        self::assertSame(1, substr_count($vcf, 'FN:Jack Rian'));
+        self::assertSame(1, substr_count($vcf, 'FN:George Bush'));
     }
 
     /**
@@ -95,7 +95,7 @@ class Actions_Contacts_Export extends ActionTestCase
      */
     public function test_export_search()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -103,6 +103,6 @@ class Actions_Contacts_Export extends ActionTestCase
      */
     public function test_prepare_for_export()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 }

--- a/tests/Actions/Contacts/GroupAddmembersTest.php
+++ b/tests/Actions/Contacts/GroupAddmembersTest.php
@@ -13,8 +13,8 @@ class Actions_Contacts_Group_Addmembers extends ActionTestCase
         $action = new rcmail_action_contacts_group_addmembers();
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'contacts', 'add-members');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         // Invalid group id
         $_POST = ['_source' => '0', '_gid' => 'unknown'];
@@ -23,9 +23,9 @@ class Actions_Contacts_Group_Addmembers extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('add-members', $result['action']);
-        $this->assertSame('this.display_message("No group assignments changed.","notice",0);', trim($result['exec']));
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('add-members', $result['action']);
+        self::assertSame('this.display_message("No group assignments changed.","notice",0);', trim($result['exec']));
 
         // Readonly addressbook
         $_POST = ['_source' => rcube_addressbook::TYPE_RECIPIENT, '_gid' => 'test'];
@@ -34,9 +34,9 @@ class Actions_Contacts_Group_Addmembers extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('add-members', $result['action']);
-        $this->assertSame('this.display_message("This address source is read only.","warning",0);', trim($result['exec']));
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('add-members', $result['action']);
+        self::assertSame('this.display_message("This address source is read only.","warning",0);', trim($result['exec']));
     }
 
     /**
@@ -47,7 +47,7 @@ class Actions_Contacts_Group_Addmembers extends ActionTestCase
         $action = new rcmail_action_contacts_group_addmembers();
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'contacts', 'add-members');
 
-        $this->assertTrue($action->checks());
+        self::assertTrue($action->checks());
 
         self::initDB('contacts');
 
@@ -65,13 +65,13 @@ class Actions_Contacts_Group_Addmembers extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('add-members', $result['action']);
-        $this->assertSame('this.display_message("Successfully added the contacts to this group.","confirmation",0);', trim($result['exec']));
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('add-members', $result['action']);
+        self::assertSame('this.display_message("Successfully added the contacts to this group.","confirmation",0);', trim($result['exec']));
 
         $query = $db->query('SELECT * FROM `contactgroupmembers` WHERE `contactgroup_id` = ? AND `contact_id` = ?', $gid, $cid);
         $result = $db->fetch_assoc($query);
 
-        $this->assertTrue(!empty($result));
+        self::assertTrue(!empty($result));
     }
 }

--- a/tests/Actions/Contacts/GroupCreateTest.php
+++ b/tests/Actions/Contacts/GroupCreateTest.php
@@ -13,8 +13,8 @@ class Actions_Contacts_Group_Create extends ActionTestCase
         $action = new rcmail_action_contacts_group_create();
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'contacts', 'group-create');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         // Unset group name
         $_POST = ['_source' => '0', '_name' => ''];
@@ -23,9 +23,9 @@ class Actions_Contacts_Group_Create extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('group-create', $result['action']);
-        $this->assertSame('this.display_message("An error occurred while saving.","error",0);', trim($result['exec']));
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('group-create', $result['action']);
+        self::assertSame('this.display_message("An error occurred while saving.","error",0);', trim($result['exec']));
 
         // Readonly addressbook
         $_POST = ['_source' => rcube_addressbook::TYPE_RECIPIENT, '_name' => 'test'];
@@ -34,9 +34,9 @@ class Actions_Contacts_Group_Create extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('group-create', $result['action']);
-        $this->assertSame('this.display_message("This address source is read only.","warning",0);', trim($result['exec']));
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('group-create', $result['action']);
+        self::assertSame('this.display_message("This address source is read only.","warning",0);', trim($result['exec']));
     }
 
     /**
@@ -47,7 +47,7 @@ class Actions_Contacts_Group_Create extends ActionTestCase
         $action = new rcmail_action_contacts_group_create();
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'contacts', 'group-create');
 
-        $this->assertTrue($action->checks());
+        self::assertTrue($action->checks());
 
         self::initDB('contacts');
 
@@ -57,15 +57,15 @@ class Actions_Contacts_Group_Create extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('group-create', $result['action']);
-        $this->assertTrue(strpos($result['exec'], 'this.display_message("Group created successfully.","confirmation",0);') !== false);
-        $this->assertTrue(strpos($result['exec'], 'this.insert_contact_group({"source":"0","id":"2","name":"test"});') !== false);
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('group-create', $result['action']);
+        self::assertTrue(strpos($result['exec'], 'this.display_message("Group created successfully.","confirmation",0);') !== false);
+        self::assertTrue(strpos($result['exec'], 'this.insert_contact_group({"source":"0","id":"2","name":"test"});') !== false);
 
         $db = rcmail::get_instance()->get_dbh();
         $query = $db->query('SELECT * FROM `contactgroups` WHERE `user_id` = 1 AND `name` = \'test\'');
         $result = $db->fetch_assoc($query);
 
-        $this->assertTrue(!empty($result));
+        self::assertTrue(!empty($result));
     }
 }

--- a/tests/Actions/Contacts/GroupDeleteTest.php
+++ b/tests/Actions/Contacts/GroupDeleteTest.php
@@ -13,8 +13,8 @@ class Actions_Contacts_Group_Delete extends ActionTestCase
         $action = new rcmail_action_contacts_group_delete();
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'contacts', 'group-delete');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         // Invalid group id
         $_POST = ['_source' => '0', '_gid' => 'unknown'];
@@ -23,9 +23,9 @@ class Actions_Contacts_Group_Delete extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('group-delete', $result['action']);
-        $this->assertSame('this.display_message("An error occurred while saving.","error",0);', trim($result['exec']));
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('group-delete', $result['action']);
+        self::assertSame('this.display_message("An error occurred while saving.","error",0);', trim($result['exec']));
 
         // Readonly addressbook
         $_POST = ['_source' => rcube_addressbook::TYPE_RECIPIENT, '_name' => 'test'];
@@ -34,9 +34,9 @@ class Actions_Contacts_Group_Delete extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('group-delete', $result['action']);
-        $this->assertSame('this.display_message("This address source is read only.","warning",0);', trim($result['exec']));
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('group-delete', $result['action']);
+        self::assertSame('this.display_message("This address source is read only.","warning",0);', trim($result['exec']));
     }
 
     /**
@@ -47,7 +47,7 @@ class Actions_Contacts_Group_Delete extends ActionTestCase
         $action = new rcmail_action_contacts_group_delete();
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'contacts', 'group-delete');
 
-        $this->assertTrue($action->checks());
+        self::assertTrue($action->checks());
 
         self::initDB('contacts');
 
@@ -62,14 +62,14 @@ class Actions_Contacts_Group_Delete extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('group-delete', $result['action']);
-        $this->assertTrue(strpos($result['exec'], 'this.display_message("Group deleted successfully.","confirmation",0);') !== false);
-        $this->assertTrue(strpos($result['exec'], 'this.remove_group_item({"source":"0","id":"' . $gid . '"});') !== false);
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('group-delete', $result['action']);
+        self::assertTrue(strpos($result['exec'], 'this.display_message("Group deleted successfully.","confirmation",0);') !== false);
+        self::assertTrue(strpos($result['exec'], 'this.remove_group_item({"source":"0","id":"' . $gid . '"});') !== false);
 
         $query = $db->query('SELECT * FROM `contactgroups` WHERE `contactgroup_id` = ? AND `del` = 1', $gid);
         $result = $db->fetch_assoc($query);
 
-        $this->assertTrue(!empty($result));
+        self::assertTrue(!empty($result));
     }
 }

--- a/tests/Actions/Contacts/GroupDelmembersTest.php
+++ b/tests/Actions/Contacts/GroupDelmembersTest.php
@@ -13,8 +13,8 @@ class Actions_Contacts_Group_Delmembers extends ActionTestCase
         $action = new rcmail_action_contacts_group_delmembers();
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'contacts', 'del-members');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         // Invalid group id
         $_POST = ['_source' => '0', '_gid' => 'unknown'];
@@ -23,9 +23,9 @@ class Actions_Contacts_Group_Delmembers extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('del-members', $result['action']);
-        $this->assertSame('this.display_message("An error occurred while saving.","error",0);', trim($result['exec']));
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('del-members', $result['action']);
+        self::assertSame('this.display_message("An error occurred while saving.","error",0);', trim($result['exec']));
 
         // Readonly addressbook
         $_POST = ['_source' => rcube_addressbook::TYPE_RECIPIENT, '_gid' => 'test'];
@@ -34,9 +34,9 @@ class Actions_Contacts_Group_Delmembers extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('del-members', $result['action']);
-        $this->assertSame('this.display_message("This address source is read only.","warning",0);', trim($result['exec']));
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('del-members', $result['action']);
+        self::assertSame('this.display_message("This address source is read only.","warning",0);', trim($result['exec']));
     }
 
     /**
@@ -47,7 +47,7 @@ class Actions_Contacts_Group_Delmembers extends ActionTestCase
         $action = new rcmail_action_contacts_group_delmembers();
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'contacts', 'del-members');
 
-        $this->assertTrue($action->checks());
+        self::assertTrue($action->checks());
 
         self::initDB('contacts');
 
@@ -66,14 +66,14 @@ class Actions_Contacts_Group_Delmembers extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('del-members', $result['action']);
-        $this->assertTrue(strpos($result['exec'], 'this.display_message("Successfully removed contacts from this group.","confirmation",0);') !== false);
-        $this->assertTrue(strpos($result['exec'], 'this.remove_group_contacts({"source":"0","gid":"' . $gid . '"});') !== false);
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('del-members', $result['action']);
+        self::assertTrue(strpos($result['exec'], 'this.display_message("Successfully removed contacts from this group.","confirmation",0);') !== false);
+        self::assertTrue(strpos($result['exec'], 'this.remove_group_contacts({"source":"0","gid":"' . $gid . '"});') !== false);
 
         $query = $db->query('SELECT * FROM `contactgroupmembers` WHERE `contactgroup_id` = ? AND `contact_id` = ?', $gid, $cid);
         $result = $db->fetch_assoc($query);
 
-        $this->assertTrue(empty($result));
+        self::assertTrue(empty($result));
     }
 }

--- a/tests/Actions/Contacts/GroupRenameTest.php
+++ b/tests/Actions/Contacts/GroupRenameTest.php
@@ -13,8 +13,8 @@ class Actions_Contacts_Group_Rename extends ActionTestCase
         $action = new rcmail_action_contacts_group_rename();
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'contacts', 'group-rename');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         // Invalid group id
         $_POST = ['_source' => '0', '_gid' => 'unknown', '_name' => ''];
@@ -23,9 +23,9 @@ class Actions_Contacts_Group_Rename extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('group-rename', $result['action']);
-        $this->assertSame('this.display_message("An error occurred while saving.","error",0);', trim($result['exec']));
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('group-rename', $result['action']);
+        self::assertSame('this.display_message("An error occurred while saving.","error",0);', trim($result['exec']));
 
         // Readonly addressbook
         $_POST = ['_source' => rcube_addressbook::TYPE_RECIPIENT, '_gid' => 'aaa', '_name' => 'new-test'];
@@ -34,9 +34,9 @@ class Actions_Contacts_Group_Rename extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('group-rename', $result['action']);
-        $this->assertSame('this.display_message("This address source is read only.","warning",0);', trim($result['exec']));
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('group-rename', $result['action']);
+        self::assertSame('this.display_message("This address source is read only.","warning",0);', trim($result['exec']));
     }
 
     /**
@@ -47,7 +47,7 @@ class Actions_Contacts_Group_Rename extends ActionTestCase
         $action = new rcmail_action_contacts_group_rename();
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'contacts', 'group-rename');
 
-        $this->assertTrue($action->checks());
+        self::assertTrue($action->checks());
 
         self::initDB('contacts');
 
@@ -62,14 +62,14 @@ class Actions_Contacts_Group_Rename extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('group-rename', $result['action']);
-        $this->assertTrue(strpos($result['exec'], 'this.display_message("Group renamed successfully.","confirmation",0);') !== false);
-        $this->assertTrue(strpos($result['exec'], 'this.update_contact_group({"source":"0","id":"' . $gid . '","name":"new-name"') !== false);
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('group-rename', $result['action']);
+        self::assertTrue(strpos($result['exec'], 'this.display_message("Group renamed successfully.","confirmation",0);') !== false);
+        self::assertTrue(strpos($result['exec'], 'this.update_contact_group({"source":"0","id":"' . $gid . '","name":"new-name"') !== false);
 
         $query = $db->query('SELECT * FROM `contactgroups` WHERE `contactgroup_id` = ? AND `name` = ?', $gid, 'new-name');
         $result = $db->fetch_assoc($query);
 
-        $this->assertTrue(!empty($result));
+        self::assertTrue(!empty($result));
     }
 }

--- a/tests/Actions/Contacts/ImportTest.php
+++ b/tests/Actions/Contacts/ImportTest.php
@@ -13,8 +13,8 @@ class Actions_Contacts_Import extends ActionTestCase
         $action = new rcmail_action_contacts_import();
         $output = $this->initOutput(rcmail_action::MODE_HTTP, 'contacts', 'import');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         self::initDB('contacts');
 
@@ -24,10 +24,10 @@ class Actions_Contacts_Import extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame('contactimport', $output->template);
-        $this->assertSame('Import contacts', $output->getProperty('pagetitle'));
-        $this->assertTrue(stripos($result, '<!DOCTYPE html>') === 0);
-        $this->assertTrue(strpos($result, "rcmail.gui_object('importform', 'rcmImportForm');") !== false);
+        self::assertSame('contactimport', $output->template);
+        self::assertSame('Import contacts', $output->getProperty('pagetitle'));
+        self::assertTrue(stripos($result, '<!DOCTYPE html>') === 0);
+        self::assertTrue(strpos($result, "rcmail.gui_object('importform', 'rcmImportForm');") !== false);
     }
 
     /**
@@ -36,6 +36,6 @@ class Actions_Contacts_Import extends ActionTestCase
     public function test_run_steps()
     {
         // TODO: Test all import steps
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 }

--- a/tests/Actions/Contacts/IndexTest.php
+++ b/tests/Actions/Contacts/IndexTest.php
@@ -13,23 +13,23 @@ class Actions_Contacts_Index extends ActionTestCase
         $action = new rcmail_action_contacts_index();
         $output = $this->initOutput(rcmail_action::MODE_HTTP, 'contacts', '');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         // self::initDB('contacts');
 
         $action->run();
 
-        $this->assertSame([], $output->headers);
-        $this->assertNull($output->getOutput());
+        self::assertSame([], $output->headers);
+        self::assertNull($output->getOutput());
 
         $sources = $output->get_env('address_sources');
 
-        $this->assertCount(3, $sources);
-        $this->assertSame('Personal Addresses', $sources[0]['name']);
-        $this->assertSame('Collected Recipients', $sources[1]['name']);
-        $this->assertSame('Trusted Senders', $sources[2]['name']);
-        $this->assertSame('Contacts', $output->getProperty('pagetitle'));
+        self::assertCount(3, $sources);
+        self::assertSame('Personal Addresses', $sources[0]['name']);
+        self::assertSame('Collected Recipients', $sources[1]['name']);
+        self::assertSame('Trusted Senders', $sources[2]['name']);
+        self::assertSame('Contacts', $output->getProperty('pagetitle'));
     }
 
     /**
@@ -40,16 +40,16 @@ class Actions_Contacts_Index extends ActionTestCase
         $action = new rcmail_action_contacts_index();
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'contacts', 'list');
 
-        $this->assertTrue($action->checks());
+        self::assertTrue($action->checks());
 
         // self::initDB('contacts');
 
         $action->run();
 
-        $this->assertSame([], $output->headers);
-        $this->assertNull($output->getOutput());
-        $this->assertNull($output->get_env('address_sources'));
-        $this->assertSame('', $output->getProperty('pagetitle'));
+        self::assertSame([], $output->headers);
+        self::assertNull($output->getOutput());
+        self::assertNull($output->get_env('address_sources'));
+        self::assertSame('', $output->getProperty('pagetitle'));
     }
 
     /**
@@ -57,7 +57,7 @@ class Actions_Contacts_Index extends ActionTestCase
      */
     public function test_contact_source()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -65,7 +65,7 @@ class Actions_Contacts_Index extends ActionTestCase
      */
     public function test_set_sourcename()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -73,7 +73,7 @@ class Actions_Contacts_Index extends ActionTestCase
      */
     public function test_directory_list()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -81,7 +81,7 @@ class Actions_Contacts_Index extends ActionTestCase
      */
     public function test_savedsearch_list()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -89,7 +89,7 @@ class Actions_Contacts_Index extends ActionTestCase
      */
     public function test_contact_groups()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -97,7 +97,7 @@ class Actions_Contacts_Index extends ActionTestCase
      */
     public function test_contacts_list()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -105,7 +105,7 @@ class Actions_Contacts_Index extends ActionTestCase
      */
     public function test_contacts_list_title()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -116,7 +116,7 @@ class Actions_Contacts_Index extends ActionTestCase
         $output = $this->initOutput(rcmail_action::MODE_HTTP, 'contacts', '');
         $result = rcmail_action_contacts_index::rowcount_display([]);
 
-        $this->assertSame('<span id="rcmcountdisplay">Loading...</span>', $result);
+        self::assertSame('<span id="rcmcountdisplay">Loading...</span>', $result);
     }
 
     /**
@@ -124,7 +124,7 @@ class Actions_Contacts_Index extends ActionTestCase
      */
     public function test_get_rowcount_text()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -135,7 +135,7 @@ class Actions_Contacts_Index extends ActionTestCase
         $output = $this->initOutput(rcmail_action::MODE_HTTP, 'contacts', '');
         $result = rcmail_action_contacts_index::get_type_label('home');
 
-        $this->assertSame('Home', $result);
+        self::assertSame('Home', $result);
     }
 
     /**
@@ -143,7 +143,7 @@ class Actions_Contacts_Index extends ActionTestCase
      */
     public function test_contact_form()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -151,7 +151,7 @@ class Actions_Contacts_Index extends ActionTestCase
      */
     public function test_contact_photo()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -159,7 +159,7 @@ class Actions_Contacts_Index extends ActionTestCase
      */
     public function test_search_update()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -167,7 +167,7 @@ class Actions_Contacts_Index extends ActionTestCase
      */
     public function test_get_cids()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -180,7 +180,7 @@ class Actions_Contacts_Index extends ActionTestCase
         $result = rcmail_action_contacts_index::source_selector([]);
         $expected = '<span>Personal Addresses<input type="hidden" name="_source" value="0"></span>';
 
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
 
         // TODO: Test more
     }

--- a/tests/Actions/Contacts/ListTest.php
+++ b/tests/Actions/Contacts/ListTest.php
@@ -13,8 +13,8 @@ class Actions_Contacts_List extends ActionTestCase
         $action = new rcmail_action_contacts_list();
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'contacts', 'list');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         self::initDB('contacts');
 
@@ -22,16 +22,16 @@ class Actions_Contacts_List extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('list', $result['action']);
-        $this->assertSame(1, $result['env']['pagecount']);
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('list', $result['action']);
+        self::assertSame(1, $result['env']['pagecount']);
 
         $commands = explode("\n", trim($result['exec']));
 
-        $this->assertCount(8, $commands);
-        $this->assertSame('this.set_group_prop(null);', $commands[0]);
-        $this->assertSame('this.set_rowcount("Contacts 1 to 6 of 6");', $commands[1]);
-        $this->assertStringMatchesFormat(
+        self::assertCount(8, $commands);
+        self::assertSame('this.set_group_prop(null);', $commands[0]);
+        self::assertSame('this.set_rowcount("Contacts 1 to 6 of 6");', $commands[1]);
+        self::assertStringMatchesFormat(
             'this.add_contact_row("%i",{"name":"George Bush"},"person",'
             . '{"name":"George Bush","email":"g.bush@gov.com","ID":"%i"});',
             $commands[2]

--- a/tests/Actions/Contacts/MailtoTest.php
+++ b/tests/Actions/Contacts/MailtoTest.php
@@ -13,8 +13,8 @@ class Actions_Contacts_Mailto extends ActionTestCase
         $action = new rcmail_action_contacts_mailto();
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'contacts', 'mailto');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         self::initDB('contacts');
 
@@ -29,12 +29,12 @@ class Actions_Contacts_Mailto extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('mailto', $result['action']);
-        $this->assertTrue(strpos($result['exec'], 'this.open_compose_step({"_mailto":"') !== false);
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('mailto', $result['action']);
+        self::assertTrue(strpos($result['exec'], 'this.open_compose_step({"_mailto":"') !== false);
 
         preg_match('/_mailto":"([0-9a-z]+)/', $result['exec'], $m);
 
-        $this->assertSame('John+Doe+%3Cjohndoe%40example.org%3E', $_SESSION['mailto'][$m[1]]);
+        self::assertSame('John+Doe+%3Cjohndoe%40example.org%3E', $_SESSION['mailto'][$m[1]]);
     }
 }

--- a/tests/Actions/Contacts/MoveTest.php
+++ b/tests/Actions/Contacts/MoveTest.php
@@ -13,8 +13,8 @@ class Actions_Contacts_Move extends ActionTestCase
         $action = new rcmail_action_contacts_move();
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'contacts', 'move');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         self::initDB('contacts');
 
@@ -29,21 +29,21 @@ class Actions_Contacts_Move extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('move', $result['action']);
-        $this->assertSame(0, $result['env']['pagecount']);
-        $this->assertTrue(strpos($result['exec'], 'this.display_message("Successfully moved 1 contacts.","confirmation",0);') !== false);
-        $this->assertTrue(strpos($result['exec'], 'this.set_rowcount("No contacts found.");') !== false);
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('move', $result['action']);
+        self::assertSame(0, $result['env']['pagecount']);
+        self::assertTrue(strpos($result['exec'], 'this.display_message("Successfully moved 1 contacts.","confirmation",0);') !== false);
+        self::assertTrue(strpos($result['exec'], 'this.set_rowcount("No contacts found.");') !== false);
 
         $query = $db->query('SELECT * FROM `contacts` WHERE `email` = ?', 'test@collected.eu');
         $result = $db->fetch_assoc($query);
 
-        $this->assertTrue(!empty($result));
+        self::assertTrue(!empty($result));
 
         $query = $db->query('SELECT * FROM `collected_addresses` WHERE `email` = ?', 'test@collected.eu');
         $result = $db->fetch_assoc($query);
 
-        $this->assertTrue(empty($result));
+        self::assertTrue(empty($result));
     }
 
     /**
@@ -52,6 +52,6 @@ class Actions_Contacts_Move extends ActionTestCase
     public function test_move_contact_to_group()
     {
         // Test error handling, test moving to a group, test moving multiple contacts
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 }

--- a/tests/Actions/Contacts/PhotoTest.php
+++ b/tests/Actions/Contacts/PhotoTest.php
@@ -13,15 +13,15 @@ class Actions_Contacts_Photo extends ActionTestCase
         $action = new rcmail_action_contacts_photo();
         $output = $this->initOutput(rcmail_action::MODE_HTTP, 'contacts', 'photo');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         $this->runAndAssert($action, OutputJsonMock::E_EXIT);
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: image/gif'], $output->headers);
-        $this->assertSame(base64_decode(rcmail_output::BLANK_GIF, true), $result);
+        self::assertSame(['Content-Type: image/gif'], $output->headers);
+        self::assertSame(base64_decode(rcmail_output::BLANK_GIF, true), $result);
 
         $_GET = ['_error' => 1];
 
@@ -29,8 +29,8 @@ class Actions_Contacts_Photo extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['HTTP/1.0 204 Photo not found'], $output->headers);
-        $this->assertSame('', $result);
+        self::assertSame(['HTTP/1.0 204 Photo not found'], $output->headers);
+        self::assertSame('', $result);
     }
 
     /**
@@ -38,6 +38,6 @@ class Actions_Contacts_Photo extends ActionTestCase
      */
     public function test_photo()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 }

--- a/tests/Actions/Contacts/PrintTest.php
+++ b/tests/Actions/Contacts/PrintTest.php
@@ -13,8 +13,8 @@ class Actions_Contacts_Print extends ActionTestCase
         $action = new rcmail_action_contacts_print();
         $output = $this->initOutput(rcmail_action::MODE_HTTP, 'contacts', 'print');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         self::initDB('contacts');
 
@@ -28,9 +28,9 @@ class Actions_Contacts_Print extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame('contactprint', $output->template);
-        $this->assertSame('', $output->getProperty('pagetitle')); // TODO: there should be a title
-        $this->assertTrue(stripos($result, '<!DOCTYPE html>') === 0);
+        self::assertSame('contactprint', $output->template);
+        self::assertSame('', $output->getProperty('pagetitle')); // TODO: there should be a title
+        self::assertTrue(stripos($result, '<!DOCTYPE html>') === 0);
     }
 
     /**
@@ -38,7 +38,7 @@ class Actions_Contacts_Print extends ActionTestCase
      */
     public function test_contact_head()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -46,6 +46,6 @@ class Actions_Contacts_Print extends ActionTestCase
      */
     public function test_contact_details()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 }

--- a/tests/Actions/Contacts/QrcodeTest.php
+++ b/tests/Actions/Contacts/QrcodeTest.php
@@ -13,20 +13,20 @@ class Actions_Contacts_Qrcode extends ActionTestCase
         $action = new rcmail_action_contacts_qrcode();
         $output = $this->initOutput(rcmail_action::MODE_HTTP, 'contacts', 'qrcode');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         $this->runAndAssert($action, OutputJsonMock::E_EXIT);
 
         $result = $output->getOutput();
 
-        $this->assertSame(['HTTP/1.0 404 Contact not found'], $output->headers);
-        $this->assertSame('', $result);
+        self::assertSame(['HTTP/1.0 404 Contact not found'], $output->headers);
+        self::assertSame('', $result);
 
         $type = $action->check_support();
 
         if (!$type) {
-            $this->markTestSkipped();
+            self::markTestSkipped();
         }
 
         $db = rcmail::get_instance()->get_dbh();
@@ -40,13 +40,13 @@ class Actions_Contacts_Qrcode extends ActionTestCase
         $result = $output->getOutput();
 
         if ($type == 'image/png') {
-            $this->assertSame('Content-Type: image/png', $output->headers[0]);
-            $this->assertMatchesRegularExpression('/^\x89\x50\x4E\x47/', $result);
+            self::assertSame('Content-Type: image/png', $output->headers[0]);
+            self::assertMatchesRegularExpression('/^\x89\x50\x4E\x47/', $result);
         } else {
-            $this->assertSame('Content-Type: image/svg+xml', $output->headers[0]);
-            $this->assertMatchesRegularExpression('/^<\?xml/', $result);
-            $this->assertMatchesRegularExpression('/<svg /', $result);
-            $this->assertMatchesRegularExpression('/<rect /', $result);
+            self::assertSame('Content-Type: image/svg+xml', $output->headers[0]);
+            self::assertMatchesRegularExpression('/^<\?xml/', $result);
+            self::assertMatchesRegularExpression('/<svg /', $result);
+            self::assertMatchesRegularExpression('/<rect /', $result);
         }
     }
 }

--- a/tests/Actions/Contacts/SaveTest.php
+++ b/tests/Actions/Contacts/SaveTest.php
@@ -13,35 +13,35 @@ class Actions_Contacts_Save extends ActionTestCase
         $action = new rcmail_action_contacts_save();
         $output = $this->initOutput(rcmail_action::MODE_HTTP, 'contacts', 'save');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         // reload
         $_GET = ['_reload' => 1];
 
         $action->run();
 
-        $this->assertNull($output->getOutput());
-        $this->assertNull($output->getProperty('message'));
-        $this->assertSame('add', rcmail::get_instance()->action);
+        self::assertNull($output->getOutput());
+        self::assertNull($output->getProperty('message'));
+        self::assertSame('add', rcmail::get_instance()->action);
 
         // readonly addressbook
         $_GET = ['_source' => rcube_addressbook::TYPE_RECIPIENT];
 
         $action->run();
 
-        $this->assertNull($output->getOutput());
-        $this->assertSame('contactreadonly', $output->getProperty('message'));
-        $this->assertSame('add', rcmail::get_instance()->action);
+        self::assertNull($output->getOutput());
+        self::assertSame('contactreadonly', $output->getProperty('message'));
+        self::assertSame('add', rcmail::get_instance()->action);
 
         // empty $_POST
         $_POST = ['_source' => '0'];
 
         $action->run();
 
-        $this->assertNull($output->getOutput());
-        $this->assertSame('nonamewarning', $output->getProperty('message'));
-        $this->assertSame('add', rcmail::get_instance()->action);
+        self::assertNull($output->getOutput());
+        self::assertSame('nonamewarning', $output->getProperty('message'));
+        self::assertSame('add', rcmail::get_instance()->action);
     }
 
     /**
@@ -66,15 +66,15 @@ class Actions_Contacts_Save extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame('iframe', $output->template);
-        $this->assertSame('successfullysaved', $output->getProperty('message'));
-        $this->assertTrue(stripos($result, '<!DOCTYPE html>') === 0);
+        self::assertSame('iframe', $output->template);
+        self::assertSame('successfullysaved', $output->getProperty('message'));
+        self::assertTrue(stripos($result, '<!DOCTYPE html>') === 0);
 
         $db = rcmail::get_instance()->get_dbh();
         $query = $db->query('SELECT `contact_id` FROM `contacts` WHERE `email` = ?', 'test@user.com');
         $contact = $db->fetch_assoc($query);
 
-        $this->assertTrue(!empty($contact));
+        self::assertTrue(!empty($contact));
     }
 
     /**
@@ -82,7 +82,7 @@ class Actions_Contacts_Save extends ActionTestCase
      */
     public function test_run_existing_contact()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -90,6 +90,6 @@ class Actions_Contacts_Save extends ActionTestCase
      */
     public function test_process_input()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 }

--- a/tests/Actions/Contacts/SearchCreateTest.php
+++ b/tests/Actions/Contacts/SearchCreateTest.php
@@ -13,8 +13,8 @@ class Actions_Contacts_Search_Create extends ActionTestCase
         $action = new rcmail_action_contacts_search_create();
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'contacts', 'search-create');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         // Unset group name
         $_POST = ['_name' => ''];
@@ -23,9 +23,9 @@ class Actions_Contacts_Search_Create extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('search-create', $result['action']);
-        $this->assertSame('this.display_message("Could not create saved search.","error",0);', trim($result['exec']));
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('search-create', $result['action']);
+        self::assertSame('this.display_message("Could not create saved search.","error",0);', trim($result['exec']));
     }
 
     /**
@@ -36,7 +36,7 @@ class Actions_Contacts_Search_Create extends ActionTestCase
         $action = new rcmail_action_contacts_search_create();
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'contacts', 'search-create');
 
-        $this->assertTrue($action->checks());
+        self::assertTrue($action->checks());
 
         self::initDB('searches');
 
@@ -50,15 +50,15 @@ class Actions_Contacts_Search_Create extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('search-create', $result['action']);
-        $this->assertTrue(strpos($result['exec'], 'this.display_message("Saved search created successfully.","confirmation",0);') !== false);
-        $this->assertTrue(strpos($result['exec'], 'this.insert_saved_search("test2",') !== false);
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('search-create', $result['action']);
+        self::assertTrue(strpos($result['exec'], 'this.display_message("Saved search created successfully.","confirmation",0);') !== false);
+        self::assertTrue(strpos($result['exec'], 'this.insert_saved_search("test2",') !== false);
 
         $db = rcmail::get_instance()->get_dbh();
         $query = $db->query('SELECT * FROM `searches` WHERE `name` = \'test2\'');
         $result = $db->fetch_assoc($query);
 
-        $this->assertTrue(!empty($result));
+        self::assertTrue(!empty($result));
     }
 }

--- a/tests/Actions/Contacts/SearchDeleteTest.php
+++ b/tests/Actions/Contacts/SearchDeleteTest.php
@@ -13,8 +13,8 @@ class Actions_Contacts_Search_Delete extends ActionTestCase
         $action = new rcmail_action_contacts_search_delete();
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'contacts', 'search-delete');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         $_POST = ['_sid' => 'unknown'];
 
@@ -22,9 +22,9 @@ class Actions_Contacts_Search_Delete extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('search-delete', $result['action']);
-        $this->assertSame('this.display_message("Could not delete saved search.","error",0);', trim($result['exec']));
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('search-delete', $result['action']);
+        self::assertSame('this.display_message("Could not delete saved search.","error",0);', trim($result['exec']));
     }
 
     /**
@@ -35,7 +35,7 @@ class Actions_Contacts_Search_Delete extends ActionTestCase
         $action = new rcmail_action_contacts_search_delete();
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'contacts', 'search-delete');
 
-        $this->assertTrue($action->checks());
+        self::assertTrue($action->checks());
 
         self::initDB('searches');
 
@@ -50,16 +50,16 @@ class Actions_Contacts_Search_Delete extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('search-delete', $result['action']);
-        $this->assertSame(0, $result['env']['pagecount']);
-        $this->assertTrue(strpos($result['exec'], 'this.display_message("Saved search deleted successfully.","confirmation",0);') !== false);
-        $this->assertTrue(strpos($result['exec'], 'this.remove_search_item("' . $sid . '")') !== false);
-        $this->assertTrue(strpos($result['exec'], 'this.set_rowcount("No contacts found.");') !== false);
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('search-delete', $result['action']);
+        self::assertSame(0, $result['env']['pagecount']);
+        self::assertTrue(strpos($result['exec'], 'this.display_message("Saved search deleted successfully.","confirmation",0);') !== false);
+        self::assertTrue(strpos($result['exec'], 'this.remove_search_item("' . $sid . '")') !== false);
+        self::assertTrue(strpos($result['exec'], 'this.set_rowcount("No contacts found.");') !== false);
 
         $query = $db->query('SELECT * FROM `searches` WHERE `name` = \'test\'');
         $result = $db->fetch_assoc($query);
 
-        $this->assertTrue(empty($result));
+        self::assertTrue(empty($result));
     }
 }

--- a/tests/Actions/Contacts/SearchTest.php
+++ b/tests/Actions/Contacts/SearchTest.php
@@ -13,8 +13,8 @@ class Actions_Contacts_Search extends ActionTestCase
         $action = new rcmail_action_contacts_search();
         $output = $this->initOutput(rcmail_action::MODE_HTTP, 'contacts', 'search');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         $_GET = ['_form' => 1];
 
@@ -22,9 +22,9 @@ class Actions_Contacts_Search extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame('contactsearch', $output->template);
-        $this->assertSame('', $output->getProperty('pagetitle')); // TODO: there should be a title
-        $this->assertTrue(stripos($result, '<!DOCTYPE html>') === 0);
+        self::assertSame('contactsearch', $output->template);
+        self::assertSame('', $output->getProperty('pagetitle')); // TODO: there should be a title
+        self::assertTrue(stripos($result, '<!DOCTYPE html>') === 0);
     }
 
     /**
@@ -35,7 +35,7 @@ class Actions_Contacts_Search extends ActionTestCase
         $action = new rcmail_action_contacts_search();
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'contacts', 'search');
 
-        $this->assertTrue($action->checks());
+        self::assertTrue($action->checks());
 
         self::initDB('contacts');
 
@@ -45,16 +45,16 @@ class Actions_Contacts_Search extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('search', $result['action']);
-        $this->assertSame(1, $result['env']['pagecount']);
-        $this->assertMatchesRegularExpression('/^[0-9a-z]{32}$/', $result['env']['search_request']);
-        $this->assertTrue(strpos($result['exec'], 'this.add_contact_row') !== false);
-        $this->assertTrue(strpos($result['exec'], 'this.set_rowcount("Contacts 1 to 1 of 1");') !== false);
-        $this->assertTrue(strpos($result['exec'], 'this.display_message("1 contacts found.","confirmation",0);') !== false);
-        $this->assertTrue(strpos($result['exec'], 'this.unselect_directory();') !== false);
-        $this->assertTrue(strpos($result['exec'], 'this.enable_command("search-create",true);') !== false);
-        $this->assertTrue(strpos($result['exec'], 'this.update_group_commands()') !== false);
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('search', $result['action']);
+        self::assertSame(1, $result['env']['pagecount']);
+        self::assertMatchesRegularExpression('/^[0-9a-z]{32}$/', $result['env']['search_request']);
+        self::assertTrue(strpos($result['exec'], 'this.add_contact_row') !== false);
+        self::assertTrue(strpos($result['exec'], 'this.set_rowcount("Contacts 1 to 1 of 1");') !== false);
+        self::assertTrue(strpos($result['exec'], 'this.display_message("1 contacts found.","confirmation",0);') !== false);
+        self::assertTrue(strpos($result['exec'], 'this.unselect_directory();') !== false);
+        self::assertTrue(strpos($result['exec'], 'this.enable_command("search-create",true);') !== false);
+        self::assertTrue(strpos($result['exec'], 'this.update_group_commands()') !== false);
     }
 
     /**
@@ -63,7 +63,7 @@ class Actions_Contacts_Search extends ActionTestCase
     public function test_run_search()
     {
         // TODO: Search using saved search, or using the form
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -71,6 +71,6 @@ class Actions_Contacts_Search extends ActionTestCase
      */
     public function test_contact_search_form()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 }

--- a/tests/Actions/Contacts/ShowTest.php
+++ b/tests/Actions/Contacts/ShowTest.php
@@ -13,8 +13,8 @@ class Actions_Contacts_Show extends ActionTestCase
         $action = new rcmail_action_contacts_show();
         $output = $this->initOutput(rcmail_action::MODE_HTTP, 'contacts', 'show');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         self::initDB('contacts');
 
@@ -31,12 +31,12 @@ class Actions_Contacts_Show extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame('contact', $output->template);
-        $this->assertSame('', $output->getProperty('pagetitle'));
-        $this->assertSame($contact['contact_id'], $output->get_env('cid'));
-        $this->assertFalse($output->get_env('readonly'));
-        $this->assertSame('Personal Addresses', $output->get_env('sourcename'));
-        $this->assertTrue(stripos($result, '<!DOCTYPE html>') === 0);
+        self::assertSame('contact', $output->template);
+        self::assertSame('', $output->getProperty('pagetitle'));
+        self::assertSame($contact['contact_id'], $output->get_env('cid'));
+        self::assertFalse($output->get_env('readonly'));
+        self::assertSame('Personal Addresses', $output->get_env('sourcename'));
+        self::assertTrue(stripos($result, '<!DOCTYPE html>') === 0);
     }
 
     /**
@@ -44,7 +44,7 @@ class Actions_Contacts_Show extends ActionTestCase
      */
     public function test_contact_head()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -52,7 +52,7 @@ class Actions_Contacts_Show extends ActionTestCase
      */
     public function test_contact_details()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -63,7 +63,7 @@ class Actions_Contacts_Show extends ActionTestCase
         $input = 'test@<email.tld';
         $expected = '<a href="mailto:test@&lt;email.tld" onclick="return rcmail.command(\'compose\',\'test@&lt;email.tld\',this)"'
             . ' title="Compose mail to" class="email">test@&lt;email.tld</a>';
-        $this->assertSame($expected, rcmail_action_contacts_show::render_email_value($input));
+        self::assertSame($expected, rcmail_action_contacts_show::render_email_value($input));
     }
 
     /**
@@ -73,7 +73,7 @@ class Actions_Contacts_Show extends ActionTestCase
     {
         $input = '+48-123<456';
         $expected = '<a href="tel:+48-123456" class="phone">+48-123&lt;456</a>';
-        $this->assertSame($expected, rcmail_action_contacts_show::render_phone_value($input));
+        self::assertSame($expected, rcmail_action_contacts_show::render_phone_value($input));
     }
 
     /**
@@ -83,7 +83,7 @@ class Actions_Contacts_Show extends ActionTestCase
     {
         $input = 'http://test/<123';
         $expected = '<a href="http://test/&lt;123" target="_blank" class="url">http://test/&lt;123</a>';
-        $this->assertSame($expected, rcmail_action_contacts_show::render_url_value($input));
+        self::assertSame($expected, rcmail_action_contacts_show::render_url_value($input));
     }
 
     /**
@@ -91,6 +91,6 @@ class Actions_Contacts_Show extends ActionTestCase
      */
     public function test_contact_record_groups()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 }

--- a/tests/Actions/Contacts/UndoTest.php
+++ b/tests/Actions/Contacts/UndoTest.php
@@ -13,8 +13,8 @@ class Actions_Contacts_Undo extends ActionTestCase
         $action = new rcmail_action_contacts_undo();
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'contacts', 'undo');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         self::initDB('contacts');
 
@@ -30,15 +30,15 @@ class Actions_Contacts_Undo extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('undo', $result['action']);
-        $this->assertTrue(strpos($result['exec'], 'his.display_message("Contact(s) restored successfully.","confirmation",0);') !== false);
-        $this->assertTrue(strpos($result['exec'], 'this.list_contacts()') !== false);
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('undo', $result['action']);
+        self::assertTrue(strpos($result['exec'], 'his.display_message("Contact(s) restored successfully.","confirmation",0);') !== false);
+        self::assertTrue(strpos($result['exec'], 'this.list_contacts()') !== false);
 
         $query = $db->query('SELECT * FROM `contacts` WHERE `contact_id` = ' . $cid);
         $result = $db->fetch_assoc($query);
 
-        $this->assertTrue(!empty($result));
-        $this->assertTrue(empty($result['del']));
+        self::assertTrue(!empty($result));
+        self::assertTrue(empty($result['del']));
     }
 }

--- a/tests/Actions/Contacts/UploadPhotoTest.php
+++ b/tests/Actions/Contacts/UploadPhotoTest.php
@@ -13,8 +13,8 @@ class Actions_Contacts_Upload_Photo extends ActionTestCase
         $action = new rcmail_action_contacts_upload_photo();
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'contacts', 'upload-photo');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         $_SERVER['REQUEST_METHOD'] = 'POST';
 
@@ -23,9 +23,9 @@ class Actions_Contacts_Upload_Photo extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('upload-photo', $result['action']);
-        $this->assertTrue(strpos($result['exec'], 'this.photo_upload_end();') !== false);
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('upload-photo', $result['action']);
+        self::assertTrue(strpos($result['exec'], 'this.photo_upload_end();') !== false);
 
         // Upload a file
         $file = $this->fakeUpload('_photo', false);
@@ -34,16 +34,16 @@ class Actions_Contacts_Upload_Photo extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('upload-photo', $result['action']);
-        $this->assertTrue(strpos($result['exec'], 'this.replace_contact_photo("' . $file['id'] . '");') !== false);
-        $this->assertTrue(strpos($result['exec'], 'this.photo_upload_end();') !== false);
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('upload-photo', $result['action']);
+        self::assertTrue(strpos($result['exec'], 'this.replace_contact_photo("' . $file['id'] . '");') !== false);
+        self::assertTrue(strpos($result['exec'], 'this.photo_upload_end();') !== false);
 
         $upload = rcmail::get_instance()->get_uploaded_file($file['id']);
-        $this->assertSame($file['name'], $upload['name']);
-        $this->assertSame($file['type'], $upload['mimetype']);
-        $this->assertSame($file['size'], $upload['size']);
-        $this->assertSame('contact', $upload['group']);
+        self::assertSame($file['name'], $upload['name']);
+        self::assertSame($file['type'], $upload['mimetype']);
+        self::assertSame($file['size'], $upload['size']);
+        self::assertSame('contact', $upload['group']);
 
         // TODO: Test invalid image format, upload errors handling
     }

--- a/tests/Actions/Login/OauthTest.php
+++ b/tests/Actions/Login/OauthTest.php
@@ -13,14 +13,14 @@ class Actions_Login_Oauth extends ActionTestCase
         $action = new rcmail_action_login_oauth();
         $output = $this->initOutput(rcmail_action::MODE_HTTP, 'login', '');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         $this->runAndAssert($action, OutputHtmlMock::E_EXIT);
 
         $result = $output->getOutput();
 
-        $this->assertSame("ERROR: Missing required OAuth config options 'oauth_auth_uri', 'oauth_client_id'", trim(StderrMock::$output));
-        $this->assertNull($output->getOutput());
+        self::assertSame("ERROR: Missing required OAuth config options 'oauth_auth_uri', 'oauth_client_id'", trim(StderrMock::$output));
+        self::assertNull($output->getOutput());
     }
 }

--- a/tests/Actions/Mail/AddcontactTest.php
+++ b/tests/Actions/Mail/AddcontactTest.php
@@ -12,6 +12,6 @@ class Actions_Mail_Addcontact extends ActionTestCase
     {
         $object = new rcmail_action_mail_addcontact();
 
-        $this->assertInstanceOf('rcmail_action', $object);
+        self::assertInstanceOf('rcmail_action', $object);
     }
 }

--- a/tests/Actions/Mail/AttachmentDeleteTest.php
+++ b/tests/Actions/Mail/AttachmentDeleteTest.php
@@ -14,8 +14,8 @@ class Actions_Mail_AttachmentDelete extends ActionTestCase
         $action = new rcmail_action_mail_attachment_delete();
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'mail', 'delete-attachment');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         // First we create the upload record
         $file = $this->fileUpload('101');
@@ -23,7 +23,7 @@ class Actions_Mail_AttachmentDelete extends ActionTestCase
         // Test list_uploaded_files(), just because
         $list = $rcmail->list_uploaded_files('101');
 
-        $this->assertSame([$file], $list);
+        self::assertSame([$file], $list);
 
         // This is needed so upload deletion works
         $rcmail = rcmail::get_instance();
@@ -43,9 +43,9 @@ class Actions_Mail_AttachmentDelete extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('delete-attachment', $result['action']);
-        $this->assertSame('this.remove_from_attachment_list("rcmfile' . $file['id'] . '");', trim($result['exec']));
-        $this->assertNull($rcmail->get_uploaded_file($file['id']));
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('delete-attachment', $result['action']);
+        self::assertSame('this.remove_from_attachment_list("rcmfile' . $file['id'] . '");', trim($result['exec']));
+        self::assertNull($rcmail->get_uploaded_file($file['id']));
     }
 }

--- a/tests/Actions/Mail/AttachmentDisplayTest.php
+++ b/tests/Actions/Mail/AttachmentDisplayTest.php
@@ -12,6 +12,6 @@ class Actions_Mail_AttachmentDisplay extends ActionTestCase
     {
         $object = new rcmail_action_mail_attachment_display();
 
-        $this->assertInstanceOf('rcmail_action', $object);
+        self::assertInstanceOf('rcmail_action', $object);
     }
 }

--- a/tests/Actions/Mail/AttachmentRenameTest.php
+++ b/tests/Actions/Mail/AttachmentRenameTest.php
@@ -14,8 +14,8 @@ class Actions_Mail_AttachmentRename extends ActionTestCase
         $action = new rcmail_action_mail_attachment_rename();
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'mail', 'rename-attachment');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         // First we create the upload record
         $file = $this->fileUpload('100');
@@ -29,12 +29,12 @@ class Actions_Mail_AttachmentRename extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('rename-attachment', $result['action']);
-        $this->assertSame('this.rename_attachment_handler("rcmfile' . $file['id'] . '","mod.gif");', trim($result['exec']));
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('rename-attachment', $result['action']);
+        self::assertSame('this.rename_attachment_handler("rcmfile' . $file['id'] . '","mod.gif");', trim($result['exec']));
 
         $upload = $rcmail->get_uploaded_file($file['id']);
-        $this->assertSame($_POST['_name'], $upload['name']);
-        $this->assertSame($_POST['_id'], $upload['group']);
+        self::assertSame($_POST['_name'], $upload['name']);
+        self::assertSame($_POST['_id'], $upload['group']);
     }
 }

--- a/tests/Actions/Mail/AttachmentUploadTest.php
+++ b/tests/Actions/Mail/AttachmentUploadTest.php
@@ -13,8 +13,8 @@ class Actions_Mail_AttachmentUpload extends ActionTestCase
         $action = new rcmail_action_mail_attachment_upload();
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'mail', 'upload');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         $_SERVER['REQUEST_METHOD'] = 'POST';
         $_GET = [
@@ -29,10 +29,10 @@ class Actions_Mail_AttachmentUpload extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('upload', $result['action']);
-        $this->assertTrue(strpos($result['exec'], 'this.remove_from_attachment_list("upload123");') !== false);
-        $this->assertTrue(strpos($result['exec'], 'this.auto_save_start(false);') !== false);
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('upload', $result['action']);
+        self::assertTrue(strpos($result['exec'], 'this.remove_from_attachment_list("upload123");') !== false);
+        self::assertTrue(strpos($result['exec'], 'this.auto_save_start(false);') !== false);
 
         // Upload a file
         $_SESSION = ['compose_data_123' => ['test' => 'test']];
@@ -43,16 +43,16 @@ class Actions_Mail_AttachmentUpload extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('upload', $result['action']);
-        $this->assertTrue(strpos($result['exec'], 'this.add2attachment_list("rcmfile' . $file['id'] . '"') !== false);
-        $this->assertTrue(strpos($result['exec'], 'this.auto_save_start(false);') !== false);
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('upload', $result['action']);
+        self::assertTrue(strpos($result['exec'], 'this.add2attachment_list("rcmfile' . $file['id'] . '"') !== false);
+        self::assertTrue(strpos($result['exec'], 'this.auto_save_start(false);') !== false);
 
         $upload = rcmail::get_instance()->get_uploaded_file($file['id']);
-        $this->assertSame($file['name'], $upload['name']);
-        $this->assertSame($file['type'], $upload['mimetype']);
-        $this->assertSame($file['size'], $upload['size']);
-        $this->assertSame($_GET['_id'], $upload['group']);
+        self::assertSame($file['name'], $upload['name']);
+        self::assertSame($file['type'], $upload['mimetype']);
+        self::assertSame($file['size'], $upload['size']);
+        self::assertSame($_GET['_id'], $upload['group']);
 
         // Upload error case
         $_SESSION = ['compose_data_123' => ['test' => 'test']];
@@ -62,10 +62,10 @@ class Actions_Mail_AttachmentUpload extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('upload', $result['action']);
-        $this->assertTrue(strpos($result['exec'], 'this.display_message("The uploaded file exceeds the maximum size') !== false);
-        $this->assertTrue(strpos($result['exec'], 'this.auto_save_start(false);') !== false);
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('upload', $result['action']);
+        self::assertTrue(strpos($result['exec'], 'this.display_message("The uploaded file exceeds the maximum size') !== false);
+        self::assertTrue(strpos($result['exec'], 'this.auto_save_start(false);') !== false);
 
         // TODO: Test max_message_size handling
     }
@@ -75,6 +75,6 @@ class Actions_Mail_AttachmentUpload extends ActionTestCase
      */
     public function test_uri()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 }

--- a/tests/Actions/Mail/AutocompleteTest.php
+++ b/tests/Actions/Mail/AutocompleteTest.php
@@ -12,6 +12,6 @@ class Actions_Mail_Autocomplete extends ActionTestCase
     {
         $object = new rcmail_action_mail_autocomplete();
 
-        $this->assertInstanceOf('rcmail_action', $object);
+        self::assertInstanceOf('rcmail_action', $object);
     }
 }

--- a/tests/Actions/Mail/BounceTest.php
+++ b/tests/Actions/Mail/BounceTest.php
@@ -12,6 +12,6 @@ class Actions_Mail_Bounce extends ActionTestCase
     {
         $object = new rcmail_action_mail_bounce();
 
-        $this->assertInstanceOf('rcmail_action', $object);
+        self::assertInstanceOf('rcmail_action', $object);
     }
 }

--- a/tests/Actions/Mail/CheckRecentTest.php
+++ b/tests/Actions/Mail/CheckRecentTest.php
@@ -12,6 +12,6 @@ class Actions_Mail_CheckRecent extends ActionTestCase
     {
         $object = new rcmail_action_mail_check_recent();
 
-        $this->assertInstanceOf('rcmail_action', $object);
+        self::assertInstanceOf('rcmail_action', $object);
     }
 }

--- a/tests/Actions/Mail/ComposeTest.php
+++ b/tests/Actions/Mail/ComposeTest.php
@@ -12,7 +12,7 @@ class Actions_Mail_Compose extends ActionTestCase
     {
         $object = new rcmail_action_mail_compose();
 
-        $this->assertInstanceOf('rcmail_action', $object);
+        self::assertInstanceOf('rcmail_action', $object);
     }
 
     /**
@@ -22,16 +22,16 @@ class Actions_Mail_Compose extends ActionTestCase
     {
         $action = new rcmail_action_mail_compose();
 
-        $this->assertSame('> ', $action->quote_text(''));
+        self::assertSame('> ', $action->quote_text(''));
 
         $result = $action->quote_text("test1\ntest2");
         $expected = "> test1\n> test2";
 
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
 
         $result = $action->quote_text("> test1\n> test2");
         $expected = ">> test1\n>> test2";
 
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 }

--- a/tests/Actions/Mail/CopyTest.php
+++ b/tests/Actions/Mail/CopyTest.php
@@ -12,7 +12,7 @@ class Actions_Mail_Copy extends ActionTestCase
     {
         $object = new rcmail_action_mail_copy();
 
-        $this->assertInstanceOf('rcmail_action', $object);
+        self::assertInstanceOf('rcmail_action', $object);
     }
 
     /**
@@ -23,7 +23,7 @@ class Actions_Mail_Copy extends ActionTestCase
         $action = new rcmail_action_mail_copy();
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'mail', 'copy');
 
-        $this->assertTrue($action->checks());
+        self::assertTrue($action->checks());
 
         $_POST = [
             '_uid' => 1,
@@ -41,11 +41,11 @@ class Actions_Mail_Copy extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('copy', $result['action']);
-        $this->assertTrue(strpos($result['exec'], 'this.display_message("Message(s) copied successfully.","confirmation",0);') !== false);
-        $this->assertTrue(strpos($result['exec'], 'this.set_unread_count("Trash",30,false,"");') !== false);
-        $this->assertTrue(strpos($result['exec'], 'this.set_quota(') !== false);
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('copy', $result['action']);
+        self::assertTrue(strpos($result['exec'], 'this.display_message("Message(s) copied successfully.","confirmation",0);') !== false);
+        self::assertTrue(strpos($result['exec'], 'this.set_unread_count("Trash",30,false,"");') !== false);
+        self::assertTrue(strpos($result['exec'], 'this.set_quota(') !== false);
     }
 
     /**
@@ -72,8 +72,8 @@ class Actions_Mail_Copy extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('copy', $result['action']);
-        $this->assertSame('this.display_message("Unable to perform operation. Folder is read-only.","error",0);', trim($result['exec']));
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('copy', $result['action']);
+        self::assertSame('this.display_message("Unable to perform operation. Folder is read-only.","error",0);', trim($result['exec']));
     }
 }

--- a/tests/Actions/Mail/DeleteTest.php
+++ b/tests/Actions/Mail/DeleteTest.php
@@ -12,6 +12,6 @@ class Actions_Mail_Delete extends ActionTestCase
     {
         $object = new rcmail_action_mail_delete();
 
-        $this->assertInstanceOf('rcmail_action', $object);
+        self::assertInstanceOf('rcmail_action', $object);
     }
 }

--- a/tests/Actions/Mail/FolderExpungeTest.php
+++ b/tests/Actions/Mail/FolderExpungeTest.php
@@ -12,7 +12,7 @@ class Actions_Mail_FolderExpunge extends ActionTestCase
     {
         $object = new rcmail_action_mail_folder_expunge();
 
-        $this->assertInstanceOf('rcmail_action', $object);
+        self::assertInstanceOf('rcmail_action', $object);
     }
 
     /**
@@ -23,7 +23,7 @@ class Actions_Mail_FolderExpunge extends ActionTestCase
         $action = new rcmail_action_mail_folder_expunge();
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'mail', 'expunge');
 
-        $this->assertTrue($action->checks());
+        self::assertTrue($action->checks());
 
         $_POST = ['_mbox' => 'INBOX'];
 
@@ -36,10 +36,10 @@ class Actions_Mail_FolderExpunge extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('expunge', $result['action']);
-        $this->assertTrue(strpos($result['exec'], 'this.display_message("Folder successfully compacted.","confirmation",0);') !== false);
-        $this->assertTrue(strpos($result['exec'], 'this.set_quota(') === false);
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('expunge', $result['action']);
+        self::assertTrue(strpos($result['exec'], 'this.display_message("Folder successfully compacted.","confirmation",0);') !== false);
+        self::assertTrue(strpos($result['exec'], 'this.set_quota(') === false);
     }
 
     /**
@@ -50,7 +50,7 @@ class Actions_Mail_FolderExpunge extends ActionTestCase
         $action = new rcmail_action_mail_folder_expunge();
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'mail', 'expunge');
 
-        $this->assertTrue($action->checks());
+        self::assertTrue($action->checks());
 
         $_POST = ['_mbox' => 'INBOX'];
         $_REQUEST = ['_reload' => 1];
@@ -64,10 +64,10 @@ class Actions_Mail_FolderExpunge extends ActionTestCase
 
         $commands = $output->getProperty('commands');
 
-        $this->assertNull($output->getOutput());
-        $this->assertSame('list', rcmail::get_instance()->action);
-        $this->assertCount(3, $commands);
-        $this->assertSame([
+        self::assertNull($output->getOutput());
+        self::assertSame('list', rcmail::get_instance()->action);
+        self::assertCount(3, $commands);
+        self::assertSame([
                 'display_message',
                 'Folder successfully compacted.',
                 'confirmation',
@@ -75,8 +75,8 @@ class Actions_Mail_FolderExpunge extends ActionTestCase
             ],
             $commands[0]
         );
-        $this->assertSame('set_quota', $commands[1][0]);
-        $this->assertSame('message_list.clear', $commands[2][0]);
+        self::assertSame('set_quota', $commands[1][0]);
+        self::assertSame('message_list.clear', $commands[2][0]);
     }
 
     /**
@@ -99,8 +99,8 @@ class Actions_Mail_FolderExpunge extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('expunge', $result['action']);
-        $this->assertSame('this.display_message("Unable to perform operation. Folder is read-only.","error",0);', trim($result['exec']));
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('expunge', $result['action']);
+        self::assertSame('this.display_message("Unable to perform operation. Folder is read-only.","error",0);', trim($result['exec']));
     }
 }

--- a/tests/Actions/Mail/FolderPurgeTest.php
+++ b/tests/Actions/Mail/FolderPurgeTest.php
@@ -12,6 +12,6 @@ class Actions_Mail_FolderPurge extends ActionTestCase
     {
         $object = new rcmail_action_mail_folder_purge();
 
-        $this->assertInstanceOf('rcmail_action', $object);
+        self::assertInstanceOf('rcmail_action', $object);
     }
 }

--- a/tests/Actions/Mail/GetTest.php
+++ b/tests/Actions/Mail/GetTest.php
@@ -12,6 +12,6 @@ class Actions_Mail_Get extends ActionTestCase
     {
         $object = new rcmail_action_mail_get();
 
-        $this->assertInstanceOf('rcmail_action', $object);
+        self::assertInstanceOf('rcmail_action', $object);
     }
 }

--- a/tests/Actions/Mail/GetunreadTest.php
+++ b/tests/Actions/Mail/GetunreadTest.php
@@ -12,6 +12,6 @@ class Actions_Mail_Getunread extends ActionTestCase
     {
         $object = new rcmail_action_mail_getunread();
 
-        $this->assertInstanceOf('rcmail_action', $object);
+        self::assertInstanceOf('rcmail_action', $object);
     }
 }

--- a/tests/Actions/Mail/GroupExpandTest.php
+++ b/tests/Actions/Mail/GroupExpandTest.php
@@ -12,6 +12,6 @@ class Actions_Mail_GroupExpand extends ActionTestCase
     {
         $object = new rcmail_action_mail_group_expand();
 
-        $this->assertInstanceOf('rcmail_action', $object);
+        self::assertInstanceOf('rcmail_action', $object);
     }
 }

--- a/tests/Actions/Mail/HeadersTest.php
+++ b/tests/Actions/Mail/HeadersTest.php
@@ -12,6 +12,6 @@ class Actions_Mail_Headers extends ActionTestCase
     {
         $object = new rcmail_action_mail_headers();
 
-        $this->assertInstanceOf('rcmail_action', $object);
+        self::assertInstanceOf('rcmail_action', $object);
     }
 }

--- a/tests/Actions/Mail/ImportTest.php
+++ b/tests/Actions/Mail/ImportTest.php
@@ -12,6 +12,6 @@ class Actions_Mail_Import extends ActionTestCase
     {
         $object = new rcmail_action_mail_import();
 
-        $this->assertInstanceOf('rcmail_action', $object);
+        self::assertInstanceOf('rcmail_action', $object);
     }
 }

--- a/tests/Actions/Mail/IndexTest.php
+++ b/tests/Actions/Mail/IndexTest.php
@@ -331,15 +331,15 @@ class Actions_Mail_Index extends ActionTestCase
         $body = rcmail_action_mail_index::print_body($part->body, $part, ['safe' => false]);
         $html = rcmail_action_mail_index::html4inline($body, $params);
 
-        $this->assertMatchesRegularExpression('/src="' . $part->replaces['ex1.jpg'] . '"/', $html, 'Replace reference to inline image');
-        $this->assertMatchesRegularExpression('#background="program/resources/blocked.gif"#', $html, 'Replace external background image');
-        $this->assertDoesNotMatchRegularExpression('/ex3.jpg/', $html, 'No references to external images');
-        $this->assertDoesNotMatchRegularExpression('/<meta [^>]+>/', $html, 'No meta tags allowed');
-        $this->assertDoesNotMatchRegularExpression('/<form [^>]+>/', $html, 'No form tags allowed');
-        $this->assertMatchesRegularExpression('/Subscription form/', $html, 'Include <form> contents');
-        $this->assertMatchesRegularExpression('/<!-- link ignored -->/', $html, 'No external links allowed');
-        $this->assertMatchesRegularExpression('/<a[^>]+ target="_blank"/', $html, 'Set target to _blank');
-        // $this->assertTrue($GLOBALS['REMOTE_OBJECTS'], "Remote object detected");
+        self::assertMatchesRegularExpression('/src="' . $part->replaces['ex1.jpg'] . '"/', $html, 'Replace reference to inline image');
+        self::assertMatchesRegularExpression('#background="program/resources/blocked.gif"#', $html, 'Replace external background image');
+        self::assertDoesNotMatchRegularExpression('/ex3.jpg/', $html, 'No references to external images');
+        self::assertDoesNotMatchRegularExpression('/<meta [^>]+>/', $html, 'No meta tags allowed');
+        self::assertDoesNotMatchRegularExpression('/<form [^>]+>/', $html, 'No form tags allowed');
+        self::assertMatchesRegularExpression('/Subscription form/', $html, 'Include <form> contents');
+        self::assertMatchesRegularExpression('/<!-- link ignored -->/', $html, 'No external links allowed');
+        self::assertMatchesRegularExpression('/<a[^>]+ target="_blank"/', $html, 'Set target to _blank');
+        // self::assertTrue($GLOBALS['REMOTE_OBJECTS'], "Remote object detected");
 
         // render HTML in safe mode
         $body = rcmail_action_mail_index::print_body($part->body, $part, ['safe' => true]);

--- a/tests/Actions/Mail/IndexTest.php
+++ b/tests/Actions/Mail/IndexTest.php
@@ -13,8 +13,8 @@ class Actions_Mail_Index extends ActionTestCase
         $action = new rcmail_action_mail_index();
         $output = $this->initOutput(rcmail_action::MODE_HTTP, 'mail', '');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         $_GET = ['_uid' => 10];
 
@@ -37,17 +37,17 @@ class Actions_Mail_Index extends ActionTestCase
 
         $action->run();
 
-        $this->assertSame([], $output->headers);
-        $this->assertNull($output->getOutput());
-        $this->assertSame('Inbox', $output->getProperty('pagetitle'));
-        $this->assertSame('INBOX', $output->get_env('mailbox'));
-        $this->assertSame(10, $output->get_env('pagesize'));
-        $this->assertSame('/', $output->get_env('delimiter'));
-        $this->assertSame('widescreen', $output->get_env('layout'));
-        $this->assertSame('Drafts', $output->get_env('drafts_mailbox'));
-        $this->assertSame('Trash', $output->get_env('trash_mailbox'));
-        $this->assertSame('Junk', $output->get_env('junk_mailbox'));
-        $this->assertSame(10, $output->get_env('list_uid'));
+        self::assertSame([], $output->headers);
+        self::assertNull($output->getOutput());
+        self::assertSame('Inbox', $output->getProperty('pagetitle'));
+        self::assertSame('INBOX', $output->get_env('mailbox'));
+        self::assertSame(10, $output->get_env('pagesize'));
+        self::assertSame('/', $output->get_env('delimiter'));
+        self::assertSame('widescreen', $output->get_env('layout'));
+        self::assertSame('Drafts', $output->get_env('drafts_mailbox'));
+        self::assertSame('Trash', $output->get_env('trash_mailbox'));
+        self::assertSame('Junk', $output->get_env('junk_mailbox'));
+        self::assertSame(10, $output->get_env('list_uid'));
     }
 
     /**
@@ -58,7 +58,7 @@ class Actions_Mail_Index extends ActionTestCase
         $action = new rcmail_action_mail_index();
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'mail', 'list');
 
-        $this->assertTrue($action->checks());
+        self::assertTrue($action->checks());
 
         // Set expected storage function calls/results
         self::mockStorage()
@@ -78,17 +78,17 @@ class Actions_Mail_Index extends ActionTestCase
 
         $action->run();
 
-        $this->assertSame([], $output->headers);
-        $this->assertNull($output->getOutput());
-        $this->assertSame('', $output->getProperty('pagetitle'));
-        $this->assertSame('INBOX', $output->get_env('mailbox'));
-        $this->assertSame(10, $output->get_env('pagesize'));
-        $this->assertSame(1, $output->get_env('current_page'));
-        $this->assertSame('/', $output->get_env('delimiter'));
-        $this->assertSame('widescreen', $output->get_env('layout'));
-        $this->assertSame('Drafts', $output->get_env('drafts_mailbox'));
-        $this->assertSame('Trash', $output->get_env('trash_mailbox'));
-        $this->assertSame('Junk', $output->get_env('junk_mailbox'));
+        self::assertSame([], $output->headers);
+        self::assertNull($output->getOutput());
+        self::assertSame('', $output->getProperty('pagetitle'));
+        self::assertSame('INBOX', $output->get_env('mailbox'));
+        self::assertSame(10, $output->get_env('pagesize'));
+        self::assertSame(1, $output->get_env('current_page'));
+        self::assertSame('/', $output->get_env('delimiter'));
+        self::assertSame('widescreen', $output->get_env('layout'));
+        self::assertSame('Drafts', $output->get_env('drafts_mailbox'));
+        self::assertSame('Trash', $output->get_env('trash_mailbox'));
+        self::assertSame('Junk', $output->get_env('junk_mailbox'));
     }
 
     /**
@@ -100,19 +100,19 @@ class Actions_Mail_Index extends ActionTestCase
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'mail', 'list');
 
         $output->set_env('mailbox', 'INBOX');
-        $this->assertSame('from', $action->message_list_smart_column_name());
+        self::assertSame('from', $action->message_list_smart_column_name());
 
         $output->set_env('mailbox', 'Drafts');
-        $this->assertSame('to', $action->message_list_smart_column_name());
+        self::assertSame('to', $action->message_list_smart_column_name());
 
         $output->set_env('mailbox', 'Drafts/Subfolder');
-        $this->assertSame('to', $action->message_list_smart_column_name());
+        self::assertSame('to', $action->message_list_smart_column_name());
 
         $output->set_env('mailbox', 'Sent');
-        $this->assertSame('to', $action->message_list_smart_column_name());
+        self::assertSame('to', $action->message_list_smart_column_name());
 
         $output->set_env('mailbox', 'Sent/Subfolder');
-        $this->assertSame('to', $action->message_list_smart_column_name());
+        self::assertSame('to', $action->message_list_smart_column_name());
     }
 
     /**
@@ -127,9 +127,9 @@ class Actions_Mail_Index extends ActionTestCase
 
         $result = $action->message_list([]);
 
-        $this->assertMatchesRegularExpression('/^<table id="rcubemessagelist".*<\/table>$/', $result);
+        self::assertMatchesRegularExpression('/^<table id="rcubemessagelist".*<\/table>$/', $result);
         $listcols = ['threads', 'subject', 'status', 'fromto', 'date', 'size', 'flag', 'attachment'];
-        $this->assertSame($listcols, $output->get_env('listcols'));
+        self::assertSame($listcols, $output->get_env('listcols'));
     }
 
     /**
@@ -148,10 +148,10 @@ class Actions_Mail_Index extends ActionTestCase
 
         $action->js_message_list([]);
 
-        $this->assertFalse($output->get_env('multifolder_listing'));
+        self::assertFalse($output->get_env('multifolder_listing'));
         $commands = $output->getProperty('commands');
-        $this->assertCount(1, $commands);
-        $this->assertSame('set_message_coltypes', $commands[0][0]);
+        self::assertCount(1, $commands);
+        self::assertSame('set_message_coltypes', $commands[0][0]);
     }
 
     /**
@@ -167,7 +167,7 @@ class Actions_Mail_Index extends ActionTestCase
         $expected = '<a href="#list-options" onclick="return rcmail.command(\'menu-open\', \'messagelistmenu\', this, event)"'
             . ' class="listmenu" id="listmenulink" title="List options..." tabindex="0"><img src="ico.png" alt="List options..."></a>';
 
-        $this->assertSame($expected, $link);
+        self::assertSame($expected, $link);
     }
 
     /**
@@ -175,7 +175,7 @@ class Actions_Mail_Index extends ActionTestCase
      */
     public function test_messagecount_display()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -183,7 +183,7 @@ class Actions_Mail_Index extends ActionTestCase
      */
     public function test_get_messagecount_text()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -191,7 +191,7 @@ class Actions_Mail_Index extends ActionTestCase
      */
     public function test_send_unread_count()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -199,7 +199,7 @@ class Actions_Mail_Index extends ActionTestCase
      */
     public function test_check_safe()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -207,7 +207,7 @@ class Actions_Mail_Index extends ActionTestCase
      */
     public function test_part_image_type()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -217,12 +217,12 @@ class Actions_Mail_Index extends ActionTestCase
     {
         $action = new rcmail_action_mail_index();
 
-        $this->assertNull($action->address_string(''));
+        self::assertNull($action->address_string(''));
 
         $result = $action->address_string('test@domain.com');
         $expected = '<span class="adr"><span title="test@domain.com" class="rcmContactAddress">test@domain.com</span></span>';
 
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
 
         $result = $action->address_string('test@domain.com', null, true, true);
         $expected = '<span class="adr"><a href="mailto:test@domain.com" class="rcmContactAddress" '
@@ -230,14 +230,14 @@ class Actions_Mail_Index extends ActionTestCase
             . 'test@domain.com</a><a href="#add" title="Add to address book" class="rcmaddcontact" '
             . 'onclick="return rcmail.command(\'add-contact\',\'test@domain.com\',this)"></a></span>';
 
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
 
         setProperty($action, 'PRINT_MODE', true);
 
         $result = $action->address_string('test@domain.com');
         $expected = '<span class="adr">&lt;test@domain.com&gt;</span>';
 
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     /**
@@ -250,13 +250,13 @@ class Actions_Mail_Index extends ActionTestCase
         $part->mime_id = '1';
 
         $part->mimetype = 'text/html';
-        $this->assertSame('HTML Message', $action->attachment_name($part));
+        self::assertSame('HTML Message', $action->attachment_name($part));
 
         $part->mimetype = 'application/pdf';
-        $this->assertSame('Part 1.pdf', $action->attachment_name($part));
+        self::assertSame('Part 1.pdf', $action->attachment_name($part));
 
         $part->filename = 'test.pdf';
-        $this->assertSame('test.pdf', $action->attachment_name($part));
+        self::assertSame('test.pdf', $action->attachment_name($part));
     }
 
     /**
@@ -264,7 +264,7 @@ class Actions_Mail_Index extends ActionTestCase
      */
     public function test_search_filter()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -272,7 +272,7 @@ class Actions_Mail_Index extends ActionTestCase
      */
     public function test_search_interval()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -280,7 +280,7 @@ class Actions_Mail_Index extends ActionTestCase
      */
     public function test_message_error()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -288,7 +288,7 @@ class Actions_Mail_Index extends ActionTestCase
      */
     public function test_message_import_form()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -312,7 +312,7 @@ class Actions_Mail_Index extends ActionTestCase
     {
         $object = new rcmail_action_mail_index();
 
-        $this->assertInstanceOf('rcmail_action', $object);
+        self::assertInstanceOf('rcmail_action', $object);
     }
 
     /**
@@ -345,11 +345,11 @@ class Actions_Mail_Index extends ActionTestCase
         $body = rcmail_action_mail_index::print_body($part->body, $part, ['safe' => true]);
         $html = rcmail_action_mail_index::html4inline($body, $params);
 
-        $this->assertMatchesRegularExpression('/<style [^>]+>/', $html, 'Allow styles in safe mode');
-        $this->assertMatchesRegularExpression('#src="http://evilsite.net/mailings/ex3.jpg"#', $html, 'Allow external images in HTML (safe mode)');
-        $this->assertMatchesRegularExpression("#url\\('?http://evilsite.net/newsletter/image/bg/bg-64.jpg'?\\)#", $html, 'Allow external images in CSS (safe mode)');
+        self::assertMatchesRegularExpression('/<style [^>]+>/', $html, 'Allow styles in safe mode');
+        self::assertMatchesRegularExpression('#src="http://evilsite.net/mailings/ex3.jpg"#', $html, 'Allow external images in HTML (safe mode)');
+        self::assertMatchesRegularExpression("#url\\('?http://evilsite.net/newsletter/image/bg/bg-64.jpg'?\\)#", $html, 'Allow external images in CSS (safe mode)');
         $css = '<link rel="stylesheet" .+_action=modcss.+_u=tmp-[a-z0-9]+\.css';
-        $this->assertMatchesRegularExpression('#' . $css . '#Ui', $html, 'Filter (anonymized) external stylesheets with utils/modcss.php');
+        self::assertMatchesRegularExpression('#' . $css . '#Ui', $html, 'Filter (anonymized) external stylesheets with utils/modcss.php');
     }
 
     /**
@@ -362,15 +362,15 @@ class Actions_Mail_Index extends ActionTestCase
         $part = $this->get_html_part('src/htmlxss.txt');
         $washed = rcmail_action_mail_index::print_body($part->body, $part, ['safe' => true]);
 
-        $this->assertDoesNotMatchRegularExpression('/src="skins/', $washed, 'Remove local references');
-        $this->assertDoesNotMatchRegularExpression('/\son[a-z]+/', $washed, 'Remove on* attributes');
-        $this->assertStringNotContainsString('onload', $washed, 'Handle invalid style');
+        self::assertDoesNotMatchRegularExpression('/src="skins/', $washed, 'Remove local references');
+        self::assertDoesNotMatchRegularExpression('/\son[a-z]+/', $washed, 'Remove on* attributes');
+        self::assertStringNotContainsString('onload', $washed, 'Handle invalid style');
 
         $params = ['container_id' => 'foo'];
         $html = rcmail_action_mail_index::html4inline($washed, $params);
 
-        $this->assertDoesNotMatchRegularExpression('/onclick="return rcmail.command(\'compose\',\'xss@somehost.net\',this)"/', $html, 'Clean mailto links');
-        $this->assertDoesNotMatchRegularExpression('/alert/', $html, 'Remove alerts');
+        self::assertDoesNotMatchRegularExpression('/onclick="return rcmail.command(\'compose\',\'xss@somehost.net\',this)"/', $html, 'Clean mailto links');
+        self::assertDoesNotMatchRegularExpression('/alert/', $html, 'Remove alerts');
     }
 
     /**
@@ -386,8 +386,8 @@ class Actions_Mail_Index extends ActionTestCase
         $body = rcmail_action_mail_index::print_body($part->body, $part, ['safe' => true]);
         $washed = rcmail_action_mail_index::html4inline($body, $params);
 
-        $this->assertDoesNotMatchRegularExpression('/alert|expression|javascript|xss/', $washed, 'Remove evil style blocks');
-        $this->assertDoesNotMatchRegularExpression('/font-style:italic/', $washed, 'Allow valid styles');
+        self::assertDoesNotMatchRegularExpression('/alert|expression|javascript|xss/', $washed, 'Remove evil style blocks');
+        self::assertDoesNotMatchRegularExpression('/font-style:italic/', $washed, 'Allow valid styles');
     }
 
     /**
@@ -402,8 +402,8 @@ class Actions_Mail_Index extends ActionTestCase
             . '<a href="vbscript:alert(document.cookie)">Internet Explorer</a></p>';
         $washed = rcmail_action_mail_index::wash_html($html, ['safe' => true], []);
 
-        $this->assertDoesNotMatchRegularExpression('/data:text/', $washed, 'Remove data:text/html links');
-        $this->assertDoesNotMatchRegularExpression('/vbscript:/', $washed, 'Remove vbscript: links');
+        self::assertDoesNotMatchRegularExpression('/data:text/', $washed, 'Remove data:text/html links');
+        self::assertDoesNotMatchRegularExpression('/vbscript:/', $washed, 'Remove vbscript: links');
     }
 
     /**
@@ -415,11 +415,11 @@ class Actions_Mail_Index extends ActionTestCase
         $params = ['container_id' => 'foo'];
         $html = rcmail_action_mail_index::html4inline($html, $params);
 
-        $this->assertMatchesRegularExpression('/<div style="font-size:11px">/', $html, 'Body attributes');
-        $this->assertArrayHasKey('container_attrib', $params, "'container_attrib' param set");
-        $this->assertMatchesRegularExpression('/background-color: #fff;/', $params['container_attrib']['style'], 'Body style (bgcolor)');
-        $this->assertMatchesRegularExpression('/background-image: url\(test\)/', $params['container_attrib']['style'], 'Body style (background)');
-        $this->assertMatchesRegularExpression('/color: #000/', $params['container_attrib']['style'], 'Body style (text)');
+        self::assertMatchesRegularExpression('/<div style="font-size:11px">/', $html, 'Body attributes');
+        self::assertArrayHasKey('container_attrib', $params, "'container_attrib' param set");
+        self::assertMatchesRegularExpression('/background-color: #fff;/', $params['container_attrib']['style'], 'Body style (bgcolor)');
+        self::assertMatchesRegularExpression('/background-image: url\(test\)/', $params['container_attrib']['style'], 'Body style (background)');
+        self::assertMatchesRegularExpression('/color: #000/', $params['container_attrib']['style'], 'Body style (text)');
     }
 
     /**
@@ -434,7 +434,7 @@ class Actions_Mail_Index extends ActionTestCase
         $part = $this->get_html_part('src/invalidchars.html');
         $washed = rcmail_action_mail_index::print_body($part->body, $part);
 
-        $this->assertMatchesRegularExpression('/<p>(символ|симол)<\/p>/', $washed, 'Remove non-unicode characters from HTML message body');
+        self::assertMatchesRegularExpression('/<p>(символ|симол)<\/p>/', $washed, 'Remove non-unicode characters from HTML message body');
     }
 
     /**
@@ -452,28 +452,28 @@ class Actions_Mail_Index extends ActionTestCase
 
         $body = '<html><head><meta charset="iso-8859-1_X"></head><body>Test1<br>Test2';
         $washed = rcmail_action_mail_index::wash_html($body, $args);
-        $this->assertStringContainsString("<html><head>{$meta}</head><body>Test1", $washed, 'Meta tag insertion (1)');
+        self::assertStringContainsString("<html><head>{$meta}</head><body>Test1", $washed, 'Meta tag insertion (1)');
 
         $body = '<html><head><meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" /></head><body>Test1<br>Test2';
         $washed = rcmail_action_mail_index::wash_html($body, $args);
-        $this->assertStringContainsString("<html><head>{$meta}</head><body>Test1", $washed, 'Meta tag insertion (2)');
+        self::assertStringContainsString("<html><head>{$meta}</head><body>Test1", $washed, 'Meta tag insertion (2)');
 
         $body = 'Test1<br>Test2';
         $washed = rcmail_action_mail_index::wash_html($body, $args);
-        $this->assertTrue(strpos($washed, "<html><head>{$meta}</head>") === 0, 'Meta tag insertion (3)');
+        self::assertTrue(strpos($washed, "<html><head>{$meta}</head>") === 0, 'Meta tag insertion (3)');
 
         $body = '<html>Test1<br>Test2';
         $washed = rcmail_action_mail_index::wash_html($body, $args);
-        $this->assertTrue(strpos($washed, "<html><head>{$meta}</head>") === 0, 'Meta tag insertion (4)');
+        self::assertTrue(strpos($washed, "<html><head>{$meta}</head>") === 0, 'Meta tag insertion (4)');
 
         $body = '<html><head></head>Test1<br>Test2';
         $washed = rcmail_action_mail_index::wash_html($body, $args);
-        $this->assertTrue(strpos($washed, "<html><head>{$meta}</head>") === 0, 'Meta tag insertion (5)');
+        self::assertTrue(strpos($washed, "<html><head>{$meta}</head>") === 0, 'Meta tag insertion (5)');
 
         $body = '<html><head></head><body>Test1<br>Test2<meta charset="utf-8"></body>';
         $washed = rcmail_action_mail_index::wash_html($body, $args);
-        $this->assertTrue(strpos($washed, "<html><head>{$meta}</head>") === 0, 'Meta tag insertion (6)');
-        $this->assertTrue(strpos($washed, 'Test2</body>') > 0, 'Meta tag insertion (7)');
+        self::assertTrue(strpos($washed, "<html><head>{$meta}</head>") === 0, 'Meta tag insertion (6)');
+        self::assertTrue(strpos($washed, 'Test2</body>') > 0, 'Meta tag insertion (7)');
     }
 
     /**
@@ -489,17 +489,17 @@ class Actions_Mail_Index extends ActionTestCase
         $part->body = quoted_printable_decode(file_get_contents(TESTS_DIR . 'src/plainbody.txt'));
         $html = rcmail_action_mail_index::print_body($part->body, $part, ['safe' => true]);
 
-        $this->assertMatchesRegularExpression(
+        self::assertMatchesRegularExpression(
             '/<a href="mailto:nobody@roundcube.net" onclick="return rcmail.command\(\'compose\',\'nobody@roundcube.net\',this\)">nobody@roundcube.net<\/a>/',
             $html,
             'Mailto links with onclick'
         );
-        $this->assertMatchesRegularExpression(
+        self::assertMatchesRegularExpression(
             '#<a rel="noreferrer" target="_blank" href="http://www.apple.com/legal/privacy">http://www.apple.com/legal/privacy</a>#',
             $html,
             'Links with target=_blank'
         );
-        $this->assertMatchesRegularExpression(
+        self::assertMatchesRegularExpression(
             '#\[<a rel="noreferrer" target="_blank" href="http://example.com/\?tx\[a\]=5">http://example.com/\?tx\[a\]=5</a>\]#',
             $html,
             'Links with square brackets'
@@ -523,7 +523,7 @@ class Actions_Mail_Index extends ActionTestCase
         $mailto = '<a href="mailto:me@me.com"'
             . ' onclick="return rcmail.command(\'compose\',\'me@me.com?subject=this is the subject&amp;body=this is the body\',this)" rel="noreferrer">e-mail</a>';
 
-        $this->assertMatchesRegularExpression('|' . preg_quote($mailto, '|') . '|', $html, 'Extended mailto links');
+        self::assertMatchesRegularExpression('|' . preg_quote($mailto, '|') . '|', $html, 'Extended mailto links');
     }
 
     /**
@@ -537,9 +537,9 @@ class Actions_Mail_Index extends ActionTestCase
         $washed = rcmail_action_mail_index::print_body($part->body, $part, ['safe' => true]);
 
         // #1487759
-        $this->assertMatchesRegularExpression('|<p>test1</p>|', $washed, 'Buggy HTML comments');
+        self::assertMatchesRegularExpression('|<p>test1</p>|', $washed, 'Buggy HTML comments');
         // but conditional comments (<!--[if ...) should be removed
-        $this->assertDoesNotMatchRegularExpression('|<p>test2</p>|', $washed, 'Conditional HTML comments');
+        self::assertDoesNotMatchRegularExpression('|<p>test2</p>|', $washed, 'Conditional HTML comments');
     }
 
     /**
@@ -553,16 +553,16 @@ class Actions_Mail_Index extends ActionTestCase
         $html = '<a href="/">test</a>';
         $body = rcmail_action_mail_index::print_body($html, $this->get_html_part(), ['safe' => false, 'plain' => false]);
 
-        $this->assertStringNotContainsString('href="/"', $body);
-        $this->assertStringContainsString('<a>', $body);
+        self::assertStringNotContainsString('href="/"', $body);
+        self::assertStringContainsString('<a>', $body);
 
         $html = '<a href="https://roundcube.net">test</a>';
         $body = rcmail_action_mail_index::print_body($html, $this->get_html_part(), ['safe' => false, 'plain' => false]);
 
         // allow external links, add target and noreferrer
-        $this->assertStringContainsString('<a href="https://roundcube.net"', $body);
-        $this->assertStringContainsString(' target="_blank"', $body);
-        $this->assertStringContainsString(' rel="noreferrer"', $body);
+        self::assertStringContainsString('<a href="https://roundcube.net"', $body);
+        self::assertStringContainsString(' target="_blank"', $body);
+        self::assertStringContainsString(' rel="noreferrer"', $body);
     }
 
     /**
@@ -575,8 +575,8 @@ class Actions_Mail_Index extends ActionTestCase
         $html = '<a style="x:><img src=x onerror=alert(1)//">test</a>';
         $body = rcmail_action_mail_index::print_body($html, $this->get_html_part(), ['safe' => false, 'plain' => false]);
 
-        $this->assertStringNotContainsString('onerror=alert(1)//">test', $body);
-        $this->assertStringContainsString('<a style="x: &gt;"', $body);
+        self::assertStringNotContainsString('onerror=alert(1)//">test', $body);
+        self::assertStringContainsString('<a style="x: &gt;"', $body);
     }
 
     /**
@@ -584,6 +584,6 @@ class Actions_Mail_Index extends ActionTestCase
      */
     public function test_supported_mimetypes()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 }

--- a/tests/Actions/Mail/ListContactsTest.php
+++ b/tests/Actions/Mail/ListContactsTest.php
@@ -12,6 +12,6 @@ class Actions_Mail_ListContacts extends ActionTestCase
     {
         $object = new rcmail_action_mail_list_contacts();
 
-        $this->assertInstanceOf('rcmail_action', $object);
+        self::assertInstanceOf('rcmail_action', $object);
     }
 }

--- a/tests/Actions/Mail/ListTest.php
+++ b/tests/Actions/Mail/ListTest.php
@@ -12,6 +12,6 @@ class Actions_Mail_List extends ActionTestCase
     {
         $object = new rcmail_action_mail_list();
 
-        $this->assertInstanceOf('rcmail_action', $object);
+        self::assertInstanceOf('rcmail_action', $object);
     }
 }

--- a/tests/Actions/Mail/MarkTest.php
+++ b/tests/Actions/Mail/MarkTest.php
@@ -12,6 +12,6 @@ class Actions_Mail_Mark extends ActionTestCase
     {
         $object = new rcmail_action_mail_mark();
 
-        $this->assertInstanceOf('rcmail_action', $object);
+        self::assertInstanceOf('rcmail_action', $object);
     }
 }

--- a/tests/Actions/Mail/MoveTest.php
+++ b/tests/Actions/Mail/MoveTest.php
@@ -12,6 +12,6 @@ class Actions_Mail_Move extends ActionTestCase
     {
         $object = new rcmail_action_mail_move();
 
-        $this->assertInstanceOf('rcmail_action', $object);
+        self::assertInstanceOf('rcmail_action', $object);
     }
 }

--- a/tests/Actions/Mail/PagenavTest.php
+++ b/tests/Actions/Mail/PagenavTest.php
@@ -12,6 +12,6 @@ class Actions_Mail_Pagenav extends ActionTestCase
     {
         $object = new rcmail_action_mail_pagenav();
 
-        $this->assertInstanceOf('rcmail_action', $object);
+        self::assertInstanceOf('rcmail_action', $object);
     }
 }

--- a/tests/Actions/Mail/SearchContactsTest.php
+++ b/tests/Actions/Mail/SearchContactsTest.php
@@ -12,6 +12,6 @@ class Actions_Mail_SearchContacts extends ActionTestCase
     {
         $object = new rcmail_action_mail_search_contacts();
 
-        $this->assertInstanceOf('rcmail_action', $object);
+        self::assertInstanceOf('rcmail_action', $object);
     }
 }

--- a/tests/Actions/Mail/SearchTest.php
+++ b/tests/Actions/Mail/SearchTest.php
@@ -13,7 +13,7 @@ class Actions_Mail_Search extends ActionTestCase
         $action = new rcmail_action_mail_search();
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'mail', 'search');
 
-        $this->assertTrue($action->checks());
+        self::assertTrue($action->checks());
 
         $_GET = [
             '_q' => 'test',
@@ -39,15 +39,15 @@ class Actions_Mail_Search extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('search', $result['action']);
-        $this->assertSame(0, $result['env']['messagecount']);
-        $this->assertSame(0, $result['env']['pagecount']);
-        $this->assertSame(0, $result['env']['exists']);
-        $this->assertTrue(strpos($result['exec'], 'this.display_message("Search returned no matches.","notice",0);') !== false);
-        $this->assertTrue(strpos($result['exec'], 'this.set_rowcount("Mailbox is empty","INBOX");') !== false);
-        $this->assertTrue(strpos($result['exec'], 'this.set_pagetitle("Roundcube Webmail :: Search result");') !== false);
-        $this->assertTrue(strpos($result['exec'], 'this.set_quota') !== false);
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('search', $result['action']);
+        self::assertSame(0, $result['env']['messagecount']);
+        self::assertSame(0, $result['env']['pagecount']);
+        self::assertSame(0, $result['env']['exists']);
+        self::assertTrue(strpos($result['exec'], 'this.display_message("Search returned no matches.","notice",0);') !== false);
+        self::assertTrue(strpos($result['exec'], 'this.set_rowcount("Mailbox is empty","INBOX");') !== false);
+        self::assertTrue(strpos($result['exec'], 'this.set_pagetitle("Roundcube Webmail :: Search result");') !== false);
+        self::assertTrue(strpos($result['exec'], 'this.set_quota') !== false);
     }
 
     /**
@@ -100,14 +100,14 @@ class Actions_Mail_Search extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('search', $result['action']);
-        $this->assertSame(1, $result['env']['messagecount']);
-        $this->assertSame(1, $result['env']['pagecount']);
-        $this->assertSame(1, $result['env']['exists']);
-        $this->assertTrue(strpos($result['exec'], 'this.display_message("1 messages found.","confirmation",0);') !== false);
-        $this->assertTrue(strpos($result['exec'], 'this.set_rowcount("Messages 1 to 1 of 1","INBOX");') !== false);
-        $this->assertTrue(strpos($result['exec'], 'this.set_pagetitle("Roundcube Webmail :: Search result");') !== false);
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('search', $result['action']);
+        self::assertSame(1, $result['env']['messagecount']);
+        self::assertSame(1, $result['env']['pagecount']);
+        self::assertSame(1, $result['env']['exists']);
+        self::assertTrue(strpos($result['exec'], 'this.display_message("1 messages found.","confirmation",0);') !== false);
+        self::assertTrue(strpos($result['exec'], 'this.set_rowcount("Messages 1 to 1 of 1","INBOX");') !== false);
+        self::assertTrue(strpos($result['exec'], 'this.set_pagetitle("Roundcube Webmail :: Search result");') !== false);
     }
 
     /**
@@ -293,7 +293,7 @@ class Actions_Mail_Search extends ActionTestCase
             $result = rcmail_action_mail_search::search_input($input);
         }
 
-        $this->assertSame($output, $result);
+        self::assertSame($output, $result);
     }
 
     /**
@@ -326,6 +326,6 @@ class Actions_Mail_Search extends ActionTestCase
     public function test_search_interval_criteria($input, $output)
     {
         $result = rcmail_action_mail_search::search_interval_criteria($input);
-        $this->assertSame($output, $result);
+        self::assertSame($output, $result);
     }
 }

--- a/tests/Actions/Mail/SendTest.php
+++ b/tests/Actions/Mail/SendTest.php
@@ -12,6 +12,6 @@ class Actions_Mail_Send extends ActionTestCase
     {
         $object = new rcmail_action_mail_send();
 
-        $this->assertInstanceOf('rcmail_action', $object);
+        self::assertInstanceOf('rcmail_action', $object);
     }
 }

--- a/tests/Actions/Mail/SendmdnTest.php
+++ b/tests/Actions/Mail/SendmdnTest.php
@@ -12,6 +12,6 @@ class Actions_Mail_Sendmdn extends ActionTestCase
     {
         $object = new rcmail_action_mail_sendmdn();
 
-        $this->assertInstanceOf('rcmail_action', $object);
+        self::assertInstanceOf('rcmail_action', $object);
     }
 }

--- a/tests/Actions/Mail/ShowTest.php
+++ b/tests/Actions/Mail/ShowTest.php
@@ -12,6 +12,6 @@ class Actions_Mail_Show extends ActionTestCase
     {
         $object = new rcmail_action_mail_show();
 
-        $this->assertInstanceOf('rcmail_action', $object);
+        self::assertInstanceOf('rcmail_action', $object);
     }
 }

--- a/tests/Actions/Mail/ViewsourceTest.php
+++ b/tests/Actions/Mail/ViewsourceTest.php
@@ -12,6 +12,6 @@ class Actions_Mail_Viewsource extends ActionTestCase
     {
         $object = new rcmail_action_mail_viewsource();
 
-        $this->assertInstanceOf('rcmail_action', $object);
+        self::assertInstanceOf('rcmail_action', $object);
     }
 }

--- a/tests/Actions/Settings/AboutTest.php
+++ b/tests/Actions/Settings/AboutTest.php
@@ -13,16 +13,16 @@ class Actions_Settings_About extends ActionTestCase
         $action = new rcmail_action_settings_about();
         $output = $this->initOutput(rcmail_action::MODE_HTTP, 'settings', 'about');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         $this->runAndAssert($action, OutputHtmlMock::E_EXIT);
 
         $result = $output->getOutput();
 
-        $this->assertSame('about', $output->template);
-        $this->assertSame('About', $output->getProperty('pagetitle'));
-        $this->assertTrue(stripos($result, '<!DOCTYPE html>') === 0);
-        $this->assertTrue(strpos($result, 'This program is free software') !== false);
+        self::assertSame('about', $output->template);
+        self::assertSame('About', $output->getProperty('pagetitle'));
+        self::assertTrue(stripos($result, '<!DOCTYPE html>') === 0);
+        self::assertTrue(strpos($result, 'This program is free software') !== false);
     }
 }

--- a/tests/Actions/Settings/FolderCreateTest.php
+++ b/tests/Actions/Settings/FolderCreateTest.php
@@ -13,8 +13,8 @@ class Actions_Settings_FolderCreate extends ActionTestCase
         $action = new rcmail_action_settings_folder_create();
         $output = $this->initOutput(rcmail_action::MODE_HTTP, 'settings', 'folder-create');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         // Set expected storage function calls/results
         self::mockStorage()
@@ -42,9 +42,9 @@ class Actions_Settings_FolderCreate extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame('folderedit', $output->template);
-        $this->assertSame('', $output->getProperty('pagetitle')); // TODO: It should have some title
-        $this->assertTrue(stripos($result, '<!DOCTYPE html>') === 0);
-        $this->assertTrue(strpos($result, "rcmail.gui_object('editform', 'form');") !== false);
+        self::assertSame('folderedit', $output->template);
+        self::assertSame('', $output->getProperty('pagetitle')); // TODO: It should have some title
+        self::assertTrue(stripos($result, '<!DOCTYPE html>') === 0);
+        self::assertTrue(strpos($result, "rcmail.gui_object('editform', 'form');") !== false);
     }
 }

--- a/tests/Actions/Settings/FolderDeleteTest.php
+++ b/tests/Actions/Settings/FolderDeleteTest.php
@@ -13,8 +13,8 @@ class Actions_Settings_FolderDelete extends ActionTestCase
         $action = new rcmail_action_settings_folder_delete();
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'settings', 'folder-delete');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         // Set expected storage function calls/results
         self::mockStorage()
@@ -27,12 +27,12 @@ class Actions_Settings_FolderDelete extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('folder-delete', $result['action']);
-        $this->assertTrue(strpos($result['exec'], 'this.display_message("Folder successfully deleted.","confirmation",0);') !== false);
-        $this->assertTrue(strpos($result['exec'], 'this.remove_folder_row("Test");') !== false);
-        $this->assertTrue(strpos($result['exec'], 'this.subscription_select();') !== false);
-        $this->assertTrue(strpos($result['exec'], 'this.set_quota(') !== false);
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('folder-delete', $result['action']);
+        self::assertTrue(strpos($result['exec'], 'this.display_message("Folder successfully deleted.","confirmation",0);') !== false);
+        self::assertTrue(strpos($result['exec'], 'this.remove_folder_row("Test");') !== false);
+        self::assertTrue(strpos($result['exec'], 'this.subscription_select();') !== false);
+        self::assertTrue(strpos($result['exec'], 'this.set_quota(') !== false);
     }
 
     /**
@@ -55,9 +55,9 @@ class Actions_Settings_FolderDelete extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('folder-delete', $result['action']);
-        $this->assertTrue(strpos($result['exec'], 'this.display_message("Unable to perform operation. Folder is read-only.","error",0);') !== false);
-        $this->assertTrue(strpos($result['exec'], 'this.remove_folder_row("Test");') === false);
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('folder-delete', $result['action']);
+        self::assertTrue(strpos($result['exec'], 'this.display_message("Unable to perform operation. Folder is read-only.","error",0);') !== false);
+        self::assertTrue(strpos($result['exec'], 'this.remove_folder_row("Test");') === false);
     }
 }

--- a/tests/Actions/Settings/FolderEditTest.php
+++ b/tests/Actions/Settings/FolderEditTest.php
@@ -13,8 +13,8 @@ class Actions_Settings_FolderEdit extends ActionTestCase
         $action = new rcmail_action_settings_folder_edit();
         $output = $this->initOutput(rcmail_action::MODE_HTTP, 'settings', 'folder-edit');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         // Set expected storage function calls/results
         self::mockStorage()
@@ -43,10 +43,10 @@ class Actions_Settings_FolderEdit extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame('folderedit', $output->template);
-        $this->assertSame('', $output->getProperty('pagetitle')); // TODO: It should have some title
-        $this->assertTrue(stripos($result, '<!DOCTYPE html>') === 0);
-        $this->assertTrue(strpos($result, 'Folder properties') !== false);
+        self::assertSame('folderedit', $output->template);
+        self::assertSame('', $output->getProperty('pagetitle')); // TODO: It should have some title
+        self::assertTrue(stripos($result, '<!DOCTYPE html>') === 0);
+        self::assertTrue(strpos($result, 'Folder properties') !== false);
     }
 
     /**
@@ -54,6 +54,6 @@ class Actions_Settings_FolderEdit extends ActionTestCase
      */
     public function test_folder_form()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 }

--- a/tests/Actions/Settings/FolderPurgeTest.php
+++ b/tests/Actions/Settings/FolderPurgeTest.php
@@ -13,8 +13,8 @@ class Actions_Settings_FolderPurge extends ActionTestCase
         $action = new rcmail_action_settings_folder_purge();
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'settings', 'folder-purge');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         // Set expected storage function calls/results
         self::mockStorage()
@@ -27,12 +27,12 @@ class Actions_Settings_FolderPurge extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('folder-purge', $result['action']);
-        $this->assertSame(0, $result['env']['messagecount']);
-        $this->assertTrue(strpos($result['exec'], 'this.display_message("Message(s) moved successfully.","confirmation",0);') !== false);
-        $this->assertTrue(strpos($result['exec'], 'this.show_folder("Test",null,true);') !== false);
-        $this->assertTrue(strpos($result['exec'], 'this.set_quota') === false);
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('folder-purge', $result['action']);
+        self::assertSame(0, $result['env']['messagecount']);
+        self::assertTrue(strpos($result['exec'], 'this.display_message("Message(s) moved successfully.","confirmation",0);') !== false);
+        self::assertTrue(strpos($result['exec'], 'this.show_folder("Test",null,true);') !== false);
+        self::assertTrue(strpos($result['exec'], 'this.set_quota') === false);
     }
 
     /**
@@ -43,8 +43,8 @@ class Actions_Settings_FolderPurge extends ActionTestCase
         $action = new rcmail_action_settings_folder_purge();
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'settings', 'folder-purge');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         // Set expected storage function calls/results
         self::mockStorage()
@@ -57,12 +57,12 @@ class Actions_Settings_FolderPurge extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('folder-purge', $result['action']);
-        $this->assertSame(0, $result['env']['messagecount']);
-        $this->assertTrue(strpos($result['exec'], 'this.display_message("Folder successfully emptied.","confirmation",0);') !== false);
-        $this->assertTrue(strpos($result['exec'], 'this.show_folder("Trash",null,true);') !== false);
-        $this->assertTrue(strpos($result['exec'], 'this.set_quota') !== false);
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('folder-purge', $result['action']);
+        self::assertSame(0, $result['env']['messagecount']);
+        self::assertTrue(strpos($result['exec'], 'this.display_message("Folder successfully emptied.","confirmation",0);') !== false);
+        self::assertTrue(strpos($result['exec'], 'this.show_folder("Trash",null,true);') !== false);
+        self::assertTrue(strpos($result['exec'], 'this.set_quota') !== false);
     }
 
     /**
@@ -85,8 +85,8 @@ class Actions_Settings_FolderPurge extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('folder-purge', $result['action']);
-        $this->assertTrue(strpos($result['exec'], 'this.display_message("Unable to perform operation. Folder is read-only.","error",0);') !== false);
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('folder-purge', $result['action']);
+        self::assertTrue(strpos($result['exec'], 'this.display_message("Unable to perform operation. Folder is read-only.","error",0);') !== false);
     }
 }

--- a/tests/Actions/Settings/FolderRenameTest.php
+++ b/tests/Actions/Settings/FolderRenameTest.php
@@ -13,8 +13,8 @@ class Actions_Settings_FolderRename extends ActionTestCase
         $action = new rcmail_action_settings_folder_rename();
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'settings', 'folder-rename');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         // Set expected storage function calls/results
         self::mockStorage()
@@ -28,9 +28,9 @@ class Actions_Settings_FolderRename extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('folder-rename', $result['action']);
-        $this->assertTrue(strpos($result['exec'], 'this.replace_folder_row("Test","Test2","Test2","Test2",false,"mailbox");') !== false);
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('folder-rename', $result['action']);
+        self::assertTrue(strpos($result['exec'], 'this.replace_folder_row("Test","Test2","Test2","Test2",false,"mailbox");') !== false);
     }
 
     /**
@@ -53,8 +53,8 @@ class Actions_Settings_FolderRename extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('folder-rename', $result['action']);
-        $this->assertTrue(strpos($result['exec'], 'this.display_message("Unable to perform operation. Folder is read-only.","error",0);') !== false);
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('folder-rename', $result['action']);
+        self::assertTrue(strpos($result['exec'], 'this.display_message("Unable to perform operation. Folder is read-only.","error",0);') !== false);
     }
 }

--- a/tests/Actions/Settings/FolderSaveTest.php
+++ b/tests/Actions/Settings/FolderSaveTest.php
@@ -13,8 +13,8 @@ class Actions_Settings_FolderSave extends ActionTestCase
         $action = new rcmail_action_settings_folder_save();
         $output = $this->initOutput(rcmail_action::MODE_HTTP, 'settings', 'folder-save');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         // Set expected storage function calls/results
         self::mockStorage()
@@ -33,11 +33,11 @@ class Actions_Settings_FolderSave extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame('iframe', $output->template);
-        $this->assertTrue(stripos($result, '<!DOCTYPE html>') === 0);
-        $this->assertTrue(strpos($result, 'display_message("Folder created successfully.","confirmation",0);') !== false);
-        $this->assertTrue(strpos($result, '.add_folder_row("NewTest"') !== false);
-        $this->assertTrue(strpos($result, '.subscription_select()') !== false);
+        self::assertSame('iframe', $output->template);
+        self::assertTrue(stripos($result, '<!DOCTYPE html>') === 0);
+        self::assertTrue(strpos($result, 'display_message("Folder created successfully.","confirmation",0);') !== false);
+        self::assertTrue(strpos($result, '.add_folder_row("NewTest"') !== false);
+        self::assertTrue(strpos($result, '.subscription_select()') !== false);
     }
 
     /**
@@ -45,7 +45,7 @@ class Actions_Settings_FolderSave extends ActionTestCase
      */
     public function test_folder_update()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -53,6 +53,6 @@ class Actions_Settings_FolderSave extends ActionTestCase
      */
     public function test_error_handling()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 }

--- a/tests/Actions/Settings/FolderSizeTest.php
+++ b/tests/Actions/Settings/FolderSizeTest.php
@@ -13,8 +13,8 @@ class Actions_Settings_FolderSize extends ActionTestCase
         $action = new rcmail_action_settings_folder_size();
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'settings', 'folder-size');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         // Set expected storage function calls/results
         self::mockStorage()
@@ -26,9 +26,9 @@ class Actions_Settings_FolderSize extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('folder-size', $result['action']);
-        $this->assertSame('this.folder_size_update("100 B");', trim($result['exec']));
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('folder-size', $result['action']);
+        self::assertSame('this.folder_size_update("100 B");', trim($result['exec']));
     }
 
     /**
@@ -51,8 +51,8 @@ class Actions_Settings_FolderSize extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('folder-size', $result['action']);
-        $this->assertTrue(strpos($result['exec'], 'this.display_message("Unable to perform operation. Folder is read-only.","error",0);') !== false);
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('folder-size', $result['action']);
+        self::assertTrue(strpos($result['exec'], 'this.display_message("Unable to perform operation. Folder is read-only.","error",0);') !== false);
     }
 }

--- a/tests/Actions/Settings/FolderSubscribeTest.php
+++ b/tests/Actions/Settings/FolderSubscribeTest.php
@@ -13,8 +13,8 @@ class Actions_Settings_FolderSubscribe extends ActionTestCase
         $action = new rcmail_action_settings_folder_subscribe();
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'settings', 'folder-subscribe');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         // Set expected storage function calls/results
         self::mockStorage()
@@ -27,9 +27,9 @@ class Actions_Settings_FolderSubscribe extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('folder-subscribe', $result['action']);
-        $this->assertTrue(strpos($result['exec'], 'this.display_message("Folder successfully subscribed.","confirmation",0);') !== false);
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('folder-subscribe', $result['action']);
+        self::assertTrue(strpos($result['exec'], 'this.display_message("Folder successfully subscribed.","confirmation",0);') !== false);
 
         // TODO: Test a special folder subscription
     }
@@ -56,10 +56,10 @@ class Actions_Settings_FolderSubscribe extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('folder-subscribe', $result['action']);
-        $this->assertTrue(strpos($result['exec'], 'this.display_message("Unable to perform operation. Folder is read-only.","error",0);') !== false);
-        $this->assertTrue(strpos($result['exec'], 'this.reset_subscription("Test",false);') !== false);
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('folder-subscribe', $result['action']);
+        self::assertTrue(strpos($result['exec'], 'this.display_message("Unable to perform operation. Folder is read-only.","error",0);') !== false);
+        self::assertTrue(strpos($result['exec'], 'this.reset_subscription("Test",false);') !== false);
 
         // TODO: Test TRYCREATE error handling
     }

--- a/tests/Actions/Settings/FolderUnsubscribeTest.php
+++ b/tests/Actions/Settings/FolderUnsubscribeTest.php
@@ -13,8 +13,8 @@ class Actions_Settings_FolderUnsubscribe extends ActionTestCase
         $action = new rcmail_action_settings_folder_unsubscribe();
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'settings', 'folder-unsubscribe');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         // Set expected storage function calls/results
         self::mockStorage()
@@ -27,9 +27,9 @@ class Actions_Settings_FolderUnsubscribe extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('folder-unsubscribe', $result['action']);
-        $this->assertTrue(strpos($result['exec'], 'this.display_message("Folder successfully unsubscribed.","confirmation",0);') !== false);
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('folder-unsubscribe', $result['action']);
+        self::assertTrue(strpos($result['exec'], 'this.display_message("Folder successfully unsubscribed.","confirmation",0);') !== false);
     }
 
     /**
@@ -52,9 +52,9 @@ class Actions_Settings_FolderUnsubscribe extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('folder-unsubscribe', $result['action']);
-        $this->assertTrue(strpos($result['exec'], 'this.display_message("Unable to perform operation. Folder is read-only.","error",0);') !== false);
-        $this->assertTrue(strpos($result['exec'], 'this.reset_subscription("Test",true);') !== false);
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('folder-unsubscribe', $result['action']);
+        self::assertTrue(strpos($result['exec'], 'this.display_message("Unable to perform operation. Folder is read-only.","error",0);') !== false);
+        self::assertTrue(strpos($result['exec'], 'this.reset_subscription("Test",true);') !== false);
     }
 }

--- a/tests/Actions/Settings/FoldersTest.php
+++ b/tests/Actions/Settings/FoldersTest.php
@@ -13,8 +13,8 @@ class Actions_Settings_Folders extends ActionTestCase
         $action = new rcmail_action_settings_folders();
         $output = $this->initOutput(rcmail_action::MODE_HTTP, 'settings', 'folders');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         // Set expected storage function calls/results
         self::mockStorage()
@@ -48,10 +48,10 @@ class Actions_Settings_Folders extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame('folders', $output->template);
-        $this->assertSame('Folders', $output->getProperty('pagetitle'));
-        $this->assertTrue(stripos($result, '<!DOCTYPE html>') === 0);
-        $this->assertMatchesRegularExpression('/treelist(.min)?.js/', $result);
+        self::assertSame('folders', $output->template);
+        self::assertSame('Folders', $output->getProperty('pagetitle'));
+        self::assertTrue(stripos($result, '<!DOCTYPE html>') === 0);
+        self::assertMatchesRegularExpression('/treelist(.min)?.js/', $result);
     }
 
     /**
@@ -59,7 +59,7 @@ class Actions_Settings_Folders extends ActionTestCase
      */
     public function test_folder_subscriptions()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -67,7 +67,7 @@ class Actions_Settings_Folders extends ActionTestCase
      */
     public function test_folder_filter()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -75,7 +75,7 @@ class Actions_Settings_Folders extends ActionTestCase
      */
     public function test_folder_options()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -83,6 +83,6 @@ class Actions_Settings_Folders extends ActionTestCase
      */
     public function test_update_folder_row()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 }

--- a/tests/Actions/Settings/IdentitiesTest.php
+++ b/tests/Actions/Settings/IdentitiesTest.php
@@ -13,8 +13,8 @@ class Actions_Settings_Identities extends ActionTestCase
         $action = new rcmail_action_settings_identities();
         $output = $this->initOutput(rcmail_action::MODE_HTTP, 'settings', 'identities');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         self::initDB('identities');
 
@@ -22,11 +22,11 @@ class Actions_Settings_Identities extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame('identities', $output->template);
-        $this->assertSame('Identities', $output->getProperty('pagetitle'));
-        $this->assertTrue(stripos($result, '<!DOCTYPE html>') === 0);
-        $this->assertTrue(strpos($result, 'test@example.org') !== false);
-        $this->assertMatchesRegularExpression('/list(.min)?.js/', $result);
+        self::assertSame('identities', $output->template);
+        self::assertSame('Identities', $output->getProperty('pagetitle'));
+        self::assertTrue(stripos($result, '<!DOCTYPE html>') === 0);
+        self::assertTrue(strpos($result, 'test@example.org') !== false);
+        self::assertMatchesRegularExpression('/list(.min)?.js/', $result);
     }
 
     /**
@@ -45,6 +45,6 @@ class Actions_Settings_Identities extends ActionTestCase
             . '<tbody><tr id="rcmrow1"><td class="mail">test &lt;test@example.com&gt;</td></tr>'
             . '<tr id="rcmrow2"><td class="mail">test &lt;test@example.org&gt;</td></tr></tbody></table>';
 
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 }

--- a/tests/Actions/Settings/IdentityCreateTest.php
+++ b/tests/Actions/Settings/IdentityCreateTest.php
@@ -13,16 +13,16 @@ class Actions_Settings_IdentityCreate extends ActionTestCase
         $action = new rcmail_action_settings_identity_create();
         $output = $this->initOutput(rcmail_action::MODE_HTTP, 'settings', 'add-identity');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         $this->runAndAssert($action, OutputHtmlMock::E_EXIT);
 
         $result = $output->getOutput();
 
-        $this->assertSame('identityedit', $output->template);
-        $this->assertSame('Add identity', $output->getProperty('pagetitle'));
-        $this->assertTrue(stripos($result, '<!DOCTYPE html>') === 0);
-        $this->assertTrue(strpos($result, "rcmail.gui_object('editform', 'form')") !== false);
+        self::assertSame('identityedit', $output->template);
+        self::assertSame('Add identity', $output->getProperty('pagetitle'));
+        self::assertTrue(stripos($result, '<!DOCTYPE html>') === 0);
+        self::assertTrue(strpos($result, "rcmail.gui_object('editform', 'form')") !== false);
     }
 }

--- a/tests/Actions/Settings/IdentityDeleteTest.php
+++ b/tests/Actions/Settings/IdentityDeleteTest.php
@@ -13,8 +13,8 @@ class Actions_Settings_IdentityDelete extends ActionTestCase
         $action = new rcmail_action_settings_identity_delete();
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'settings', 'delete-identity');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         self::initDB('identities');
 
@@ -29,15 +29,15 @@ class Actions_Settings_IdentityDelete extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('delete-identity', $result['action']);
-        $this->assertTrue(strpos($result['exec'], 'this.display_message("Successfully deleted.","confirmation",0);') !== false);
-        $this->assertTrue(strpos($result['exec'], 'this.remove_identity("' . $iid . '")') !== false);
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('delete-identity', $result['action']);
+        self::assertTrue(strpos($result['exec'], 'this.display_message("Successfully deleted.","confirmation",0);') !== false);
+        self::assertTrue(strpos($result['exec'], 'this.remove_identity("' . $iid . '")') !== false);
 
         $query = $db->query('SELECT * FROM `identities` WHERE `identity_id` = ?', $iid);
         $result = $db->fetch_assoc($query);
 
-        $this->assertTrue(!empty($result['del']));
+        self::assertTrue(!empty($result['del']));
 
         // Test error handling
         $action = new rcmail_action_settings_identity_delete();
@@ -49,8 +49,8 @@ class Actions_Settings_IdentityDelete extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('delete-identity', $result['action']);
-        $this->assertStringContainsString('this.display_message("An error occurred while saving.","error",0);', $result['exec']);
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('delete-identity', $result['action']);
+        self::assertStringContainsString('this.display_message("An error occurred while saving.","error",0);', $result['exec']);
     }
 }

--- a/tests/Actions/Settings/IdentityEditTest.php
+++ b/tests/Actions/Settings/IdentityEditTest.php
@@ -13,8 +13,8 @@ class Actions_Settings_IdentityEdit extends ActionTestCase
         $action = new rcmail_action_settings_identity_edit();
         $output = $this->initOutput(rcmail_action::MODE_HTTP, 'settings', 'edit-identity');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         self::initDB('identities');
 
@@ -28,12 +28,12 @@ class Actions_Settings_IdentityEdit extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame('identityedit', $output->template);
-        $this->assertSame('Edit identity', $output->getProperty('pagetitle'));
-        $this->assertSame($identity['identity_id'], $output->get_env('iid'));
-        $this->assertTrue(stripos($result, '<!DOCTYPE html>') === 0);
-        $this->assertTrue(strpos($result, "rcmail.gui_object('editform', 'form')") !== false);
-        $this->assertTrue(strpos($result, 'test@example.com') !== false);
+        self::assertSame('identityedit', $output->template);
+        self::assertSame('Edit identity', $output->getProperty('pagetitle'));
+        self::assertSame($identity['identity_id'], $output->get_env('iid'));
+        self::assertTrue(stripos($result, '<!DOCTYPE html>') === 0);
+        self::assertTrue(strpos($result, "rcmail.gui_object('editform', 'form')") !== false);
+        self::assertTrue(strpos($result, 'test@example.com') !== false);
 
         // TODO: Test error handling
     }
@@ -50,7 +50,7 @@ class Actions_Settings_IdentityEdit extends ActionTestCase
 
         $result = $action->identity_form([]);
 
-        $this->assertTrue(strpos($result, '<form id="identityImageUpload"') !== false);
-        $this->assertTrue(strpos($result, '<legend>Settings</legend>') !== false);
+        self::assertTrue(strpos($result, '<form id="identityImageUpload"') !== false);
+        self::assertTrue(strpos($result, '<legend>Settings</legend>') !== false);
     }
 }

--- a/tests/Actions/Settings/IdentitySaveTest.php
+++ b/tests/Actions/Settings/IdentitySaveTest.php
@@ -13,8 +13,8 @@ class Actions_Settings_IdentitySave extends ActionTestCase
         $action = new rcmail_action_settings_identity_save();
         $output = $this->initOutput(rcmail_action::MODE_HTTP, 'settings', 'save-identity');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         self::initDB('identities');
 
@@ -34,16 +34,16 @@ class Actions_Settings_IdentitySave extends ActionTestCase
 
         $action->run();
 
-        $this->assertSame('edit-identity', rcmail::get_instance()->action);
-        $this->assertSame('successfullysaved', $output->getProperty('message'));
+        self::assertSame('edit-identity', rcmail::get_instance()->action);
+        self::assertSame('successfullysaved', $output->getProperty('message'));
 
         $query = $db->query('SELECT * FROM `identities` WHERE `identity_id` = ?', $identity['identity_id']);
         $identity = $db->fetch_assoc($query);
 
-        $this->assertSame('new-name', $identity['name']);
-        $this->assertSame('new@example.com', $identity['email']);
-        $this->assertSame('test', $identity['signature']);
-        $this->assertSame(1, (int) $identity['standard']);
+        self::assertSame('new-name', $identity['name']);
+        self::assertSame('new@example.com', $identity['email']);
+        self::assertSame('test', $identity['signature']);
+        self::assertSame(1, (int) $identity['standard']);
     }
 
     /**
@@ -51,7 +51,7 @@ class Actions_Settings_IdentitySave extends ActionTestCase
      */
     public function test_new_identity()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -59,6 +59,6 @@ class Actions_Settings_IdentitySave extends ActionTestCase
      */
     public function test_run_errors()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 }

--- a/tests/Actions/Settings/IndexTest.php
+++ b/tests/Actions/Settings/IndexTest.php
@@ -13,14 +13,14 @@ class Actions_Settings_Index extends ActionTestCase
         $action = new rcmail_action_settings_index();
         $output = $this->initOutput(rcmail_action::MODE_HTTP, 'settings', 'preferences');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         $action->run();
 
         $result = $output->getOutput();
 
-        $this->assertSame('Preferences', $output->getProperty('pagetitle'));
+        self::assertSame('Preferences', $output->getProperty('pagetitle'));
     }
 
     /**
@@ -29,7 +29,7 @@ class Actions_Settings_Index extends ActionTestCase
     public function test_sections_list()
     {
         $result = rcmail_action_settings_index::sections_list([]);
-        $this->assertTrue(strpos($result, '<table id="rcmsectionslist"') === 0);
+        self::assertTrue(strpos($result, '<table id="rcmsectionslist"') === 0);
     }
 
     /**
@@ -38,7 +38,7 @@ class Actions_Settings_Index extends ActionTestCase
     public function test_user_prefs()
     {
         $result = rcmail_action_settings_index::user_prefs('general');
-        $this->assertSame('general', $result[0]['general']['id']);
+        self::assertSame('general', $result[0]['general']['id']);
     }
 
     /**
@@ -47,7 +47,7 @@ class Actions_Settings_Index extends ActionTestCase
     public function test_get_skins()
     {
         $result = rcmail_action_settings_index::get_skins();
-        $this->assertContains('elastic', $result);
+        self::assertContains('elastic', $result);
     }
 
     /**
@@ -58,13 +58,13 @@ class Actions_Settings_Index extends ActionTestCase
         $result = rcmail_action_settings_index::settings_tabs([]);
         $nodes = getHTMLNodes($result, "//span[@id='settingstabpreferences']");
 
-        $this->assertCount(1, $nodes);
-        $this->assertSame('preferences selected', $nodes[0]->getAttribute('class'));
-        $this->assertCount(1, $nodes[0]->childNodes);
+        self::assertCount(1, $nodes);
+        self::assertSame('preferences selected', $nodes[0]->getAttribute('class'));
+        self::assertCount(1, $nodes[0]->childNodes);
         $link = $nodes[0]->firstChild;
-        $this->assertSame('a', $link->nodeName);
-        $this->assertSame('Edit user preferences', $link->getAttribute('title'));
-        $this->assertStringEndsWith('?_task=settings&_action=preferences', $link->getAttribute('href'));
+        self::assertSame('a', $link->nodeName);
+        self::assertSame('Edit user preferences', $link->getAttribute('title'));
+        self::assertStringEndsWith('?_task=settings&_action=preferences', $link->getAttribute('href'));
     }
 
     /**
@@ -73,7 +73,7 @@ class Actions_Settings_Index extends ActionTestCase
     public function test_timezone_label()
     {
         $result = rcmail_action_settings_index::timezone_label('Europe/Warsaw');
-        $this->assertSame('Europe/Warsaw', $result);
+        self::assertSame('Europe/Warsaw', $result);
     }
 
     /**
@@ -82,7 +82,7 @@ class Actions_Settings_Index extends ActionTestCase
     public function test_timezone_standard_time_data()
     {
         $result = rcmail_action_settings_index::timezone_standard_time_data('UTC');
-        $this->assertSame('+00:00', $result['offset']);
+        self::assertSame('+00:00', $result['offset']);
     }
 
     /**
@@ -94,7 +94,7 @@ class Actions_Settings_Index extends ActionTestCase
 
         // TODO: test image replacement
 
-        $this->assertSame('<p>test</p>', $result);
+        self::assertSame('<p>test</p>', $result);
     }
 
     /**
@@ -104,6 +104,6 @@ class Actions_Settings_Index extends ActionTestCase
     {
         $result = rcmail_action_settings_index::wash_html('<p>test</p>');
 
-        $this->assertSame('<p>test</p>', $result);
+        self::assertSame('<p>test</p>', $result);
     }
 }

--- a/tests/Actions/Settings/PrefsEditTest.php
+++ b/tests/Actions/Settings/PrefsEditTest.php
@@ -13,8 +13,8 @@ class Actions_Settings_PrefsEdit extends ActionTestCase
         $action = new rcmail_action_settings_prefs_edit();
         $output = $this->initOutput(rcmail_action::MODE_HTTP, 'settings', 'edit-prefs');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         $_GET['_section'] = 'general';
 
@@ -22,9 +22,9 @@ class Actions_Settings_PrefsEdit extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame('settingsedit', $output->template);
-        $this->assertSame('Preferences', $output->getProperty('pagetitle'));
-        $this->assertTrue(stripos($result, '<!DOCTYPE html>') === 0);
-        $this->assertTrue(strpos($result, "rcmail.gui_object('editform', 'form')") !== false);
+        self::assertSame('settingsedit', $output->template);
+        self::assertSame('Preferences', $output->getProperty('pagetitle'));
+        self::assertTrue(stripos($result, '<!DOCTYPE html>') === 0);
+        self::assertTrue(strpos($result, "rcmail.gui_object('editform', 'form')") !== false);
     }
 }

--- a/tests/Actions/Settings/PrefsSaveTest.php
+++ b/tests/Actions/Settings/PrefsSaveTest.php
@@ -13,16 +13,16 @@ class Actions_Settings_PrefsSave extends ActionTestCase
         $action = new rcmail_action_settings_prefs_save();
         $output = $this->initOutput(rcmail_action::MODE_HTTP, 'settings', 'save-prefs');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         // TODO: Test all sections
         $_POST['_section'] = 'general';
 
         $action->run();
 
-        $this->assertSame('edit-prefs', rcmail::get_instance()->action);
-        $this->assertSame('successfullysaved', $output->getProperty('message'));
+        self::assertSame('edit-prefs', rcmail::get_instance()->action);
+        self::assertSame('successfullysaved', $output->getProperty('message'));
     }
 
     /**
@@ -36,8 +36,8 @@ class Actions_Settings_PrefsSave extends ActionTestCase
 
         rcmail::get_instance()->config->set('test', null);
 
-        $this->assertNull($action->prefs_input('unset', '/test/'));
-        $this->assertSame('test', $action->prefs_input('test', '/^test/'));
-        $this->assertNull($action->prefs_input('test', '/^a/'));
+        self::assertNull($action->prefs_input('unset', '/test/'));
+        self::assertSame('test', $action->prefs_input('test', '/^test/'));
+        self::assertNull($action->prefs_input('test', '/^a/'));
     }
 }

--- a/tests/Actions/Settings/ResponseCreateTest.php
+++ b/tests/Actions/Settings/ResponseCreateTest.php
@@ -13,8 +13,8 @@ class Actions_Settings_ResponseCreate extends ActionTestCase
         $action = new rcmail_action_settings_response_create();
         $output = $this->initOutput(rcmail_action::MODE_HTTP, 'settings', 'add-response');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         $_GET = [];
 
@@ -22,10 +22,10 @@ class Actions_Settings_ResponseCreate extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame('responseedit', $output->template);
-        $this->assertSame('Add response', $output->getProperty('pagetitle'));
-        $this->assertFalse($output->get_env('readonly'));
-        $this->assertTrue(stripos($result, '<!DOCTYPE html>') === 0);
-        $this->assertTrue(strpos($result, "rcmail.gui_object('editform', 'form')") !== false);
+        self::assertSame('responseedit', $output->template);
+        self::assertSame('Add response', $output->getProperty('pagetitle'));
+        self::assertFalse($output->get_env('readonly'));
+        self::assertTrue(stripos($result, '<!DOCTYPE html>') === 0);
+        self::assertTrue(strpos($result, "rcmail.gui_object('editform', 'form')") !== false);
     }
 }

--- a/tests/Actions/Settings/ResponseDeleteTest.php
+++ b/tests/Actions/Settings/ResponseDeleteTest.php
@@ -13,8 +13,8 @@ class Actions_Settings_ResponseDelete extends ActionTestCase
         $action = new rcmail_action_settings_response_delete();
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'settings', 'delete-response');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         $rcmail = rcmail::get_instance();
         $rcmail->user->save_prefs(['compose_responses_static' => []]);
@@ -23,7 +23,7 @@ class Actions_Settings_ResponseDelete extends ActionTestCase
 
         $responses = $rcmail->get_compose_responses();
 
-        $this->assertCount(2, $responses);
+        self::assertCount(2, $responses);
 
         $rid = $responses[0]['id'];
 
@@ -34,15 +34,15 @@ class Actions_Settings_ResponseDelete extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('delete-response', $result['action']);
-        $this->assertTrue(strpos($result['exec'], 'this.display_message("Successfully deleted.","confirmation");') !== false);
-        $this->assertTrue(strpos($result['exec'], 'this.remove_response("' . $rid . '")') !== false);
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('delete-response', $result['action']);
+        self::assertTrue(strpos($result['exec'], 'this.display_message("Successfully deleted.","confirmation");') !== false);
+        self::assertTrue(strpos($result['exec'], 'this.remove_response("' . $rid . '")') !== false);
 
         $responses = $rcmail->get_compose_responses();
 
-        $this->assertCount(1, $responses);
-        $this->assertTrue($responses[0]['id'] != $rid);
+        self::assertCount(1, $responses);
+        self::assertTrue($responses[0]['id'] != $rid);
 
         // Test error
         $_POST = ['_id' => 'unknown'];
@@ -51,10 +51,10 @@ class Actions_Settings_ResponseDelete extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('delete-response', $result['action']);
-        $this->assertTrue(strpos($result['exec'], 'this.display_message("An error occurred while saving.","error"') !== false);
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('delete-response', $result['action']);
+        self::assertTrue(strpos($result['exec'], 'this.display_message("An error occurred while saving.","error"') !== false);
 
-        $this->assertCount(1, $rcmail->get_compose_responses());
+        self::assertCount(1, $rcmail->get_compose_responses());
     }
 }

--- a/tests/Actions/Settings/ResponseEditTest.php
+++ b/tests/Actions/Settings/ResponseEditTest.php
@@ -13,8 +13,8 @@ class Actions_Settings_ResponseEdit extends ActionTestCase
         $action = new rcmail_action_settings_response_edit();
         $output = $this->initOutput(rcmail_action::MODE_HTTP, 'settings', 'edit-response');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         $rcmail = rcmail::get_instance();
         $rcmail->user->save_prefs([
@@ -34,13 +34,13 @@ class Actions_Settings_ResponseEdit extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame('responseedit', $output->template);
-        $this->assertSame('Edit response', $output->getProperty('pagetitle'));
-        $this->assertTrue($output->get_env('readonly'));
-        $this->assertTrue(stripos($result, '<!DOCTYPE html>') === 0);
-        $this->assertTrue(strpos($result, "rcmail.gui_object('editform', 'form')") !== false);
-        $this->assertTrue(strpos($result, 'tinymce.min.js') !== false);
-        $this->assertTrue(strpos($result, 'Static Response One</textarea>') !== false);
+        self::assertSame('responseedit', $output->template);
+        self::assertSame('Edit response', $output->getProperty('pagetitle'));
+        self::assertTrue($output->get_env('readonly'));
+        self::assertTrue(stripos($result, '<!DOCTYPE html>') === 0);
+        self::assertTrue(strpos($result, "rcmail.gui_object('editform', 'form')") !== false);
+        self::assertTrue(strpos($result, 'tinymce.min.js') !== false);
+        self::assertTrue(strpos($result, 'Static Response One</textarea>') !== false);
 
         // Test writable response
         $_GET = ['_id' => $responses[2]['id']];
@@ -49,10 +49,10 @@ class Actions_Settings_ResponseEdit extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame('responseedit', $output->template);
-        $this->assertSame('Edit response', $output->getProperty('pagetitle'));
-        $this->assertFalse($output->get_env('readonly'));
-        $this->assertTrue(strpos($result, 'test response 2&lt;/b&gt;&lt;/p&gt;</textarea>') !== false);
+        self::assertSame('responseedit', $output->template);
+        self::assertSame('Edit response', $output->getProperty('pagetitle'));
+        self::assertFalse($output->get_env('readonly'));
+        self::assertTrue(strpos($result, 'test response 2&lt;/b&gt;&lt;/p&gt;</textarea>') !== false);
     }
 
     /**
@@ -62,6 +62,6 @@ class Actions_Settings_ResponseEdit extends ActionTestCase
     {
         $result = rcmail_action_settings_response_edit::response_form([]);
 
-        $this->assertTrue(strpos(trim($result), '<table>') === 0);
+        self::assertTrue(strpos(trim($result), '<table>') === 0);
     }
 }

--- a/tests/Actions/Settings/ResponseGetTest.php
+++ b/tests/Actions/Settings/ResponseGetTest.php
@@ -13,8 +13,8 @@ class Actions_Settings_ResponseGet extends ActionTestCase
         $action = new rcmail_action_settings_response_get();
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'settings', 'response-get');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         $rcmail = rcmail::get_instance();
         $rcmail->user->save_prefs([
@@ -35,14 +35,14 @@ class Actions_Settings_ResponseGet extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('response-get', $result['action']);
-        $this->assertTrue(preg_match('/this\.insert_response\(([^)]+)\);/', $result['exec'], $m) === 1);
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('response-get', $result['action']);
+        self::assertTrue(preg_match('/this\.insert_response\(([^)]+)\);/', $result['exec'], $m) === 1);
         $data = json_decode($m[1], true);
-        $this->assertSame($responses[0]['id'], $data['id']);
-        $this->assertSame('static 1', $data['name']);
-        $this->assertTrue($data['is_html']);
-        $this->assertSame('<div class="pre">Static Response One</div>', $data['data']);
+        self::assertSame($responses[0]['id'], $data['id']);
+        self::assertSame('static 1', $data['name']);
+        self::assertTrue($data['is_html']);
+        self::assertSame('<div class="pre">Static Response One</div>', $data['data']);
 
         // Test unknown identifier
 
@@ -52,9 +52,9 @@ class Actions_Settings_ResponseGet extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('response-get', $result['action']);
-        $this->assertSame('', $result['exec']);
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('response-get', $result['action']);
+        self::assertSame('', $result['exec']);
 
         // Test a normal response (html converted to text)
 
@@ -64,13 +64,13 @@ class Actions_Settings_ResponseGet extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('response-get', $result['action']);
-        $this->assertTrue(preg_match('/this\.insert_response\(([^)]+)\);/', $result['exec'], $m) === 1);
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('response-get', $result['action']);
+        self::assertTrue(preg_match('/this\.insert_response\(([^)]+)\);/', $result['exec'], $m) === 1);
         $data = json_decode($m[1], true);
-        $this->assertSame($responses[2]['id'], $data['id']);
-        $this->assertSame('response 2', $data['name']);
-        $this->assertFalse($data['is_html']);
-        $this->assertSame('test response 2', $data['data']);
+        self::assertSame($responses[2]['id'], $data['id']);
+        self::assertSame('response 2', $data['name']);
+        self::assertFalse($data['is_html']);
+        self::assertSame('test response 2', $data['data']);
     }
 }

--- a/tests/Actions/Settings/ResponseSaveTest.php
+++ b/tests/Actions/Settings/ResponseSaveTest.php
@@ -13,8 +13,8 @@ class Actions_Settings_ResponseSave extends ActionTestCase
         $action = new rcmail_action_settings_response_save();
         $output = $this->initOutput(rcmail_action::MODE_HTTP, 'settings', 'save-response');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         $rcmail = rcmail::get_instance();
         $rcmail->user->save_prefs(['compose_responses_static' => []]);
@@ -32,14 +32,14 @@ class Actions_Settings_ResponseSave extends ActionTestCase
 
         $action->run();
 
-        $this->assertSame('edit-response', rcmail::get_instance()->action);
-        $this->assertSame('successfullysaved', $output->getProperty('message'));
+        self::assertSame('edit-response', rcmail::get_instance()->action);
+        self::assertSame('successfullysaved', $output->getProperty('message'));
 
         $response = $rcmail->get_compose_response($responses[0]['id']);
 
-        $this->assertSame('name1', $response['name']);
-        $this->assertSame('text1', $response['data']);
-        $this->assertTrue(empty($response['is_html']));
+        self::assertSame('name1', $response['name']);
+        self::assertSame('text1', $response['data']);
+        self::assertTrue(empty($response['is_html']));
 
         // Test updating an existing response (change format)
         $_POST = [
@@ -51,14 +51,14 @@ class Actions_Settings_ResponseSave extends ActionTestCase
 
         $action->run();
 
-        $this->assertSame('edit-response', rcmail::get_instance()->action);
-        $this->assertSame('successfullysaved', $output->getProperty('message'));
+        self::assertSame('edit-response', rcmail::get_instance()->action);
+        self::assertSame('successfullysaved', $output->getProperty('message'));
 
         $response = $rcmail->get_compose_response($responses[0]['id']);
 
-        $this->assertSame('name2', $response['name']);
-        $this->assertSame('<p>text2</p>', $response['data']);
-        $this->assertTrue(!empty($response['is_html']));
+        self::assertSame('name2', $response['name']);
+        self::assertSame('<p>text2</p>', $response['data']);
+        self::assertTrue(!empty($response['is_html']));
 
         // Test adding a response
         $_POST = [
@@ -69,15 +69,15 @@ class Actions_Settings_ResponseSave extends ActionTestCase
 
         $action->run();
 
-        $this->assertSame('edit-response', rcmail::get_instance()->action);
-        $this->assertSame('successfullysaved', $output->getProperty('message'));
+        self::assertSame('edit-response', rcmail::get_instance()->action);
+        self::assertSame('successfullysaved', $output->getProperty('message'));
 
         $responses = $rcmail->get_compose_responses();
         $response = $rcmail->get_compose_response($responses[0]['id']);
 
-        $this->assertSame('aaa', $responses[0]['name']);
-        $this->assertSame('<p>text3</p>', $response['data']);
-        $this->assertTrue(!empty($response['is_html']));
+        self::assertSame('aaa', $responses[0]['name']);
+        self::assertSame('<p>text3</p>', $response['data']);
+        self::assertTrue(!empty($response['is_html']));
 
         // TODO: Test error handling
     }

--- a/tests/Actions/Settings/ResponsesTest.php
+++ b/tests/Actions/Settings/ResponsesTest.php
@@ -13,8 +13,8 @@ class Actions_Settings_Responses extends ActionTestCase
         $action = new rcmail_action_settings_responses();
         $output = $this->initOutput(rcmail_action::MODE_HTTP, 'settings', 'responses');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         self::initDB('responses');
 
@@ -22,11 +22,11 @@ class Actions_Settings_Responses extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame('responses', $output->template);
-        $this->assertSame('Responses', $output->getProperty('pagetitle'));
-        $this->assertTrue(stripos($result, '<!DOCTYPE html>') === 0);
-        $this->assertTrue(stripos($result, '<table ') !== false);
-        $this->assertMatchesRegularExpression('/list(.min)?.js/', $result);
+        self::assertSame('responses', $output->template);
+        self::assertSame('Responses', $output->getProperty('pagetitle'));
+        self::assertTrue(stripos($result, '<!DOCTYPE html>') === 0);
+        self::assertTrue(stripos($result, '<table ') !== false);
+        self::assertMatchesRegularExpression('/list(.min)?.js/', $result);
     }
 
     /**
@@ -53,6 +53,6 @@ class Actions_Settings_Responses extends ActionTestCase
             . '<tr id="rcmrow2"><td class="name">response 2</td></tr>'
             . '</tbody></table>';
 
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 }

--- a/tests/Actions/Settings/UploadDisplayTest.php
+++ b/tests/Actions/Settings/UploadDisplayTest.php
@@ -12,6 +12,6 @@ class Actions_Settings_UploadDisplay extends ActionTestCase
     {
         $object = new rcmail_action_settings_upload_display();
 
-        $this->assertInstanceOf('rcmail_action', $object);
+        self::assertInstanceOf('rcmail_action', $object);
     }
 }

--- a/tests/Actions/Settings/UploadTest.php
+++ b/tests/Actions/Settings/UploadTest.php
@@ -13,8 +13,8 @@ class Actions_Settings_Upload extends ActionTestCase
         $action = new rcmail_action_settings_upload();
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'settings', 'upload');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         $_SERVER['REQUEST_METHOD'] = 'POST';
         $_GET = [
@@ -28,10 +28,10 @@ class Actions_Settings_Upload extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('upload', $result['action']);
-        $this->assertTrue(strpos($result['exec'], 'this.remove_from_attachment_list("upload123");') !== false);
-        $this->assertSame($_GET['_unlock'], $result['unlock']);
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('upload', $result['action']);
+        self::assertTrue(strpos($result['exec'], 'this.remove_from_attachment_list("upload123");') !== false);
+        self::assertSame($_GET['_unlock'], $result['unlock']);
 
         // Upload a file
         $file = $this->fakeUpload();
@@ -40,15 +40,15 @@ class Actions_Settings_Upload extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('upload', $result['action']);
-        $this->assertTrue(strpos($result['exec'], 'this.add2attachment_list("rcmfile' . $file['id'] . '"') !== false);
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('upload', $result['action']);
+        self::assertTrue(strpos($result['exec'], 'this.add2attachment_list("rcmfile' . $file['id'] . '"') !== false);
 
         $upload = rcmail::get_instance()->get_uploaded_file($file['id']);
-        $this->assertSame($file['name'], $upload['name']);
-        $this->assertSame($file['type'], $upload['mimetype']);
-        $this->assertSame($file['size'], $upload['size']);
-        $this->assertSame('identity', $upload['group']);
+        self::assertSame($file['name'], $upload['name']);
+        self::assertSame($file['type'], $upload['mimetype']);
+        self::assertSame($file['size'], $upload['size']);
+        self::assertSame('identity', $upload['group']);
 
         // Upload error case
         $file = $this->fakeUpload('_file', true, \UPLOAD_ERR_INI_SIZE);
@@ -57,8 +57,8 @@ class Actions_Settings_Upload extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
-        $this->assertSame('upload', $result['action']);
-        $this->assertTrue(strpos($result['exec'], 'this.display_message("The uploaded file exceeds the maximum size') !== false);
+        self::assertSame(['Content-Type: application/json; charset=UTF-8'], $output->headers);
+        self::assertSame('upload', $result['action']);
+        self::assertTrue(strpos($result['exec'], 'this.display_message("The uploaded file exceeds the maximum size') !== false);
     }
 }

--- a/tests/Actions/Utils/ErrorTest.php
+++ b/tests/Actions/Utils/ErrorTest.php
@@ -13,18 +13,18 @@ class Actions_Utils_Error extends ActionTestCase
         $output = $this->initOutput(rcmail_action::MODE_HTTP, 'mail', 'test');
         $action = new rcmail_action_utils_error();
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         // Default error
         $this->runAndAssert($action, OutputHtmlMock::E_EXIT, []);
 
         $result = $output->getOutput();
 
-        $this->assertSame('error', $output->template);
-        $this->assertTrue(stripos($result, '<!DOCTYPE html>') === 0);
-        $this->assertTrue(strpos($result, '<h3 class="error-title">SERVER ERROR!</h3>') !== false);
-        $this->assertTrue(strpos($result, '<div class="error-text">Error No. [500]</div>') !== false);
+        self::assertSame('error', $output->template);
+        self::assertTrue(stripos($result, '<!DOCTYPE html>') === 0);
+        self::assertTrue(strpos($result, '<h3 class="error-title">SERVER ERROR!</h3>') !== false);
+        self::assertTrue(strpos($result, '<div class="error-text">Error No. [500]</div>') !== false);
 
         // TODO: Test error text for all error types
     }
@@ -41,63 +41,63 @@ class Actions_Utils_Error extends ActionTestCase
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'mail', 'compose');
         $action = new rcmail_action_utils_error();
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         // Default error
         $args = ['code' => 600];
         $this->runAndAssert($action, OutputJsonMock::E_EXIT, $args);
 
-        $this->assertNull($output->getOutput());
-        $this->assertSame(['HTTP/1.0 500 Server Error!'], $output->headers);
+        self::assertNull($output->getOutput());
+        self::assertSame(['HTTP/1.0 500 Server Error!'], $output->headers);
 
         // 401
         $args = ['code' => 401, 'message' => 'test'];
         $this->runAndAssert($action, OutputJsonMock::E_EXIT, $args);
 
-        $this->assertNull($output->getOutput());
-        $this->assertSame(['HTTP/1.0 401 Authorization Failed'], $output->headers);
+        self::assertNull($output->getOutput());
+        self::assertSame(['HTTP/1.0 401 Authorization Failed'], $output->headers);
 
         // 403
         $args = ['code' => 403, 'message' => 'test'];
         $this->runAndAssert($action, OutputJsonMock::E_EXIT, $args);
 
-        $this->assertNull($output->getOutput());
-        $this->assertSame(['HTTP/1.0 403 Request Check Failed'], $output->headers);
+        self::assertNull($output->getOutput());
+        self::assertSame(['HTTP/1.0 403 Request Check Failed'], $output->headers);
 
         // 404
         $args = ['code' => 404, 'message' => 'test'];
         $this->runAndAssert($action, OutputJsonMock::E_EXIT, $args);
 
-        $this->assertNull($output->getOutput());
-        $this->assertSame(['HTTP/1.0 404 File Not Found'], $output->headers);
+        self::assertNull($output->getOutput());
+        self::assertSame(['HTTP/1.0 404 File Not Found'], $output->headers);
 
         // 410
         $args = ['code' => 410, 'message' => 'test'];
         $this->runAndAssert($action, OutputJsonMock::E_EXIT, $args);
 
-        $this->assertNull($output->getOutput());
-        $this->assertSame(['HTTP/1.0 410 Server Error!'], $output->headers);
+        self::assertNull($output->getOutput());
+        self::assertSame(['HTTP/1.0 410 Server Error!'], $output->headers);
 
         // 450
         $args = ['code' => 450, 'message' => 'test'];
         $this->runAndAssert($action, OutputJsonMock::E_EXIT, $args);
 
-        $this->assertNull($output->getOutput());
-        $this->assertSame(['HTTP/1.0 450 Compose session error'], $output->headers);
+        self::assertNull($output->getOutput());
+        self::assertSame(['HTTP/1.0 450 Compose session error'], $output->headers);
 
         // 601
         $args = ['code' => 601, 'message' => 'test'];
         $this->runAndAssert($action, OutputJsonMock::E_EXIT, $args);
 
-        $this->assertNull($output->getOutput());
-        $this->assertSame(['HTTP/1.0 500 Configuration error'], $output->headers);
+        self::assertNull($output->getOutput());
+        self::assertSame(['HTTP/1.0 500 Configuration error'], $output->headers);
 
         // 603
         $args = ['code' => 603, 'message' => 'test'];
         $this->runAndAssert($action, OutputJsonMock::E_EXIT, $args);
 
-        $this->assertNull($output->getOutput());
-        $this->assertSame(['HTTP/1.0 500 Database Error!'], $output->headers);
+        self::assertNull($output->getOutput());
+        self::assertSame(['HTTP/1.0 500 Database Error!'], $output->headers);
     }
 }

--- a/tests/Actions/Utils/Html2textTest.php
+++ b/tests/Actions/Utils/Html2textTest.php
@@ -16,12 +16,12 @@ class Actions_Utils_Html2text extends ActionTestCase
 
         $output = $this->initOutput(rcmail_action::MODE_HTTP, 'utils', 'html2text');
 
-        $this->assertInstanceOf('rcmail_action', $object);
-        $this->assertTrue($object->checks());
+        self::assertInstanceOf('rcmail_action', $object);
+        self::assertTrue($object->checks());
 
         $this->runAndAssert($object, OutputHtmlMock::E_EXIT);
 
-        $this->assertSame('test', $output->output);
-        $this->assertSame(['Content-Type: text/plain; charset=UTF-8'], $output->headers);
+        self::assertSame('test', $output->output);
+        self::assertSame(['Content-Type: text/plain; charset=UTF-8'], $output->headers);
     }
 }

--- a/tests/Actions/Utils/KillcacheTest.php
+++ b/tests/Actions/Utils/KillcacheTest.php
@@ -12,6 +12,6 @@ class Actions_Utils_Killcache extends ActionTestCase
     {
         $object = new rcmail_action_utils_killcache();
 
-        $this->assertInstanceOf('rcmail_action', $object);
+        self::assertInstanceOf('rcmail_action', $object);
     }
 }

--- a/tests/Actions/Utils/ModcssTest.php
+++ b/tests/Actions/Utils/ModcssTest.php
@@ -13,23 +13,23 @@ class Actions_Utils_Modcss extends ActionTestCase
         $action = new rcmail_action_utils_modcss();
         $output = $this->initOutput(rcmail_action::MODE_HTTP, 'utils', 'modcss');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         // No input parameters
         $this->runAndAssert($action, OutputHtmlMock::E_EXIT);
 
-        $this->assertSame(403, $output->getProperty('errorCode'));
-        $this->assertSame('Unauthorized request', $output->getProperty('errorMessage'));
-        $this->assertNull($output->getOutput());
+        self::assertSame(403, $output->getProperty('errorCode'));
+        self::assertSame('Unauthorized request', $output->getProperty('errorMessage'));
+        self::assertNull($output->getOutput());
 
         // Invalid url
         $_GET['_u'] = '****';
         $this->runAndAssert($action, OutputHtmlMock::E_EXIT);
 
-        $this->assertSame(403, $output->getProperty('errorCode'));
-        $this->assertSame('Unauthorized request', $output->getProperty('errorMessage'));
-        $this->assertNull($output->getOutput());
+        self::assertSame(403, $output->getProperty('errorCode'));
+        self::assertSame('Unauthorized request', $output->getProperty('errorMessage'));
+        self::assertNull($output->getOutput());
 
         // Valid url but not "registered"
         $url = 'https://raw.githubusercontent.com/roundcube/roundcubemail/master/aaaaaaaaaa';
@@ -38,9 +38,9 @@ class Actions_Utils_Modcss extends ActionTestCase
 
         $this->runAndAssert($action, OutputHtmlMock::E_EXIT);
 
-        $this->assertSame(403, $output->getProperty('errorCode'));
-        $this->assertSame('Unauthorized request', $output->getProperty('errorMessage'));
-        $this->assertNull($output->getOutput());
+        self::assertSame(403, $output->getProperty('errorCode'));
+        self::assertSame('Unauthorized request', $output->getProperty('errorMessage'));
+        self::assertNull($output->getOutput());
 
         // Valid url pointing to non-existing resource
         $_SESSION['modcssurls'][$key] = $url;
@@ -52,9 +52,9 @@ class Actions_Utils_Modcss extends ActionTestCase
 
         $this->runAndAssert($action, OutputHtmlMock::E_EXIT);
 
-        $this->assertSame(404, $output->getProperty('errorCode'));
-        $this->assertSame('Invalid response returned by server', $output->getProperty('errorMessage'));
-        $this->assertNull($output->getOutput());
+        self::assertSame(404, $output->getProperty('errorCode'));
+        self::assertSame('Invalid response returned by server', $output->getProperty('errorMessage'));
+        self::assertNull($output->getOutput());
 
         // Valid url pointing to an existing resource
         $url = 'https://raw.githubusercontent.com/roundcube/roundcubemail/master/program/resources/tinymce/content.css';
@@ -64,8 +64,8 @@ class Actions_Utils_Modcss extends ActionTestCase
 
         $this->runAndAssert($action, OutputHtmlMock::E_EXIT);
 
-        $this->assertNull($output->getProperty('errorCode'));
-        $this->assertSame(['Content-Type: text/css'], $output->getProperty('headers'));
-        $this->assertStringContainsString('#cid div.prefixpre', $output->getOutput());
+        self::assertNull($output->getProperty('errorCode'));
+        self::assertSame(['Content-Type: text/css'], $output->getProperty('headers'));
+        self::assertStringContainsString('#cid div.prefixpre', $output->getOutput());
     }
 }

--- a/tests/Actions/Utils/SavePrefTest.php
+++ b/tests/Actions/Utils/SavePrefTest.php
@@ -13,8 +13,8 @@ class Actions_Utils_SavePref extends ActionTestCase
         $action = new rcmail_action_utils_save_pref();
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'utils', 'save_pref');
 
-        $this->assertInstanceOf('rcmail_action', $action);
-        $this->assertTrue($action->checks());
+        self::assertInstanceOf('rcmail_action', $action);
+        self::assertTrue($action->checks());
 
         $rcmail = rcmail::get_instance();
         $rcmail->user->save_prefs(['list_cols' => []]);
@@ -31,7 +31,7 @@ class Actions_Utils_SavePref extends ActionTestCase
         $user = new rcube_user($rcmail->user->ID);
         $prefs = $user->get_prefs();
 
-        $this->assertSame(['date'], $prefs['list_cols']);
+        self::assertSame(['date'], $prefs['list_cols']);
 
         // TODO: Test writing to session, test whitelist
     }

--- a/tests/Actions/Utils/SpellHtmlTest.php
+++ b/tests/Actions/Utils/SpellHtmlTest.php
@@ -12,6 +12,6 @@ class Actions_Utils_SpellHtml extends ActionTestCase
     {
         $object = new rcmail_action_utils_spell_html();
 
-        $this->assertInstanceOf('rcmail_action', $object);
+        self::assertInstanceOf('rcmail_action', $object);
     }
 }

--- a/tests/Actions/Utils/SpellTest.php
+++ b/tests/Actions/Utils/SpellTest.php
@@ -12,6 +12,6 @@ class Actions_Utils_Spell extends ActionTestCase
     {
         $object = new rcmail_action_utils_spell();
 
-        $this->assertInstanceOf('rcmail_action', $object);
+        self::assertInstanceOf('rcmail_action', $object);
     }
 }

--- a/tests/Actions/Utils/Text2htmlTest.php
+++ b/tests/Actions/Utils/Text2htmlTest.php
@@ -12,7 +12,7 @@ class Actions_Utils_Text2html extends ActionTestCase
     {
         $object = new rcmail_action_utils_text2html();
 
-        $this->assertInstanceOf('rcmail_action', $object);
+        self::assertInstanceOf('rcmail_action', $object);
     }
 
     /**
@@ -26,11 +26,11 @@ class Actions_Utils_Text2html extends ActionTestCase
 
         $output = $this->initOutput(rcmail_action::MODE_HTTP, 'utils', 'text2html');
 
-        $this->assertTrue($object->checks());
+        self::assertTrue($object->checks());
 
         $this->runAndAssert($object, OutputHtmlMock::E_EXIT);
 
-        $this->assertSame('<div class="pre">test plain text input</div>', $output->output);
-        $this->assertSame(['Content-Type: text/html; charset=UTF-8'], $output->headers);
+        self::assertSame('<div class="pre">test plain text input</div>', $output->output);
+        self::assertSame(['Content-Type: text/html; charset=UTF-8'], $output->headers);
     }
 }

--- a/tests/Browser/Contacts/ExportTest.php
+++ b/tests/Browser/Contacts/ExportTest.php
@@ -16,7 +16,7 @@ class ExportTest extends TestCase
      */
     public function testExportAll()
     {
-        $this->browse(function ($browser) {
+        $this->browse(static function ($browser) {
             $browser->go('addressbook');
 
             $browser->clickToolbarMenuItem('export');
@@ -26,9 +26,9 @@ class ExportTest extends TestCase
             $vcard = new \rcube_vcard();
             $contacts = $vcard->import($vcard_content);
 
-            $this->assertCount(2, $contacts);
-            $this->assertSame('John Doe', $contacts[0]->displayname);
-            $this->assertSame('Jane Stalone', $contacts[1]->displayname);
+            self::assertCount(2, $contacts);
+            self::assertSame('John Doe', $contacts[0]->displayname);
+            self::assertSame('Jane Stalone', $contacts[1]->displayname);
 
             $browser->removeDownloadedFile('contacts.vcf');
         });
@@ -41,7 +41,7 @@ class ExportTest extends TestCase
      */
     public function testExportSelected()
     {
-        $this->browse(function ($browser) {
+        $this->browse(static function ($browser) {
             $browser->ctrlClick('#contacts-table tbody tr:first-child');
 
             $browser->clickToolbarMenuItem('export', 'export.select');
@@ -51,8 +51,8 @@ class ExportTest extends TestCase
             $contacts = $vcard->import($vcard_content);
 
             // Parse the downloaded vCard file
-            $this->assertCount(1, $contacts);
-            $this->assertSame('John Doe', $contacts[0]->displayname);
+            self::assertCount(1, $contacts);
+            self::assertSame('John Doe', $contacts[0]->displayname);
 
             $browser->removeDownloadedFile('contacts.vcf');
         });

--- a/tests/Browser/Logon/LoginTest.php
+++ b/tests/Browser/Logon/LoginTest.php
@@ -38,7 +38,7 @@ class LoginTest extends TestCase
             // Support link
             if ($url = $this->app->config->get('support_url')) {
                 $browser->assertSeeLink('Get support');
-                $this->assertStringStartsWith($url, $browser->attribute('.support-link', 'href'));
+                self::assertStringStartsWith($url, $browser->attribute('.support-link', 'href'));
             }
 
             // test valid login

--- a/tests/Browser/Mail/GetunreadTest.php
+++ b/tests/Browser/Mail/GetunreadTest.php
@@ -22,7 +22,7 @@ class GetunreadTest extends TestCase
 
     public function testGetunread()
     {
-        $this->browse(function ($browser) {
+        $this->browse(static function ($browser) {
             $browser->go('mail');
 
             $browser->waitFor('#messagelist tbody tr');
@@ -37,7 +37,7 @@ class GetunreadTest extends TestCase
             // Folders list state
             $browser->assertVisible('.folderlist li.inbox.unread');
 
-            $this->assertSame(strval(self::$msgcount), $browser->text('.folderlist li.inbox span.unreadcount'));
+            self::assertSame(strval(self::$msgcount), $browser->text('.folderlist li.inbox span.unreadcount'));
         });
     }
 }

--- a/tests/Browser/Mail/ListTest.php
+++ b/tests/Browser/Mail/ListTest.php
@@ -23,7 +23,7 @@ class ListTest extends TestCase
 
     public function testList()
     {
-        $this->browse(function ($browser) {
+        $this->browse(static function ($browser) {
             $browser->go('mail');
 
             $browser->waitUntilNotBusy()
@@ -32,7 +32,7 @@ class ListTest extends TestCase
             // check message list
             $browser->assertVisible('#messagelist tbody tr:first-child.unread');
 
-            $this->assertSame('Test HTML with local and remote image',
+            self::assertSame('Test HTML with local and remote image',
                 $browser->text('#messagelist tbody tr:first-child span.subject'));
 
             // Note: This element icon has width=0, use assertPresent() not assertVisible()

--- a/tests/Browser/Mail/OpenTest.php
+++ b/tests/Browser/Mail/OpenTest.php
@@ -36,11 +36,11 @@ class OpenTest extends TestCase
 
             $browser->clickToolbarMenuItem('more');
 
-            $browser->with(new Popupmenu('message-menu'), function ($browser) {
+            $browser->with(new Popupmenu('message-menu'), static function ($browser) {
                 $uids = $browser->driver->executeScript('return rcmail.message_list.get_selection()');
 
-                $this->assertCount(1, $uids);
-                $this->assertTrue(is_int($uids[0]) && $uids[0] > 0);
+                self::assertCount(1, $uids);
+                self::assertTrue(is_int($uids[0]) && $uids[0] > 0);
 
                 $uid = $uids[0];
 

--- a/tests/Browser/Mail/PreviewTest.php
+++ b/tests/Browser/Mail/PreviewTest.php
@@ -23,7 +23,7 @@ class PreviewTest extends TestCase
      */
     public function testPreview()
     {
-        $this->browse(function ($browser) {
+        $this->browse(static function ($browser) {
             $browser->go('mail');
 
             $browser->waitFor('#messagelist tbody tr:first-child')
@@ -44,7 +44,7 @@ class PreviewTest extends TestCase
                 });
             }
 
-            $browser->withinFrame('#messagecontframe', function ($browser) {
+            $browser->withinFrame('#messagecontframe', static function ($browser) {
                 $browser->waitFor('img.contactphoto');
 
                 // Privacy warning
@@ -52,8 +52,8 @@ class PreviewTest extends TestCase
                     ->assertSeeIn('#remote-objects-message', 'To protect your privacy remote resources have been blocked.');
 
                 // Images
-                $this->assertMatchesRegularExpression('/action=get/', $browser->attribute('p#v1attached > img', 'src'));
-                $this->assertMatchesRegularExpression('/blocked/', $browser->attribute('p#v1remote > img', 'src'));
+                self::assertMatchesRegularExpression('/action=get/', $browser->attribute('p#v1attached > img', 'src'));
+                self::assertMatchesRegularExpression('/blocked/', $browser->attribute('p#v1remote > img', 'src'));
 
                 // Attachments list
                 $browser->assertMissing('#attachment-list');
@@ -115,8 +115,8 @@ class PreviewTest extends TestCase
 
             $txt = $browser->readDownloadedFile('lines.txt');
 
-            $this->assertTrue(strlen($txt) == 13);
-            $this->assertSame("foo\r\nbar\r\ngna", $txt);
+            self::assertTrue(strlen($txt) == 13);
+            self::assertSame("foo\r\nbar\r\ngna", $txt);
             $browser->removeDownloadedFile('lines.txt');
 
             // On phone check Back button

--- a/tests/Browser/Settings/IdentitiesTest.php
+++ b/tests/Browser/Settings/IdentitiesTest.php
@@ -240,7 +240,7 @@ class IdentitiesTest extends TestCase
             'email' => 'another@domain.tld',
         ]);
 
-        $this->browse(function ($browser) {
+        $this->browse(static function ($browser) {
             if ($browser->isPhone()) {
                 $browser->click('a.back-sidebar-button');
             }
@@ -251,9 +251,9 @@ class IdentitiesTest extends TestCase
                 ->assertElementsCount('select[name=_from] > option', 2)
                 ->assertSeeIn('select[name=_from] > option[selected]', 'mynew@identity.com');
 
-            $this->assertTrue(trim($browser->value('#_bcc'), ', ') === 'bcc@domain.tld');
-            $this->assertTrue(trim($browser->value('#_replyto'), ', ') === 'replyto@domain.tld');
-            $this->assertTrue(strpos($browser->value('#composebody'), 'My signature') !== false);
+            self::assertTrue(trim($browser->value('#_bcc'), ', ') === 'bcc@domain.tld');
+            self::assertTrue(trim($browser->value('#_replyto'), ', ') === 'replyto@domain.tld');
+            self::assertTrue(strpos($browser->value('#composebody'), 'My signature') !== false);
 
             // TODO: Recipient input, HTML mode, identity change
 

--- a/tests/Browser/Settings/Preferences/GeneralTest.php
+++ b/tests/Browser/Settings/Preferences/GeneralTest.php
@@ -157,10 +157,10 @@ class GeneralTest extends TestCase
         $options = array_diff(array_keys($this->settings), ['refresh_interval', 'pretty_date']);
 
         foreach ($options as $option) {
-            $this->assertSame($this->settings[$option], $prefs[$option]);
+            self::assertSame($this->settings[$option], $prefs[$option]);
         }
 
-        $this->assertSame($this->settings['pretty_date'], $prefs['prettydate']);
-        $this->assertSame($this->settings['refresh_interval'], $prefs['refresh_interval'] / 60);
+        self::assertSame($this->settings['pretty_date'], $prefs['prettydate']);
+        self::assertSame($this->settings['refresh_interval'], $prefs['refresh_interval'] / 60);
     }
 }

--- a/tests/Browser/Settings/Preferences/ServerTest.php
+++ b/tests/Browser/Settings/Preferences/ServerTest.php
@@ -114,7 +114,7 @@ class ServerTest extends TestCase
         $prefs = \bootstrap::get_prefs();
 
         foreach ($this->settings as $key => $value) {
-            $this->assertSame($value, $prefs[$key]);
+            self::assertSame($value, $prefs[$key]);
         }
     }
 }

--- a/tests/Framework/AddressbookTest.php
+++ b/tests/Framework/AddressbookTest.php
@@ -76,17 +76,17 @@ class Framework_Addressbook extends TestCase
         rcube::get_instance()->config->set('addressbook_name_listing', 3);
         $result = rcube_addressbook::compose_list_name($contact);
 
-        $this->assertSame('Last, First M.', $result);
+        self::assertSame('Last, First M.', $result);
 
         rcube::get_instance()->config->set('addressbook_name_listing', 2);
         $result = rcube_addressbook::compose_list_name($contact);
 
-        $this->assertSame('Last First M.', $result);
+        self::assertSame('Last First M.', $result);
 
         rcube::get_instance()->config->set('addressbook_name_listing', 1);
         $result = rcube_addressbook::compose_list_name($contact);
 
-        $this->assertSame('First M. Last', $result);
+        self::assertSame('First M. Last', $result);
         */
     }
 }

--- a/tests/Framework/AddressbookTest.php
+++ b/tests/Framework/AddressbookTest.php
@@ -15,17 +15,17 @@ class Framework_Addressbook extends TestCase
         $data = ['email' => 'test@test.com', 'other' => 'test'];
         $result = rcube_addressbook::get_col_values('email', $data, true);
 
-        $this->assertSame(['test@test.com'], $result);
+        self::assertSame(['test@test.com'], $result);
 
         $data = ['email:home' => 'test@test.com', 'other' => 'test'];
         $result = rcube_addressbook::get_col_values('email', $data, true);
 
-        $this->assertSame(['test@test.com'], $result);
+        self::assertSame(['test@test.com'], $result);
 
         $data = ['email:home' => 'test@test.com', 'other' => 'test'];
         $result = rcube_addressbook::get_col_values('email', $data, false);
 
-        $this->assertSame(['home' => ['test@test.com']], $result);
+        self::assertSame(['home' => ['test@test.com']], $result);
     }
 
     /**
@@ -36,32 +36,32 @@ class Framework_Addressbook extends TestCase
         $contact = [];
         $result = rcube_addressbook::compose_list_name($contact);
 
-        $this->assertSame('', $result);
+        self::assertSame('', $result);
 
         $contact = ['email' => 'email@address.tld'];
         $result = rcube_addressbook::compose_list_name($contact);
 
-        $this->assertSame('email@address.tld', $result);
+        self::assertSame('email@address.tld', $result);
 
         $contact = ['email' => 'email@address.tld', 'organization' => 'Org'];
         $result = rcube_addressbook::compose_list_name($contact);
 
-        $this->assertSame('Org', $result);
+        self::assertSame('Org', $result);
 
         $contact['firstname'] = 'First';
         $result = rcube_addressbook::compose_list_name($contact);
 
-        $this->assertSame('First', $result);
+        self::assertSame('First', $result);
 
         $contact['surname'] = 'Last';
         $result = rcube_addressbook::compose_list_name($contact);
 
-        $this->assertSame('First Last', $result);
+        self::assertSame('First Last', $result);
 
         $contact['name'] = 'Name';
         $result = rcube_addressbook::compose_list_name($contact);
 
-        $this->assertSame('Name', $result);
+        self::assertSame('Name', $result);
 
         unset($contact['name']);
         $contact['prefix'] = 'Dr.';
@@ -69,7 +69,7 @@ class Framework_Addressbook extends TestCase
         $contact['middlename'] = 'M.';
         $result = rcube_addressbook::compose_list_name($contact);
 
-        $this->assertSame('Dr. First M. Last Jr.', $result);
+        self::assertSame('Dr. First M. Last Jr.', $result);
 
         // TODO: Test different modes
         /*

--- a/tests/Framework/AddressesTest.php
+++ b/tests/Framework/AddressesTest.php
@@ -15,7 +15,7 @@ class Framework_Addresses extends TestCase
         $db = new rcube_db('test');
         $object = new rcube_addresses($db, null, 1);
 
-        $this->assertInstanceOf('rcube_addresses', $object, 'Class constructor');
-        $this->assertInstanceOf('rcube_addressbook', $object, 'Class constructor');
+        self::assertInstanceOf('rcube_addresses', $object, 'Class constructor');
+        self::assertInstanceOf('rcube_addressbook', $object, 'Class constructor');
     }
 }

--- a/tests/Framework/BaseReplacerTest.php
+++ b/tests/Framework/BaseReplacerTest.php
@@ -14,7 +14,7 @@ class Framework_BaseReplacer extends TestCase
     {
         $object = new rcube_base_replacer('test');
 
-        $this->assertInstanceOf('rcube_base_replacer', $object, 'Class constructor');
+        self::assertInstanceOf('rcube_base_replacer', $object, 'Class constructor');
     }
 
     /**
@@ -28,7 +28,7 @@ class Framework_BaseReplacer extends TestCase
         $replacer = new rcube_base_replacer($base);
         $response = $replacer->replace($html);
 
-        $this->assertSame('<A href="http://shouldbethislink.com">Test URL</A>', $response);
+        self::assertSame('<A href="http://shouldbethislink.com">Test URL</A>', $response);
     }
 
     /**
@@ -57,6 +57,6 @@ class Framework_BaseReplacer extends TestCase
         $replacer = new rcube_base_replacer('test');
         $result = $replacer->absolute_url($path, $base);
 
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 }

--- a/tests/Framework/BootstrapTest.php
+++ b/tests/Framework/BootstrapTest.php
@@ -12,8 +12,8 @@ class Framework_Bootstrap extends TestCase
      */
     public function test_asciiwords()
     {
-        $this->assertSame('abc.123', asciiwords('abc%.123', false));
-        $this->assertSame('abc-123', asciiwords('abc%.123', true, '-'));
+        self::assertSame('abc.123', asciiwords('abc%.123', false));
+        self::assertSame('abc-123', asciiwords('abc%.123', true, '-'));
     }
 
     /**
@@ -25,11 +25,11 @@ class Framework_Bootstrap extends TestCase
         $needle = 'test';
         $result = in_array_nocase($needle, $haystack);
 
-        $this->assertTrue($result, 'Invalid in_array_nocase() result (Array)');
+        self::assertTrue($result, 'Invalid in_array_nocase() result (Array)');
 
         $result = in_array_nocase($needle, null);
 
-        $this->assertFalse($result, 'Invalid in_array_nocase() result (null)');
+        self::assertFalse($result, 'Invalid in_array_nocase() result (null)');
     }
 
     /**
@@ -67,12 +67,12 @@ class Framework_Bootstrap extends TestCase
 
         foreach ($data as $value => $expected) {
             $result = parse_bytes($value);
-            $this->assertSame($expected, $result, "Invalid parse_bytes() result for {$value}");
+            self::assertSame($expected, $result, "Invalid parse_bytes() result for {$value}");
         }
 
-        $this->assertFalse(parse_bytes(null));
-        $this->assertSame(0, parse_bytes(0));
-        $this->assertSame(10, parse_bytes(10.1));
+        self::assertFalse(parse_bytes(null));
+        self::assertSame(0, parse_bytes(0));
+        self::assertSame(10, parse_bytes(10.1));
     }
 
     /**
@@ -89,7 +89,7 @@ class Framework_Bootstrap extends TestCase
 
         foreach ($data as $value => $expected) {
             $result = slashify($value);
-            $this->assertSame($expected, $result, "Invalid slashify() result for {$value}");
+            self::assertSame($expected, $result, "Invalid slashify() result for {$value}");
         }
     }
 
@@ -110,7 +110,7 @@ class Framework_Bootstrap extends TestCase
 
         foreach ($data as $value => $expected) {
             $result = unslashify($value);
-            $this->assertSame($expected, $result, "Invalid unslashify() result for {$value}");
+            self::assertSame($expected, $result, "Invalid unslashify() result for {$value}");
         }
     }
 
@@ -131,7 +131,7 @@ class Framework_Bootstrap extends TestCase
 
         foreach ($data as $value => $expected) {
             $result = get_offset_sec($value);
-            $this->assertSame($expected, $result, "Invalid get_offset_sec() result for {$value}");
+            self::assertSame($expected, $result, "Invalid get_offset_sec() result for {$value}");
         }
     }
 
@@ -154,7 +154,7 @@ class Framework_Bootstrap extends TestCase
         $input_str = 'one,two,three,four,five';
         $result_str = implode(',', $result);
 
-        $this->assertSame($input_str, $result_str, 'Invalid array_keys_recursive() result');
+        self::assertSame($input_str, $result_str, 'Invalid array_keys_recursive() result');
     }
 
     /**
@@ -162,14 +162,14 @@ class Framework_Bootstrap extends TestCase
      */
     public function test_array_first()
     {
-        $this->assertNull(array_first([]));
-        $this->assertNull(array_first(false));
-        $this->assertNull(array_first('test'));
-        $this->assertSame('test', array_first(['test']));
+        self::assertNull(array_first([]));
+        self::assertNull(array_first(false));
+        self::assertNull(array_first('test'));
+        self::assertSame('test', array_first(['test']));
 
         $input = ['test1', 'test2'];
         next($input);
-        $this->assertSame('test1', array_first($input));
+        self::assertSame('test1', array_first($input));
     }
 
     /**
@@ -187,7 +187,7 @@ class Framework_Bootstrap extends TestCase
 
         foreach ($data as $set) {
             $result = abbreviate_string($set[1], $set[2], $set[3], $set[4]);
-            $this->assertSame($set[0], $result);
+            self::assertSame($set[0], $result);
         }
     }
 
@@ -206,7 +206,7 @@ class Framework_Bootstrap extends TestCase
 
         foreach ($data as $value => $expected) {
             $result = format_email($value);
-            $this->assertSame($expected, $result, "Invalid format_email() result for {$value}");
+            self::assertSame($expected, $result, "Invalid format_email() result for {$value}");
         }
     }
 
@@ -227,7 +227,7 @@ class Framework_Bootstrap extends TestCase
 
         foreach ($data as $expected => $value) {
             $result = format_email_recipient($value[0], $value[1] ?? null);
-            $this->assertSame($expected, $result, 'Invalid format_email_recipient()');
+            self::assertSame($expected, $result, 'Invalid format_email_recipient()');
         }
     }
 
@@ -237,26 +237,26 @@ class Framework_Bootstrap extends TestCase
     public function test_is_ascii()
     {
         $result = is_ascii('0123456789');
-        $this->assertTrue($result, 'Valid ASCII (numbers)');
+        self::assertTrue($result, 'Valid ASCII (numbers)');
 
         $result = is_ascii('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz');
-        $this->assertTrue($result, 'Valid ASCII (letters)');
+        self::assertTrue($result, 'Valid ASCII (letters)');
 
         $result = is_ascii(" !\"#\$%&'()*+,-./:;<=>?@[\\^_`{|}~");
-        $this->assertTrue($result, 'Valid ASCII (special characters)');
+        self::assertTrue($result, 'Valid ASCII (special characters)');
 
         $result = is_ascii("\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F"
             . "\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1A\x1B\x1C\x1D\x1E\x1F");
-        $this->assertTrue($result, 'Valid ASCII (control characters)');
+        self::assertTrue($result, 'Valid ASCII (control characters)');
 
         $result = is_ascii("\n", false);
-        $this->assertFalse($result, 'Valid ASCII (control characters)');
+        self::assertFalse($result, 'Valid ASCII (control characters)');
 
         $result = is_ascii('ż');
-        $this->assertFalse($result, 'Invalid ASCII (UTF-8 character)');
+        self::assertFalse($result, 'Invalid ASCII (UTF-8 character)');
 
         $result = is_ascii('ż', false);
-        $this->assertFalse($result, 'Invalid ASCII (UTF-8 character [2])');
+        self::assertFalse($result, 'Invalid ASCII (UTF-8 character [2])');
     }
 
     /**
@@ -264,7 +264,7 @@ class Framework_Bootstrap extends TestCase
      */
     public function test_version_parse()
     {
-        $this->assertSame('0.9.0', version_parse('0.9-stable'));
-        $this->assertSame('0.9.99', version_parse('0.9-git'));
+        self::assertSame('0.9.0', version_parse('0.9-stable'));
+        self::assertSame('0.9.99', version_parse('0.9-git'));
     }
 }

--- a/tests/Framework/BrowserTest.php
+++ b/tests/Framework/BrowserTest.php
@@ -14,12 +14,12 @@ class Framework_Browser extends TestCase
     {
         $object = $this->getBrowser($useragent);
 
-        $this->assertSame($opera, $object->opera, 'Check for Opera failed');
-        $this->assertSame($chrome, $object->chrome, 'Check for Chrome failed');
-        $this->assertSame($ie, $object->ie, 'Check for IE failed');
-        $this->assertSame($edge, $object->edge, 'Check for Edge failed');
-        $this->assertSame($safari, $object->safari, 'Check for Safari failed');
-        $this->assertSame($mz, $object->mz, 'Check for MZ failed');
+        self::assertSame($opera, $object->opera, 'Check for Opera failed');
+        self::assertSame($chrome, $object->chrome, 'Check for Chrome failed');
+        self::assertSame($ie, $object->ie, 'Check for IE failed');
+        self::assertSame($edge, $object->edge, 'Check for Edge failed');
+        self::assertSame($safari, $object->safari, 'Check for Safari failed');
+        self::assertSame($mz, $object->mz, 'Check for MZ failed');
     }
 
     /**
@@ -29,10 +29,10 @@ class Framework_Browser extends TestCase
     {
         $object = $this->getBrowser($useragent);
 
-        $this->assertSame($windows, $object->win, 'Check Result of Windows');
-        $this->assertSame($linux, $object->linux, 'Check Result of Linux');
-        $this->assertSame($mac, $object->mac, 'Check Result of Mac');
-        $this->assertSame($unix, $object->unix, 'Check Result of Unix');
+        self::assertSame($windows, $object->win, 'Check Result of Windows');
+        self::assertSame($linux, $object->linux, 'Check Result of Linux');
+        self::assertSame($mac, $object->mac, 'Check Result of Mac');
+        self::assertSame($unix, $object->unix, 'Check Result of Unix');
     }
 
     /**
@@ -41,7 +41,7 @@ class Framework_Browser extends TestCase
     public function test_version($useragent, $version)
     {
         $object = $this->getBrowser($useragent);
-        $this->assertSame($version, $object->ver);
+        self::assertSame($version, $object->ver);
     }
 
     public static function provide_version_cases(): iterable

--- a/tests/Framework/CacheDBTest.php
+++ b/tests/Framework/CacheDBTest.php
@@ -23,24 +23,24 @@ class Framework_CacheDB extends TestCase
 
         $cache->set('test', $data);
 
-        $this->assertSame($data, $cache->get('test'));
+        self::assertSame($data, $cache->get('test'));
 
         $cache->close();
 
         $cache = new rcube_cache_db(1, 'test', 60);
 
-        $this->assertSame($data, $cache->get('test'));
+        self::assertSame($data, $cache->get('test'));
 
         // Remove cached record
         $cache->remove('test');
 
-        $this->assertNull($cache->get('test'));
+        self::assertNull($cache->get('test'));
 
         $cache->close();
 
         $cache = new rcube_cache_db(1, 'test', 60);
 
-        $this->assertNull($cache->get('test'));
+        self::assertNull($cache->get('test'));
 
         // Call expunge methods
         $cache->expunge();

--- a/tests/Framework/CacheTest.php
+++ b/tests/Framework/CacheTest.php
@@ -14,8 +14,8 @@ class Framework_Cache extends TestCase
     {
         $object = rcube_cache::factory('db', 1);
 
-        $this->assertInstanceOf('rcube_cache_db', $object, 'Class constructor');
-        $this->assertInstanceOf('rcube_cache', $object, 'Class constructor');
+        self::assertInstanceOf('rcube_cache_db', $object, 'Class constructor');
+        self::assertInstanceOf('rcube_cache', $object, 'Class constructor');
     }
 
     /**
@@ -23,9 +23,9 @@ class Framework_Cache extends TestCase
      */
     public function test_key_name()
     {
-        $this->assertSame('test', rcube_cache::key_name('test'));
+        self::assertSame('test', rcube_cache::key_name('test'));
 
         $params = ['test1' => 'test2'];
-        $this->assertSame('test.ad0234829205b9033196ba818f7a872b', rcube_cache::key_name('test', $params));
+        self::assertSame('test.ad0234829205b9033196ba818f7a872b', rcube_cache::key_name('test', $params));
     }
 }

--- a/tests/Framework/CharsetTest.php
+++ b/tests/Framework/CharsetTest.php
@@ -30,7 +30,7 @@ class Framework_Charset extends TestCase
      */
     public function test_clean($input, $output)
     {
-        $this->assertSame($output, rcube_charset::clean($input));
+        self::assertSame($output, rcube_charset::clean($input));
     }
 
     /**
@@ -59,7 +59,7 @@ class Framework_Charset extends TestCase
      */
     public function test_is_valid($input, $result)
     {
-        $this->assertSame($result, rcube_charset::is_valid($input));
+        self::assertSame($result, rcube_charset::is_valid($input));
     }
 
     /**
@@ -78,7 +78,7 @@ class Framework_Charset extends TestCase
      */
     public function test_parse_charset($input, $output)
     {
-        $this->assertSame($output, rcube_charset::parse_charset($input));
+        self::assertSame($output, rcube_charset::parse_charset($input));
     }
 
     /**
@@ -114,7 +114,7 @@ class Framework_Charset extends TestCase
      */
     public function test_convert($input, $output, $from, $to)
     {
-        $this->assertSame($output, rcube_charset::convert($input, $from, $to));
+        self::assertSame($output, rcube_charset::convert($input, $from, $to));
     }
 
     /**
@@ -133,7 +133,7 @@ class Framework_Charset extends TestCase
     public function test_utf7_to_utf8($input, $output)
     {
         // @phpstan-ignore-next-line
-        $this->assertSame($output, rcube_charset::utf7_to_utf8($input));
+        self::assertSame($output, rcube_charset::utf7_to_utf8($input));
     }
 
     /**
@@ -152,7 +152,7 @@ class Framework_Charset extends TestCase
     public function test_utf7imap_to_utf8($input, $output)
     {
         // @phpstan-ignore-next-line
-        $this->assertSame($output, rcube_charset::utf7imap_to_utf8($input));
+        self::assertSame($output, rcube_charset::utf7imap_to_utf8($input));
     }
 
     /**
@@ -171,7 +171,7 @@ class Framework_Charset extends TestCase
     public function test_utf8_to_utf7imap($input, $output)
     {
         // @phpstan-ignore-next-line
-        $this->assertSame($output, rcube_charset::utf8_to_utf7imap($input));
+        self::assertSame($output, rcube_charset::utf8_to_utf7imap($input));
     }
 
     /**
@@ -190,7 +190,7 @@ class Framework_Charset extends TestCase
     public function test_utf16_to_utf8($input, $output)
     {
         // @phpstan-ignore-next-line
-        $this->assertSame($output, rcube_charset::utf16_to_utf8($input));
+        self::assertSame($output, rcube_charset::utf16_to_utf8($input));
     }
 
     /**
@@ -210,7 +210,7 @@ class Framework_Charset extends TestCase
     public function test_detect($input, $fallback, $output)
     {
         // @phpstan-ignore-next-line
-        $this->assertSame($output, rcube_charset::detect($input, $fallback));
+        self::assertSame($output, rcube_charset::detect($input, $fallback));
     }
 
     /**
@@ -229,6 +229,6 @@ class Framework_Charset extends TestCase
     public function test_detect_with_lang($input, $lang, $output)
     {
         // @phpstan-ignore-next-line
-        $this->assertSame($output, rcube_charset::detect($input, $output, $lang));
+        self::assertSame($output, rcube_charset::detect($input, $output, $lang));
     }
 }

--- a/tests/Framework/ConfigTest.php
+++ b/tests/Framework/ConfigTest.php
@@ -14,7 +14,7 @@ class Framework_Config extends TestCase
     {
         $object = new rcube_config();
 
-        $this->assertInstanceOf('rcube_config', $object, 'Class constructor');
+        self::assertInstanceOf('rcube_config', $object, 'Class constructor');
     }
 
     /**
@@ -22,8 +22,8 @@ class Framework_Config extends TestCase
      */
     public function test_resolve_timezone_alias()
     {
-        $this->assertSame('UTC', rcube_config::resolve_timezone_alias('Etc/GMT'));
-        $this->assertSame('UTC', rcube_config::resolve_timezone_alias('Etc/Zulu'));
+        self::assertSame('UTC', rcube_config::resolve_timezone_alias('Etc/GMT'));
+        self::assertSame('UTC', rcube_config::resolve_timezone_alias('Etc/Zulu'));
     }
 
     /**
@@ -33,16 +33,16 @@ class Framework_Config extends TestCase
     {
         $object = new rcube_config();
 
-        $this->assertNull($object->get('test'));
-        $this->assertSame('def', $object->get('test', 'def'));
+        self::assertNull($object->get('test'));
+        self::assertSame('def', $object->get('test', 'def'));
 
         $object->set('test', 'val');
 
-        $this->assertSame('val', $object->get('test'));
+        self::assertSame('val', $object->get('test'));
 
         putenv('ROUNDCUBE_TEST_INT=4190');
 
-        $this->assertSame(4190, $object->get('test_int'));
+        self::assertSame(4190, $object->get('test_int'));
 
         // TODO: test more code paths in get() and set()
     }
@@ -54,25 +54,25 @@ class Framework_Config extends TestCase
     {
         $object = new rcube_config();
 
-        $this->assertSame('bool', invokeMethod($object, 'guess_type', ['true']));
-        $this->assertSame('bool', invokeMethod($object, 'guess_type', ['false']));
-        $this->assertSame('bool', invokeMethod($object, 'guess_type', ['t']));
-        $this->assertSame('bool', invokeMethod($object, 'guess_type', ['f']));
-        $this->assertSame('bool', invokeMethod($object, 'guess_type', ['TRUE']));
-        $this->assertSame('bool', invokeMethod($object, 'guess_type', ['FALSE']));
-        $this->assertSame('bool', invokeMethod($object, 'guess_type', ['T']));
-        $this->assertSame('bool', invokeMethod($object, 'guess_type', ['F']));
+        self::assertSame('bool', invokeMethod($object, 'guess_type', ['true']));
+        self::assertSame('bool', invokeMethod($object, 'guess_type', ['false']));
+        self::assertSame('bool', invokeMethod($object, 'guess_type', ['t']));
+        self::assertSame('bool', invokeMethod($object, 'guess_type', ['f']));
+        self::assertSame('bool', invokeMethod($object, 'guess_type', ['TRUE']));
+        self::assertSame('bool', invokeMethod($object, 'guess_type', ['FALSE']));
+        self::assertSame('bool', invokeMethod($object, 'guess_type', ['T']));
+        self::assertSame('bool', invokeMethod($object, 'guess_type', ['F']));
 
-        $this->assertSame('float', invokeMethod($object, 'guess_type', ['1.5']));
-        $this->assertSame('float', invokeMethod($object, 'guess_type', ['1.0']));
-        $this->assertSame('float', invokeMethod($object, 'guess_type', ['1.2e3']));
-        $this->assertSame('float', invokeMethod($object, 'guess_type', ['7E-10']));
+        self::assertSame('float', invokeMethod($object, 'guess_type', ['1.5']));
+        self::assertSame('float', invokeMethod($object, 'guess_type', ['1.0']));
+        self::assertSame('float', invokeMethod($object, 'guess_type', ['1.2e3']));
+        self::assertSame('float', invokeMethod($object, 'guess_type', ['7E-10']));
 
-        $this->assertSame('int', invokeMethod($object, 'guess_type', ['1']));
-        $this->assertSame('int', invokeMethod($object, 'guess_type', ['123456789']));
+        self::assertSame('int', invokeMethod($object, 'guess_type', ['1']));
+        self::assertSame('int', invokeMethod($object, 'guess_type', ['123456789']));
 
-        $this->assertSame('string', invokeMethod($object, 'guess_type', ['ON']));
-        $this->assertSame('string', invokeMethod($object, 'guess_type', ['1-0']));
+        self::assertSame('string', invokeMethod($object, 'guess_type', ['ON']));
+        self::assertSame('string', invokeMethod($object, 'guess_type', ['1-0']));
     }
 
     /**
@@ -82,14 +82,14 @@ class Framework_Config extends TestCase
     {
         $object = new rcube_config();
 
-        $this->assertTrue(invokeMethod($object, 'parse_env', ['true']));
-        $this->assertSame(1, invokeMethod($object, 'parse_env', ['1']));
-        $this->assertSame(1.5, invokeMethod($object, 'parse_env', ['1.5']));
-        $this->assertTrue(invokeMethod($object, 'parse_env', ['1', 'bool']));
-        $this->assertSame(1.0, invokeMethod($object, 'parse_env', ['1', 'float']));
-        $this->assertSame(1, invokeMethod($object, 'parse_env', ['1', 'int']));
-        $this->assertSame('1', invokeMethod($object, 'parse_env', ['1', 'string']));
-        $this->assertSame([1], invokeMethod($object, 'parse_env', ['[1]', 'array']));
-        $this->assertSame(['test' => 1], (array) invokeMethod($object, 'parse_env', ['{"test":1}', 'object']));
+        self::assertTrue(invokeMethod($object, 'parse_env', ['true']));
+        self::assertSame(1, invokeMethod($object, 'parse_env', ['1']));
+        self::assertSame(1.5, invokeMethod($object, 'parse_env', ['1.5']));
+        self::assertTrue(invokeMethod($object, 'parse_env', ['1', 'bool']));
+        self::assertSame(1.0, invokeMethod($object, 'parse_env', ['1', 'float']));
+        self::assertSame(1, invokeMethod($object, 'parse_env', ['1', 'int']));
+        self::assertSame('1', invokeMethod($object, 'parse_env', ['1', 'string']));
+        self::assertSame([1], invokeMethod($object, 'parse_env', ['[1]', 'array']));
+        self::assertSame(['test' => 1], (array) invokeMethod($object, 'parse_env', ['{"test":1}', 'object']));
     }
 }

--- a/tests/Framework/ContactsTest.php
+++ b/tests/Framework/ContactsTest.php
@@ -14,7 +14,7 @@ class Framework_Contacts extends TestCase
     {
         $object = new rcube_contacts(rcube::get_instance()->get_dbh(), null);
 
-        $this->assertInstanceOf('rcube_contacts', $object, 'Class constructor');
+        self::assertInstanceOf('rcube_contacts', $object, 'Class constructor');
     }
 
     /**
@@ -25,17 +25,17 @@ class Framework_Contacts extends TestCase
         $contacts = new rcube_contacts(rcube::get_instance()->get_dbh(), null);
 
         $data = [];
-        $this->assertFalse($contacts->validate($data));
-        $this->assertSame(['type' => 3, 'message' => 'nonamewarning'], $contacts->get_error());
+        self::assertFalse($contacts->validate($data));
+        self::assertSame(['type' => 3, 'message' => 'nonamewarning'], $contacts->get_error());
 
         $data = ['name' => 'test'];
-        $this->assertTrue($contacts->validate($data));
+        self::assertTrue($contacts->validate($data));
 
         $data = ['email' => '@example.org'];
-        $this->assertFalse($contacts->validate($data));
-        $this->assertSame(['type' => 3, 'message' => 'Invalid email address: @example.org'], $contacts->get_error());
+        self::assertFalse($contacts->validate($data));
+        self::assertSame(['type' => 3, 'message' => 'Invalid email address: @example.org'], $contacts->get_error());
 
         $data = ['email' => 'test@test.com'];
-        $this->assertTrue($contacts->validate($data));
+        self::assertTrue($contacts->validate($data));
     }
 }

--- a/tests/Framework/ContentFilterTest.php
+++ b/tests/Framework/ContentFilterTest.php
@@ -14,6 +14,6 @@ class Framework_ContentFilter extends TestCase
     {
         $object = new rcube_content_filter();
 
-        $this->assertInstanceOf('rcube_content_filter', $object, 'Class constructor');
+        self::assertInstanceOf('rcube_content_filter', $object, 'Class constructor');
     }
 }

--- a/tests/Framework/Csv2vcardTest.php
+++ b/tests/Framework/Csv2vcardTest.php
@@ -13,7 +13,7 @@ class Framework_Csv2vcard extends TestCase
 
         // empty input
         $csv->import('');
-        $this->assertSame([], $csv->export());
+        self::assertSame([], $csv->export());
     }
 
     public function test_localization_files()
@@ -21,7 +21,7 @@ class Framework_Csv2vcard extends TestCase
         foreach (glob(RCUBE_LOCALIZATION_DIR . '*/csv2vcard.inc') as $filename) {
             $map = null;
             require $filename;
-            $this->assertTrue(count($map) > 0);
+            self::assertTrue(count($map) > 0);
         }
     }
 
@@ -34,13 +34,13 @@ class Framework_Csv2vcard extends TestCase
         $csv->import($csv_text);
         $result = $csv->export();
 
-        $this->assertCount(1, $result);
+        self::assertCount(1, $result);
 
         $vcard = $result[0]->export(false);
         $vcf_text = trim(str_replace("\r\n", "\n", $vcf_text));
         $vcard = trim(str_replace("\r\n", "\n", $vcard));
 
-        $this->assertSame($vcf_text, $vcard);
+        self::assertSame($vcf_text, $vcard);
     }
 
     public function test_import_email()
@@ -52,7 +52,7 @@ class Framework_Csv2vcard extends TestCase
         $csv->import($csv_text);
         $result = $csv->export();
 
-        $this->assertCount(4, $result);
+        self::assertCount(4, $result);
 
         $vcard = '';
         foreach ($result as $vcf) {
@@ -61,7 +61,7 @@ class Framework_Csv2vcard extends TestCase
 
         $vcf_text = trim(str_replace("\r\n", "\n", $vcf_text));
         $vcard = trim(str_replace("\r\n", "\n", $vcard));
-        $this->assertSame($vcf_text, $vcard);
+        self::assertSame($vcf_text, $vcard);
     }
 
     public function test_import_gmail()
@@ -73,13 +73,13 @@ class Framework_Csv2vcard extends TestCase
         $csv->import($csv_text);
         $result = $csv->export();
 
-        $this->assertCount(1, $result);
+        self::assertCount(1, $result);
 
         $vcard = $result[0]->export(false);
         $vcf_text = trim(str_replace("\r\n", "\n", $vcf_text));
         $vcard = trim(str_replace("\r\n", "\n", $vcard));
 
-        $this->assertSame($vcf_text, $vcard);
+        self::assertSame($vcf_text, $vcard);
     }
 
     public function test_import_outlook()
@@ -91,12 +91,12 @@ class Framework_Csv2vcard extends TestCase
         $csv->import($csv_text);
         $result = $csv->export();
 
-        $this->assertCount(1, $result);
+        self::assertCount(1, $result);
 
         $vcard = $result[0]->export(false);
         $vcf_text = trim(str_replace("\r\n", "\n", $vcf_text));
         $vcard = trim(str_replace("\r\n", "\n", $vcard));
 
-        $this->assertSame($vcf_text, $vcard);
+        self::assertSame($vcf_text, $vcard);
     }
 }

--- a/tests/Framework/DBMysqlTest.php
+++ b/tests/Framework/DBMysqlTest.php
@@ -17,6 +17,6 @@ class Framework_DBMysql extends TestCase
     {
         $object = new rcube_db_mysql('test');
 
-        $this->assertInstanceOf('rcube_db_mysql', $object, 'Class constructor');
+        self::assertInstanceOf('rcube_db_mysql', $object, 'Class constructor');
     }
 }

--- a/tests/Framework/DBPgsqlTest.php
+++ b/tests/Framework/DBPgsqlTest.php
@@ -17,7 +17,7 @@ class Framework_DBPgsql extends TestCase
     {
         $object = new rcube_db_pgsql('test');
 
-        $this->assertInstanceOf('rcube_db_pgsql', $object, 'Class constructor');
+        self::assertInstanceOf('rcube_db_pgsql', $object, 'Class constructor');
     }
 
     /**
@@ -69,7 +69,7 @@ class Framework_DBPgsql extends TestCase
 
         foreach ($script as $idx => $query) {
             $res = $method->invoke($db, $query);
-            $this->assertSame($output[$idx], $res, "Test case {$idx}");
+            self::assertSame($output[$idx], $res, "Test case {$idx}");
         }
     }
 
@@ -82,14 +82,14 @@ class Framework_DBPgsql extends TestCase
 
         $dsn = $db->parse_dsn('pgsql://USERNAME:PASSWORD@HOST:5432/DATABASE');
         $result = invokeMethod($db, 'dsn_string', [$dsn]);
-        $this->assertSame('pgsql:host=HOST;port=5432;dbname=DATABASE', $result);
+        self::assertSame('pgsql:host=HOST;port=5432;dbname=DATABASE', $result);
 
         $dsn = $db->parse_dsn('pgsql:///DATABASE');
         $result = invokeMethod($db, 'dsn_string', [$dsn]);
-        $this->assertSame('pgsql:dbname=DATABASE', $result);
+        self::assertSame('pgsql:dbname=DATABASE', $result);
 
         $dsn = $db->parse_dsn('pgsql://user@unix(/var/run/postgresql)/roundcubemail?sslmode=verify-full');
         $result = invokeMethod($db, 'dsn_string', [$dsn]);
-        $this->assertSame('pgsql:host=/var/run/postgresql;dbname=roundcubemail;sslmode=verify-full', $result);
+        self::assertSame('pgsql:host=/var/run/postgresql;dbname=roundcubemail;sslmode=verify-full', $result);
     }
 }

--- a/tests/Framework/DBSqliteTest.php
+++ b/tests/Framework/DBSqliteTest.php
@@ -17,6 +17,6 @@ class Framework_DBSqlite extends TestCase
     {
         $object = new rcube_db_sqlite('test');
 
-        $this->assertInstanceOf('rcube_db_sqlite', $object, 'Class constructor');
+        self::assertInstanceOf('rcube_db_sqlite', $object, 'Class constructor');
     }
 }

--- a/tests/Framework/DBTest.php
+++ b/tests/Framework/DBTest.php
@@ -57,8 +57,8 @@ class Framework_DB extends TestCase
             $out[] = $q;
         }
 
-        $this->assertTrue($result, 'Execute SQL script (result)');
-        $this->assertSame(implode("\n", $out), $output, 'Execute SQL script (content)');
+        self::assertTrue($result, 'Execute SQL script (result)');
+        self::assertSame(implode("\n", $out), $output, 'Execute SQL script (content)');
     }
 
     /**
@@ -109,8 +109,8 @@ class Framework_DB extends TestCase
             $out[] = $q;
         }
 
-        $this->assertTrue($result, 'Execute SQL script (result)');
-        $this->assertSame(implode("\n", $out), $output, 'Execute SQL script (content)');
+        self::assertTrue($result, 'Execute SQL script (result)');
+        self::assertSame(implode("\n", $out), $output, 'Execute SQL script (content)');
     }
 
     /**
@@ -144,7 +144,7 @@ class Framework_DB extends TestCase
             "SELECT `test` WHERE `test` = '????'",
         ]);
 
-        $this->assertSame($expected, implode("\n", $db->queries), 'Query parsing [1]');
+        self::assertSame($expected, implode("\n", $db->queries), 'Query parsing [1]');
 
         $db->set_option('identifier_start', '"');
         $db->set_option('identifier_end', '"');
@@ -172,7 +172,7 @@ class Framework_DB extends TestCase
             "SELECT \"test\" WHERE \"test\" = '????'",
         ]);
 
-        $this->assertSame($expected, implode("\n", $db->queries), 'Query parsing [2]');
+        self::assertSame($expected, implode("\n", $db->queries), 'Query parsing [2]');
     }
 
     public function test_parse_dsn()
@@ -181,23 +181,23 @@ class Framework_DB extends TestCase
 
         $result = rcube_db::parse_dsn($dsn);
 
-        $this->assertSame('mysql', $result['phptype']);
-        $this->assertSame('USERNAME', $result['username']);
-        $this->assertSame('PASSWORD', $result['password']);
-        $this->assertSame('3306', $result['port']);
-        $this->assertSame('HOST', $result['hostspec']);
-        $this->assertSame('DATABASE', $result['database']);
+        self::assertSame('mysql', $result['phptype']);
+        self::assertSame('USERNAME', $result['username']);
+        self::assertSame('PASSWORD', $result['password']);
+        self::assertSame('3306', $result['port']);
+        self::assertSame('HOST', $result['hostspec']);
+        self::assertSame('DATABASE', $result['database']);
 
         $dsn = 'pgsql:///DATABASE';
 
         $result = rcube_db::parse_dsn($dsn);
 
-        $this->assertSame('pgsql', $result['phptype']);
-        $this->assertTrue(!array_key_exists('username', $result));
-        $this->assertTrue(!array_key_exists('password', $result));
-        $this->assertTrue(!array_key_exists('port', $result));
-        $this->assertTrue(!array_key_exists('hostspec', $result));
-        $this->assertSame('DATABASE', $result['database']);
+        self::assertSame('pgsql', $result['phptype']);
+        self::assertTrue(!array_key_exists('username', $result));
+        self::assertTrue(!array_key_exists('password', $result));
+        self::assertTrue(!array_key_exists('port', $result));
+        self::assertTrue(!array_key_exists('hostspec', $result));
+        self::assertSame('DATABASE', $result['database']);
     }
 
     /**
@@ -209,7 +209,7 @@ class Framework_DB extends TestCase
 
         $tables = $db->list_tables();
 
-        $this->assertContains('users', $tables);
+        self::assertContains('users', $tables);
     }
 
     /**
@@ -221,7 +221,7 @@ class Framework_DB extends TestCase
 
         $columns = $db->list_cols('cache');
 
-        $this->assertSame(['user_id', 'cache_key', 'expires', 'data'], $columns);
+        self::assertSame(['user_id', 'cache_key', 'expires', 'data'], $columns);
     }
 
     /**
@@ -231,10 +231,10 @@ class Framework_DB extends TestCase
     {
         $db = rcube::get_instance()->get_dbh();
 
-        $this->assertSame('', $db->array2list([]));
-        $this->assertSame('\'test\'', $db->array2list(['test']));
-        $this->assertSame('\'test\'\'test\'', $db->array2list(['test\'test']));
-        $this->assertSame('\'test\'', $db->array2list('test'));
+        self::assertSame('', $db->array2list([]));
+        self::assertSame('\'test\'', $db->array2list(['test']));
+        self::assertSame('\'test\'\'test\'', $db->array2list(['test\'test']));
+        self::assertSame('\'test\'', $db->array2list('test'));
     }
 
     /**
@@ -244,10 +244,10 @@ class Framework_DB extends TestCase
     {
         $db = rcube::get_instance()->get_dbh();
 
-        $this->assertSame('(test)', $db->concat('test'));
-        $this->assertSame('(test1 || test2)', $db->concat('test1', 'test2'));
-        $this->assertSame('(test)', $db->concat(['test']));
-        $this->assertSame('(test1 || test2)', $db->concat(['test1', 'test2']));
+        self::assertSame('(test)', $db->concat('test'));
+        self::assertSame('(test1 || test2)', $db->concat('test1', 'test2'));
+        self::assertSame('(test)', $db->concat(['test']));
+        self::assertSame('(test1 || test2)', $db->concat(['test1', 'test2']));
     }
 
     /**
@@ -260,13 +260,13 @@ class Framework_DB extends TestCase
             $str .= chr($x);
         }
 
-        $this->assertSame($str, rcube_db::decode(rcube_db::encode($str)));
-        $this->assertSame($str, rcube_db::decode(rcube_db::encode($str, true), true));
+        self::assertSame($str, rcube_db::decode(rcube_db::encode($str)));
+        self::assertSame($str, rcube_db::decode(rcube_db::encode($str, true), true));
 
         $str = 'グーグル谷歌中信фδοκιμήóźdźрöß😁😃';
 
-        $this->assertSame($str, rcube_db::decode(rcube_db::encode($str)));
-        $this->assertSame($str, rcube_db::decode(rcube_db::encode($str, true), true));
+        self::assertSame($str, rcube_db::decode(rcube_db::encode($str)));
+        self::assertSame($str, rcube_db::decode(rcube_db::encode($str, true), true));
     }
 }
 

--- a/tests/Framework/EnrichedTest.php
+++ b/tests/Framework/EnrichedTest.php
@@ -14,7 +14,7 @@ class Framework_Enriched extends TestCase
     {
         $object = new rcube_enriched();
 
-        $this->assertInstanceOf('rcube_enriched', $object, 'Class constructor');
+        self::assertInstanceOf('rcube_enriched', $object, 'Class constructor');
     }
 
     /**
@@ -26,7 +26,7 @@ class Framework_Enriched extends TestCase
         $expected = '<b><i>the-text</i></b>';
         $result = rcube_enriched::to_html($enriched);
 
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     /**
@@ -69,6 +69,6 @@ class Framework_Enriched extends TestCase
     {
         $result = rcube_enriched::to_html($enriched);
 
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 }

--- a/tests/Framework/Html2textTest.php
+++ b/tests/Framework/Html2textTest.php
@@ -102,7 +102,7 @@ class rc_html2text extends TestCase
         $ht->set_html($in);
         $res = $ht->get_text();
 
-        $this->assertSame($out, $res, $title);
+        self::assertSame($out, $res, $title);
     }
 
     /**
@@ -119,9 +119,9 @@ class rc_html2text extends TestCase
         $ht = new rcube_html2text($html, false, rcube_html2text::LINKS_NONE);
         $res = $ht->get_text();
 
-        $this->assertStringContainsString('>> INNER 1', $res, 'Quote inner');
-        $this->assertStringContainsString('>> INNER 3', $res, 'Quote inner');
-        $this->assertStringContainsString('> OUTER END', $res, 'Quote outer');
+        self::assertStringContainsString('>> INNER 1', $res, 'Quote inner');
+        self::assertStringContainsString('>> INNER 3', $res, 'Quote inner');
+        self::assertStringContainsString('> OUTER END', $res, 'Quote outer');
     }
 
     public function test_broken_blockquotes()
@@ -136,7 +136,7 @@ class rc_html2text extends TestCase
         $ht = new rcube_html2text($html, false, rcube_html2text::LINKS_NONE);
         $res = $ht->get_text();
 
-        $this->assertStringContainsString('QUOTED TEXT NO END TAG FOUND', $res, 'No quoting on invalid html');
+        self::assertStringContainsString('QUOTED TEXT NO END TAG FOUND', $res, 'No quoting on invalid html');
 
         // with some (nested) end tags
         $html = <<<'EOF'
@@ -149,7 +149,7 @@ class rc_html2text extends TestCase
         $ht = new rcube_html2text($html, false, rcube_html2text::LINKS_NONE);
         $res = $ht->get_text();
 
-        $this->assertStringContainsString('QUOTED TEXT INNER 1 INNER 2 NO END', $res, 'No quoting on invalid html');
+        self::assertStringContainsString('QUOTED TEXT INNER 1 INNER 2 NO END', $res, 'No quoting on invalid html');
     }
 
     /**
@@ -168,7 +168,7 @@ Links:
         $ht = new rcube_html2text($html, false, rcube_html2text::LINKS_END);
         $res = $ht->get_text();
 
-        $this->assertSame($expected, $res, 'Links list');
+        self::assertSame($expected, $res, 'Links list');
 
         // href == content (#1490434)
         $html = '<a href="http://test.com">http://test.com</a>';
@@ -177,7 +177,7 @@ Links:
         $ht = new rcube_html2text($html, false, rcube_html2text::LINKS_END);
         $res = $ht->get_text();
 
-        $this->assertSame($expected, $res, 'Skip link with href == content');
+        self::assertSame($expected, $res, 'Skip link with href == content');
 
         // HTML entities in links
         $html = '<a href="http://test.com?test1&amp;test2">test3&amp;test4</a>';
@@ -191,7 +191,7 @@ Links:
         $ht = new rcube_html2text($html, false, rcube_html2text::LINKS_END);
         $res = $ht->get_text();
 
-        $this->assertSame($expected, $res, 'Links with HTML entities');
+        self::assertSame($expected, $res, 'Links with HTML entities');
     }
 
     /**
@@ -210,7 +210,7 @@ Links:
         $ht = new rcube_html2text($html, false, true);
         $res = $ht->get_text();
 
-        $this->assertSame($expected, $res, 'Links list');
+        self::assertSame($expected, $res, 'Links list');
 
         // href == content (#1490434)
         $html = '<a href="http://test.com">http://test.com</a>';
@@ -219,7 +219,7 @@ Links:
         $ht = new rcube_html2text($html, false, true);
         $res = $ht->get_text();
 
-        $this->assertSame($expected, $res, 'Skip link with href == content');
+        self::assertSame($expected, $res, 'Skip link with href == content');
     }
 
     /**
@@ -233,7 +233,7 @@ Links:
         $ht = new rcube_html2text($html, false, rcube_html2text::LINKS_INLINE);
         $res = $ht->get_text();
 
-        $this->assertSame($expected, $res, 'Links Inline');
+        self::assertSame($expected, $res, 'Links Inline');
 
         // href == content (#1490434)
         $html = '<a href="http://test.com">http://test.com</a>';
@@ -242,7 +242,7 @@ Links:
         $ht = new rcube_html2text($html, false, rcube_html2text::LINKS_INLINE);
         $res = $ht->get_text();
 
-        $this->assertSame($expected, $res, 'Skip link with href == content');
+        self::assertSame($expected, $res, 'Skip link with href == content');
     }
 
     /**
@@ -255,7 +255,7 @@ Links:
         $h2t = new rcube_html2text($input, false, rcube_html2text::LINKS_NONE);
         $res = $h2t->get_text();
 
-        $this->assertSame($output, $res, 'Links handling');
+        self::assertSame($output, $res, 'Links handling');
     }
 
     /**
@@ -268,7 +268,7 @@ Links:
         $h2t = new rcube_html2text($input, false, false);
         $res = $h2t->get_text();
 
-        $this->assertSame($output, $res, 'Links handling');
+        self::assertSame($output, $res, 'Links handling');
     }
 
     public static function provide_links_no_list_cases(): iterable
@@ -309,17 +309,17 @@ Links:
         $ht = new rcube_html2text($html, false);
         $res = $ht->get_text();
 
-        $this->assertSame($expected, $res, 'Links list as default (doLinks not set)');
+        self::assertSame($expected, $res, 'Links list as default (doLinks not set)');
 
         $ht = new rcube_html2text($html, false, mt_rand(3, 9999));
         $res = $ht->get_text();
 
-        $this->assertSame($expected, $res, 'Links list as default (doLinks greater than 3)');
+        self::assertSame($expected, $res, 'Links list as default (doLinks greater than 3)');
 
         $ht = new rcube_html2text($html, false, mt_rand(-9999, -1));
         $res = $ht->get_text();
 
-        $this->assertSame($expected, $res, 'Links list as default (doLinks lower than 0)');
+        self::assertSame($expected, $res, 'Links list as default (doLinks lower than 0)');
     }
 
     /**
@@ -334,6 +334,6 @@ Links:
         $h2t = new rcube_html2text($input, false, rcube_html2text::LINKS_NONE);
         $res = $h2t->get_text();
 
-        $this->assertSame("test1\n\ntest2\n\ntest3", $res, 'Huge input');
+        self::assertSame("test1\n\ntest2\n\ntest3", $res, 'Huge input');
     }
 }

--- a/tests/Framework/HtmlCheckboxTest.php
+++ b/tests/Framework/HtmlCheckboxTest.php
@@ -14,12 +14,12 @@ class Framework_HtmlCheckbox extends TestCase
     {
         $input = new html_checkbox(['value' => 1]);
 
-        $this->assertSame('<input value="1" type="checkbox">', $input->show(0));
-        $this->assertSame('<input value="1" type="checkbox">', $input->show('0'));
-        $this->assertSame('<input value="1" checked="checked" type="checkbox">', $input->show(1));
-        $this->assertSame('<input value="1" checked="checked" type="checkbox">', $input->show('1'));
-        $this->assertSame('<input value="1" checked="checked" type="checkbox">', $input->show(true));
+        self::assertSame('<input value="1" type="checkbox">', $input->show(0));
+        self::assertSame('<input value="1" type="checkbox">', $input->show('0'));
+        self::assertSame('<input value="1" checked="checked" type="checkbox">', $input->show(1));
+        self::assertSame('<input value="1" checked="checked" type="checkbox">', $input->show('1'));
+        self::assertSame('<input value="1" checked="checked" type="checkbox">', $input->show(true));
         // test that the checked state does not "leak"
-        $this->assertSame('<input value="1" type="checkbox">', $input->show(0));
+        self::assertSame('<input value="1" type="checkbox">', $input->show(0));
     }
 }

--- a/tests/Framework/HtmlTest.php
+++ b/tests/Framework/HtmlTest.php
@@ -14,7 +14,7 @@ class Framework_Html extends TestCase
     {
         $object = new html();
 
-        $this->assertInstanceOf('html', $object, 'Class constructor');
+        self::assertInstanceOf('html', $object, 'Class constructor');
     }
 
     /**
@@ -63,7 +63,7 @@ class Framework_Html extends TestCase
      */
     public function test_attrib_string($arg1, $arg2, $expected)
     {
-        $this->assertSame($expected, html::attrib_string($arg1, $arg2));
+        self::assertSame($expected, html::attrib_string($arg1, $arg2));
     }
 
     /**
@@ -89,7 +89,7 @@ class Framework_Html extends TestCase
      */
     public function test_quote($str, $expected)
     {
-        $this->assertSame($expected, html::quote($str));
+        self::assertSame($expected, html::quote($str));
     }
 
     /**
@@ -132,6 +132,6 @@ class Framework_Html extends TestCase
      */
     public function test_parse_attrib_string($arg1, $expected)
     {
-        $this->assertSame($expected, html::parse_attrib_string($arg1));
+        self::assertSame($expected, html::parse_attrib_string($arg1));
     }
 }

--- a/tests/Framework/ImageTest.php
+++ b/tests/Framework/ImageTest.php
@@ -15,14 +15,14 @@ class Framework_Image extends TestCase
         $object = new rcube_image(INSTALL_PATH . 'skins/elastic/thumbnail.png');
 
         if (!function_exists('getimagesize')) {
-            $this->markTestSkipped();
+            self::markTestSkipped();
         }
 
         $props = $object->props();
 
-        $this->assertSame('png', $props['type']);
-        $this->assertSame(64, $props['width']);
-        $this->assertSame(64, $props['height']);
+        self::assertSame('png', $props['type']);
+        self::assertSame(64, $props['width']);
+        self::assertSame(64, $props['height']);
     }
 
     /**
@@ -33,21 +33,21 @@ class Framework_Image extends TestCase
         $object = new rcube_image(INSTALL_PATH . 'skins/elastic/thumbnail.png');
 
         if (!function_exists('getimagesize')) {
-            $this->markTestSkipped();
+            self::markTestSkipped();
         }
 
         $file = rcube_utils::temp_filename('tests');
 
-        $this->assertSame('png', $object->resize(32, $file));
+        self::assertSame('png', $object->resize(32, $file));
 
         $object = new rcube_image($file);
         $props = $object->props();
 
         @unlink($file);
 
-        $this->assertSame('png', $props['type']);
-        $this->assertSame(32, $props['width']);
-        $this->assertSame(32, $props['height']);
+        self::assertSame('png', $props['type']);
+        self::assertSame(32, $props['width']);
+        self::assertSame(32, $props['height']);
     }
 
     /**
@@ -58,21 +58,21 @@ class Framework_Image extends TestCase
         $object = new rcube_image(INSTALL_PATH . 'skins/elastic/thumbnail.png');
 
         if (!function_exists('getimagesize')) {
-            $this->markTestSkipped();
+            self::markTestSkipped();
         }
 
         $file = rcube_utils::temp_filename('tests');
 
-        $this->assertTrue($object->convert(rcube_image::TYPE_JPG, $file));
+        self::assertTrue($object->convert(rcube_image::TYPE_JPG, $file));
 
         $object = new rcube_image($file);
         $props = $object->props();
 
         @unlink($file);
 
-        $this->assertSame('jpeg', $props['type']);
-        $this->assertSame(64, $props['width']);
-        $this->assertSame(64, $props['height']);
+        self::assertSame('jpeg', $props['type']);
+        self::assertSame(64, $props['width']);
+        self::assertSame(64, $props['height']);
     }
 
     /**
@@ -86,38 +86,38 @@ class Framework_Image extends TestCase
         $object = new rcube_image($file);
 
         if (class_exists('Imagick', false)) {
-            $this->assertTrue($object->is_convertable('image/gif'));
-            $this->assertFalse($object->is_convertable('xxx'));
+            self::assertTrue($object->is_convertable('image/gif'));
+            self::assertFalse($object->is_convertable('xxx'));
         } elseif (!function_exists('getimagesize')) {
-            $this->markTestSkipped();
+            self::markTestSkipped();
         }
 
         if (function_exists('imagecreatefromgif')) {
-            $this->assertTrue($object->is_convertable('image/gif'));
+            self::assertTrue($object->is_convertable('image/gif'));
         } else {
-            $this->assertFalse($object->is_convertable('image/gif'));
+            self::assertFalse($object->is_convertable('image/gif'));
         }
 
         if (function_exists('imagecreatefromjpeg')) {
-            $this->assertTrue($object->is_convertable('image/jpg'));
-            $this->assertTrue($object->is_convertable('image/jpeg'));
+            self::assertTrue($object->is_convertable('image/jpg'));
+            self::assertTrue($object->is_convertable('image/jpeg'));
         } else {
-            $this->assertFalse($object->is_convertable('image/jpg'));
-            $this->assertFalse($object->is_convertable('image/jpeg'));
+            self::assertFalse($object->is_convertable('image/jpg'));
+            self::assertFalse($object->is_convertable('image/jpeg'));
         }
 
         if (function_exists('imagecreatefrompng')) {
-            $this->assertTrue($object->is_convertable('image/png'));
+            self::assertTrue($object->is_convertable('image/png'));
         } else {
-            $this->assertFalse($object->is_convertable('image/png'));
+            self::assertFalse($object->is_convertable('image/png'));
         }
 
         if (function_exists('imagecreatefromwebp')) {
-            $this->assertTrue($object->is_convertable('image/webp'));
+            self::assertTrue($object->is_convertable('image/webp'));
         } else {
-            $this->assertFalse($object->is_convertable('image/webp'));
+            self::assertFalse($object->is_convertable('image/webp'));
         }
 
-        $this->assertFalse($object->is_convertable('xxx'));
+        self::assertFalse($object->is_convertable('xxx'));
     }
 }

--- a/tests/Framework/ImapCacheTest.php
+++ b/tests/Framework/ImapCacheTest.php
@@ -14,6 +14,6 @@ class Framework_ImapCache extends TestCase
     {
         $object = new rcube_imap_cache(new rcube_db('test'), null, null, null);
 
-        $this->assertInstanceOf('rcube_imap_cache', $object, 'Class constructor');
+        self::assertInstanceOf('rcube_imap_cache', $object, 'Class constructor');
     }
 }

--- a/tests/Framework/ImapGenericTest.php
+++ b/tests/Framework/ImapGenericTest.php
@@ -14,7 +14,7 @@ class Framework_ImapGeneric extends TestCase
     {
         $object = new rcube_imap_generic();
 
-        $this->assertInstanceOf('rcube_imap_generic', $object, 'Class constructor');
+        self::assertInstanceOf('rcube_imap_generic', $object, 'Class constructor');
     }
 
     /**
@@ -22,12 +22,12 @@ class Framework_ImapGeneric extends TestCase
      */
     public function test_escape()
     {
-        $this->assertSame('NIL', rcube_imap_generic::escape(null));
-        $this->assertSame('""', rcube_imap_generic::escape(''));
-        $this->assertSame('abc', rcube_imap_generic::escape('abc'));
-        $this->assertSame('"abc"', rcube_imap_generic::escape('abc', true));
-        $this->assertSame('"abc\"def"', rcube_imap_generic::escape('abc"def'));
-        $this->assertSame("{3}\r\na\nb", rcube_imap_generic::escape("a\nb"));
+        self::assertSame('NIL', rcube_imap_generic::escape(null));
+        self::assertSame('""', rcube_imap_generic::escape(''));
+        self::assertSame('abc', rcube_imap_generic::escape('abc'));
+        self::assertSame('"abc"', rcube_imap_generic::escape('abc', true));
+        self::assertSame('"abc\"def"', rcube_imap_generic::escape('abc"def'));
+        self::assertSame("{3}\r\na\nb", rcube_imap_generic::escape("a\nb"));
     }
 
     /**
@@ -48,18 +48,18 @@ class Framework_ImapGeneric extends TestCase
 
         $result = rcube_imap_generic::sortHeaders($headers, 'subject');
 
-        $this->assertSame('Test1', $result[0]->subject);
-        $this->assertSame('Re: Test2', $result[1]->subject);
+        self::assertSame('Test1', $result[0]->subject);
+        self::assertSame('Re: Test2', $result[1]->subject);
 
         $result = rcube_imap_generic::sortHeaders($headers, 'subject', 'DESC');
 
-        $this->assertSame('Re: Test2', $result[0]->subject);
-        $this->assertSame('Test1', $result[1]->subject);
+        self::assertSame('Re: Test2', $result[0]->subject);
+        self::assertSame('Test1', $result[1]->subject);
 
         $result = rcube_imap_generic::sortHeaders($headers, 'date', 'DESC');
 
-        $this->assertSame('Re: Test2', $result[0]->subject);
-        $this->assertSame('Test1', $result[1]->subject);
+        self::assertSame('Re: Test2', $result[0]->subject);
+        self::assertSame('Test1', $result[1]->subject);
     }
 
     /**
@@ -68,16 +68,16 @@ class Framework_ImapGeneric extends TestCase
     public function test_compressMessageSet()
     {
         $result = rcube_imap_generic::compressMessageSet([5, 4, 3]);
-        $this->assertSame('3:5', $result);
+        self::assertSame('3:5', $result);
 
         $result = rcube_imap_generic::compressMessageSet([5, 4, 3, 10, 12, 13]);
-        $this->assertSame('3:5,10,12:13', $result);
+        self::assertSame('3:5,10,12:13', $result);
 
         $result = rcube_imap_generic::compressMessageSet('1');
-        $this->assertSame('1', $result);
+        self::assertSame('1', $result);
 
         $result = rcube_imap_generic::compressMessageSet('-1');
-        $this->assertSame('INVALID', $result);
+        self::assertSame('INVALID', $result);
     }
 
     /**
@@ -86,16 +86,16 @@ class Framework_ImapGeneric extends TestCase
     public function test_uncompressMessageSet()
     {
         $result = rcube_imap_generic::uncompressMessageSet(null);
-        $this->assertSame([], $result);
-        $this->assertCount(0, $result);
+        self::assertSame([], $result);
+        self::assertCount(0, $result);
 
         $result = rcube_imap_generic::uncompressMessageSet('1');
-        $this->assertSame([1], $result);
-        $this->assertCount(1, $result);
+        self::assertSame([1], $result);
+        self::assertCount(1, $result);
 
         $result = rcube_imap_generic::uncompressMessageSet('1:3');
-        $this->assertSame([1, 2, 3], $result);
-        $this->assertCount(3, $result);
+        self::assertSame([1, 2, 3], $result);
+        self::assertCount(3, $result);
     }
 
     /**
@@ -106,19 +106,19 @@ class Framework_ImapGeneric extends TestCase
         $response = "test brack[et] {1}\r\na {0}\r\n (item1 item2)";
 
         $result = rcube_imap_generic::tokenizeResponse($response, 1);
-        $this->assertSame('test', $result);
+        self::assertSame('test', $result);
 
         $result = rcube_imap_generic::tokenizeResponse($response, 1);
-        $this->assertSame('brack[et]', $result);
+        self::assertSame('brack[et]', $result);
 
         $result = rcube_imap_generic::tokenizeResponse($response, 1);
-        $this->assertSame('a', $result);
+        self::assertSame('a', $result);
 
         $result = rcube_imap_generic::tokenizeResponse($response, 1);
-        $this->assertSame('', $result);
+        self::assertSame('', $result);
 
         $result = rcube_imap_generic::tokenizeResponse($response, 1);
-        $this->assertSame(['item1', 'item2'], $result);
+        self::assertSame(['item1', 'item2'], $result);
     }
 
     /**
@@ -212,7 +212,7 @@ class Framework_ImapGeneric extends TestCase
                 $decoded .= $method->invokeArgs(null, [$chunk, $mode, $idx == count($chunks) - 1, &$prev]);
             }
 
-            $this->assertSame($expected, $decoded, "Failed on chunk size of {$x}");
+            self::assertSame($expected, $decoded, "Failed on chunk size of {$x}");
         }
     }
 }

--- a/tests/Framework/ImapSearchTest.php
+++ b/tests/Framework/ImapSearchTest.php
@@ -14,6 +14,6 @@ class Framework_ImapSearch extends TestCase
     {
         $object = new rcube_imap_search([], true);
 
-        $this->assertInstanceOf('rcube_imap_search', $object, 'Class constructor');
+        self::assertInstanceOf('rcube_imap_search', $object, 'Class constructor');
     }
 }

--- a/tests/Framework/ImapTest.php
+++ b/tests/Framework/ImapTest.php
@@ -14,7 +14,7 @@ class Framework_Imap extends TestCase
     {
         $object = new rcube_imap();
 
-        $this->assertInstanceOf('rcube_imap', $object, 'Class constructor');
+        self::assertInstanceOf('rcube_imap', $object, 'Class constructor');
     }
 
     /**
@@ -22,17 +22,17 @@ class Framework_Imap extends TestCase
      */
     public function test_convert_criteria()
     {
-        $this->assertSame(
+        self::assertSame(
             'FLAGGED SINCE 1-Feb-1994 NOT FROM "Smith"',
             rcube_imap::convert_criteria('FLAGGED SINCE 1-Feb-1994 NOT FROM "Smith"', RCUBE_CHARSET)
         );
 
-        $this->assertSame(
+        self::assertSame(
             'ALL TEXT el',
             rcube_imap::convert_criteria("ALL TEXT {4}\r\nżel", RCUBE_CHARSET)
         );
 
-        $this->assertSame(
+        self::assertSame(
             "ALL TEXT {4}\r\nżel",
             rcube_imap::convert_criteria("ALL TEXT {4}\r\nżel", RCUBE_CHARSET, RCUBE_CHARSET)
         );
@@ -57,10 +57,10 @@ class Framework_Imap extends TestCase
         $object = new rcube_imap();
 
         $result = $object->sort_folder_list([]);
-        $this->assertSame([], $result);
+        self::assertSame([], $result);
 
         $result = $object->sort_folder_list(['B', 'A']);
-        $this->assertSame(['A', 'B'], $result);
+        self::assertSame(['A', 'B'], $result);
 
         $folders = [
             'Trash',
@@ -96,7 +96,7 @@ class Framework_Imap extends TestCase
 
         $result = $object->sort_folder_list($folders);
 
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     /**
@@ -123,20 +123,20 @@ class Framework_Imap extends TestCase
 
         $result = invokeMethod($imap, 'structure_part', [$structure]);
 
-        $this->assertSame('0', $result->mime_id);
-        $this->assertSame('multipart', $result->ctype_primary);
-        $this->assertSame('report', $result->ctype_secondary);
-        $this->assertSame('multipart/report', $result->mimetype);
-        $this->assertSame(['boundary' => '=_RrjQxjLYBqTMnoYWobuYlwN'], $result->ctype_parameters);
-        $this->assertSame([], $result->d_parameters);
-        $this->assertSame('8bit', $result->encoding);
-        $this->assertCount(3, $result->parts);
+        self::assertSame('0', $result->mime_id);
+        self::assertSame('multipart', $result->ctype_primary);
+        self::assertSame('report', $result->ctype_secondary);
+        self::assertSame('multipart/report', $result->mimetype);
+        self::assertSame(['boundary' => '=_RrjQxjLYBqTMnoYWobuYlwN'], $result->ctype_parameters);
+        self::assertSame([], $result->d_parameters);
+        self::assertSame('8bit', $result->encoding);
+        self::assertCount(3, $result->parts);
 
         $part = $result->parts[2];
-        $this->assertSame('3', $part->mime_id);
-        $this->assertSame('message/rfc822', $part->mimetype);
-        $this->assertSame('multipart/mixed', $part->real_mimetype);
-        $this->assertSame(3953, $part->size);
-        $this->assertCount(1, $part->parts);
+        self::assertSame('3', $part->mime_id);
+        self::assertSame('message/rfc822', $part->mimetype);
+        self::assertSame('multipart/mixed', $part->real_mimetype);
+        self::assertSame(3953, $part->size);
+        self::assertCount(1, $part->parts);
     }
 }

--- a/tests/Framework/LdapGenericTest.php
+++ b/tests/Framework/LdapGenericTest.php
@@ -10,7 +10,7 @@ class Framework_LdapGeneric extends TestCase
     protected function markTestSkippedIfNetLdapPackageIsNotInstalled(): void
     {
         if (!class_exists(Net_LDAP3::class)) {
-            $this->markTestSkipped('The Net_LDAP3 package not available.');
+            self::markTestSkipped('The Net_LDAP3 package not available.');
         }
     }
 
@@ -23,7 +23,7 @@ class Framework_LdapGeneric extends TestCase
 
         $object = new rcube_ldap_generic([]);
 
-        $this->assertInstanceOf('rcube_ldap_generic', $object, 'Class constructor');
+        self::assertInstanceOf('rcube_ldap_generic', $object, 'Class constructor');
     }
 
     /**
@@ -37,14 +37,14 @@ class Framework_LdapGeneric extends TestCase
 
         $result = $object->fulltext_search_filter('test', ['dn']);
 
-        $this->assertSame('(|(dn=test))', $result);
+        self::assertSame('(|(dn=test))', $result);
 
         $result = $object->fulltext_search_filter('test', ['dn', 'mail'], 2);
 
-        $this->assertSame('(|(dn=test*)(mail=test*))', $result);
+        self::assertSame('(|(dn=test*)(mail=test*))', $result);
 
         $result = $object->fulltext_search_filter('test1 test2', ['dn', 'mail'], 0);
 
-        $this->assertSame('(&(|(dn=*test1*)(mail=*test1*))(|(dn=*test2*)(mail=*test2*)))', $result);
+        self::assertSame('(&(|(dn=*test1*)(mail=*test1*))(|(dn=*test2*)(mail=*test2*)))', $result);
     }
 }

--- a/tests/Framework/LdapTest.php
+++ b/tests/Framework/LdapTest.php
@@ -14,19 +14,19 @@ class Framework_Ldap extends TestCase
     {
         // skip test if Net_LDAP3 does not exist
         if (!class_exists('Net_LDAP3')) {
-            $this->markTestSkipped('The Net_LDAP3 package not available.');
+            self::markTestSkipped('The Net_LDAP3 package not available.');
         }
 
         // skip test if php-ldap is not available
         if (!extension_loaded('ldap')) {
-            $this->markTestSkipped('The ldap extension is not available.');
+            self::markTestSkipped('The ldap extension is not available.');
         }
 
         StderrMock::start();
         $object = new rcube_ldap([]);
         StderrMock::stop();
 
-        $this->assertInstanceOf('rcube_ldap', $object, 'Class constructor');
-        $this->assertSame('ERROR: Could not connect to any LDAP server', trim(StderrMock::$output));
+        self::assertInstanceOf('rcube_ldap', $object, 'Class constructor');
+        self::assertSame('ERROR: Could not connect to any LDAP server', trim(StderrMock::$output));
     }
 }

--- a/tests/Framework/MessageHeaderTest.php
+++ b/tests/Framework/MessageHeaderTest.php
@@ -14,6 +14,6 @@ class Framework_MessageHeader extends TestCase
     {
         $object = new rcube_message_header();
 
-        $this->assertInstanceOf('rcube_message_header', $object, 'Class constructor');
+        self::assertInstanceOf('rcube_message_header', $object, 'Class constructor');
     }
 }

--- a/tests/Framework/MessagePartTest.php
+++ b/tests/Framework/MessagePartTest.php
@@ -14,7 +14,7 @@ class Framework_MessagePart extends TestCase
     {
         $object = new rcube_message_part();
 
-        $this->assertInstanceOf('rcube_message_part', $object, 'Class constructor');
+        self::assertInstanceOf('rcube_message_part', $object, 'Class constructor');
     }
 
     /**
@@ -36,26 +36,26 @@ class Framework_MessagePart extends TestCase
         }
 
         // Test some basic cases
-        $this->assertSame('A011.txt', $message->parts[0]->normalize());
-        $this->assertSame('A012.txt', $message->parts[1]->normalize());
-        $this->assertSame('A014.txt', $message->parts[2]->normalize());
+        self::assertSame('A011.txt', $message->parts[0]->normalize());
+        self::assertSame('A012.txt', $message->parts[1]->normalize());
+        self::assertSame('A014.txt', $message->parts[2]->normalize());
 
         // Test RFC2047 encoding (note: the decoding was done in rcube_mime_decode)
-        $this->assertSame('żółć.png', $message->parts[3]->normalize());
-        $this->assertSame(
+        self::assertSame('żółć.png', $message->parts[3]->normalize());
+        self::assertSame(
             'very very very very long very very very very long ćććććć very very very long name.txt',
             $message->parts[5]->normalize()
         );
 
         // Test RFC2231 encoding (note: the decoding was done in rcube_mime_decode)
-        $this->assertSame('żółć.png', $message->parts[4]->normalize());
+        self::assertSame('żółć.png', $message->parts[4]->normalize());
 
         // Test the decoding in normalize() itself
         $part = new rcube_message_part();
 
         $headers = "Content-Type: image/png; charset=UTF-16LE; name=A016.txt\r\n"
             . "Content-Disposition: attachment;\r\n filename*=UTF-8''%C5%BC%C3%B3%C5%82%C4%87.png\r\n";
-        $this->assertSame('żółć.png', $part->normalize($headers));
+        self::assertSame('żółć.png', $part->normalize($headers));
 
         $headers = "Content-Type: text/plain; charset=ISO-8859-1;\r\n"
             . " name=\"=?UTF-8?Q?very_very_very_very_long_very_very_very_very_long_=C4=87?=\r\n"
@@ -65,7 +65,7 @@ class Framework_MessagePart extends TestCase
             . " filename*0*=UTF-8''very%20very%20very%20very%20long%20very%20very%20very;\r\n"
             . " filename*1*=%20very%20long%20%C4%87%C4%87%C4%87%C4%87%C4%87%C4%87%20very;\r\n"
             . " filename*2*=%20very%20very%20long%20name.txt;\r\n";
-        $this->assertSame(
+        self::assertSame(
             'very very very very long very very very very long ćććććć very very very long name.txt',
             $part->normalize($headers)
         );

--- a/tests/Framework/MessageTest.php
+++ b/tests/Framework/MessageTest.php
@@ -16,6 +16,6 @@ class Framework_Message extends TestCase
         $body = 'test';
         $result = rcube_message::format_part_body($body, $part);
 
-        $this->assertSame('test', $result);
+        self::assertSame('test', $result);
     }
 }

--- a/tests/Framework/MimeDecodeTest.php
+++ b/tests/Framework/MimeDecodeTest.php
@@ -18,20 +18,20 @@ class Framework_MimeDecode extends TestCase
 
         $result = $decoder->decode($mail);
 
-        $this->assertInstanceOf('rcube_message_part', $result);
-        $this->assertSame('multipart/mixed', $result->mimetype);
-        $this->assertSame('=_8853bfb47b7da1852ac882e69cc724f3', $result->ctype_parameters['boundary']);
-        $this->assertSame('8bit', $result->encoding);
-        $this->assertSame(1413, $result->size);
+        self::assertInstanceOf('rcube_message_part', $result);
+        self::assertSame('multipart/mixed', $result->mimetype);
+        self::assertSame('=_8853bfb47b7da1852ac882e69cc724f3', $result->ctype_parameters['boundary']);
+        self::assertSame('8bit', $result->encoding);
+        self::assertSame(1413, $result->size);
 
-        $this->assertCount(13, $result->headers);
-        $this->assertSame('thomas@roundcube.net', $result->headers['x-sender']);
+        self::assertCount(13, $result->headers);
+        self::assertSame('thomas@roundcube.net', $result->headers['x-sender']);
 
-        $this->assertSame('=_8853bfb47b7da1852ac882e69cc724f3', $result->ctype_parameters['boundary']);
+        self::assertSame('=_8853bfb47b7da1852ac882e69cc724f3', $result->ctype_parameters['boundary']);
 
-        $this->assertCount(3, $result->parts);
-        $this->assertSame(11, $result->parts[2]->size);
-        $this->assertSame('text/plain', $result->parts[2]->mimetype);
-        $this->assertSame('lines_lf.txt', $result->parts[2]->filename);
+        self::assertCount(3, $result->parts);
+        self::assertSame(11, $result->parts[2]->size);
+        self::assertSame('text/plain', $result->parts[2]->mimetype);
+        self::assertSame('lines_lf.txt', $result->parts[2]->filename);
     }
 }

--- a/tests/Framework/MimeTest.php
+++ b/tests/Framework/MimeTest.php
@@ -85,9 +85,9 @@ class Framework_Mime extends TestCase
         foreach ($headers as $idx => $header) {
             $res = rcube_mime::decode_address_list($header);
 
-            $this->assertSame($results[$idx][0], count($res), 'Rows number in result for header: ' . $header);
-            $this->assertSame($results[$idx][1], $res[1]['name'], 'Name part decoding for header: ' . $header);
-            $this->assertSame($results[$idx][2], $res[1]['mailto'], 'Email part decoding for header: ' . $header);
+            self::assertSame($results[$idx][0], count($res), 'Rows number in result for header: ' . $header);
+            self::assertSame($results[$idx][1], $res[1]['name'], 'Name part decoding for header: ' . $header);
+            self::assertSame($results[$idx][2], $res[1]['mailto'], 'Email part decoding for header: ' . $header);
         }
     }
 
@@ -130,7 +130,7 @@ class Framework_Mime extends TestCase
         foreach ($headers as $idx => $header) {
             $res = rcube_mime::decode_address_list($header);
 
-            $this->assertSame($results[$idx], $res, "Decode address groups (#{$idx})");
+            self::assertSame($results[$idx], $res, "Decode address groups (#{$idx})");
         }
     }
 
@@ -176,7 +176,7 @@ class Framework_Mime extends TestCase
             $res = rcube_mime::decode_mime_string($item['in'], 'UTF-8');
             $res = quoted_printable_encode($res);
 
-            $this->assertSame($item['out'], $res, 'Header decoding for: ' . $idx);
+            self::assertSame($item['out'], $res, 'Header decoding for: ' . $idx);
         }
     }
 
@@ -185,7 +185,7 @@ class Framework_Mime extends TestCase
      */
     public function test_parse_headers()
     {
-        $this->assertSame([], rcube_mime::parse_headers(''));
+        self::assertSame([], rcube_mime::parse_headers(''));
 
         $headers = "Subject: Test\r\n"
             . "To: test@test1.com\r\n\ttest@test2.com\r\n";
@@ -195,7 +195,7 @@ class Framework_Mime extends TestCase
             'to' => 'test@test1.com test@test2.com',
         ];
 
-        $this->assertSame($expected, rcube_mime::parse_headers($headers));
+        self::assertSame($expected, rcube_mime::parse_headers($headers));
     }
 
     /**
@@ -206,7 +206,7 @@ class Framework_Mime extends TestCase
         $raw = file_get_contents(TESTS_DIR . 'src/format-flowed-unfolded.txt');
         $flowed = file_get_contents(TESTS_DIR . 'src/format-flowed.txt');
 
-        $this->assertSame($flowed, rcube_mime::format_flowed($raw, 80), 'Test correct folding and space-stuffing');
+        self::assertSame($flowed, rcube_mime::format_flowed($raw, 80), 'Test correct folding and space-stuffing');
     }
 
     /**
@@ -217,7 +217,7 @@ class Framework_Mime extends TestCase
         $flowed = file_get_contents(TESTS_DIR . 'src/format-flowed.txt');
         $unfolded = file_get_contents(TESTS_DIR . 'src/format-flowed-unfolded.txt');
 
-        $this->assertSame($unfolded, rcube_mime::unfold_flowed($flowed), 'Test correct unfolding of quoted lines');
+        self::assertSame($unfolded, rcube_mime::unfold_flowed($flowed), 'Test correct unfolding of quoted lines');
     }
 
     /**
@@ -232,7 +232,7 @@ class Framework_Mime extends TestCase
                     . "> \r\n"
                     . 'Sed ut perspiciatis unde omnis iste natus error sit voluptatem';
 
-        $this->assertSame($unfolded, rcube_mime::unfold_flowed($flowed), 'Test correct unfolding of quoted lines [2]');
+        self::assertSame($unfolded, rcube_mime::unfold_flowed($flowed), 'Test correct unfolding of quoted lines [2]');
     }
 
     /**
@@ -246,7 +246,7 @@ class Framework_Mime extends TestCase
                     . 'しているのを見ました。';
         $unfolded = 'そしてジョバンニはすぐうしろの天気輪の柱がいつかぼんやりした三角標の形になって、しばらく蛍のように、ぺかぺか消えたりともったりしているのを見ました。';
 
-        $this->assertSame($unfolded, rcube_mime::unfold_flowed($flowed, null, true), 'Test correct unfolding of flowed DelSp=Yes lines');
+        self::assertSame($unfolded, rcube_mime::unfold_flowed($flowed, null, true), 'Test correct unfolding of flowed DelSp=Yes lines');
     }
 
     /**
@@ -310,7 +310,7 @@ class Framework_Mime extends TestCase
         ];
 
         foreach ($samples as $sample) {
-            $this->assertSame($sample[1], call_user_func_array(['rcube_mime', 'wordwrap'], $sample[0]), 'Test text wrapping');
+            self::assertSame($sample[1], call_user_func_array(['rcube_mime', 'wordwrap'], $sample[0]), 'Test text wrapping');
         }
     }
 
@@ -322,29 +322,29 @@ class Framework_Mime extends TestCase
         $file = file_get_contents(__DIR__ . '/../src/html.msg');
         $result = rcube_mime::parse_message($file);
 
-        $this->assertInstanceOf('rcube_message_part', $result);
-        $this->assertSame('multipart/alternative', $result->mimetype);
-        $this->assertSame('1.0', $result->headers['mime-version']);
-        $this->assertSame('=_68eeaf4ab95b5312965e45c33362338e', $result->ctype_parameters['boundary']);
-        $this->assertSame('1', $result->parts[0]->mime_id);
-        $this->assertSame(12, $result->parts[0]->size);
-        $this->assertSame('text/plain', $result->parts[0]->mimetype);
-        $this->assertSame('this is test', $result->parts[0]->body);
-        $this->assertSame('2', $result->parts[1]->mime_id);
-        $this->assertSame(0, $result->parts[1]->size);
-        $this->assertSame('multipart/related', $result->parts[1]->mimetype);
-        $this->assertCount(2, $result->parts[1]->parts);
-        $this->assertSame('2.1', $result->parts[1]->parts[0]->mime_id);
-        $this->assertSame(257, $result->parts[1]->parts[0]->size);
-        $this->assertSame('text/html', $result->parts[1]->parts[0]->mimetype);
-        $this->assertSame('UTF-8', $result->parts[1]->parts[0]->charset);
-        $this->assertMatchesRegularExpression('/<html>/', $result->parts[1]->parts[0]->body);
-        $this->assertSame('2.2', $result->parts[1]->parts[1]->mime_id);
-        $this->assertSame(793, $result->parts[1]->parts[1]->size);
-        $this->assertSame('image/jpeg', $result->parts[1]->parts[1]->mimetype);
-        $this->assertSame('base64', $result->parts[1]->parts[1]->encoding);
-        $this->assertSame('inline', $result->parts[1]->parts[1]->disposition);
-        $this->assertSame('photo-mini.jpg', $result->parts[1]->parts[1]->filename);
+        self::assertInstanceOf('rcube_message_part', $result);
+        self::assertSame('multipart/alternative', $result->mimetype);
+        self::assertSame('1.0', $result->headers['mime-version']);
+        self::assertSame('=_68eeaf4ab95b5312965e45c33362338e', $result->ctype_parameters['boundary']);
+        self::assertSame('1', $result->parts[0]->mime_id);
+        self::assertSame(12, $result->parts[0]->size);
+        self::assertSame('text/plain', $result->parts[0]->mimetype);
+        self::assertSame('this is test', $result->parts[0]->body);
+        self::assertSame('2', $result->parts[1]->mime_id);
+        self::assertSame(0, $result->parts[1]->size);
+        self::assertSame('multipart/related', $result->parts[1]->mimetype);
+        self::assertCount(2, $result->parts[1]->parts);
+        self::assertSame('2.1', $result->parts[1]->parts[0]->mime_id);
+        self::assertSame(257, $result->parts[1]->parts[0]->size);
+        self::assertSame('text/html', $result->parts[1]->parts[0]->mimetype);
+        self::assertSame('UTF-8', $result->parts[1]->parts[0]->charset);
+        self::assertMatchesRegularExpression('/<html>/', $result->parts[1]->parts[0]->body);
+        self::assertSame('2.2', $result->parts[1]->parts[1]->mime_id);
+        self::assertSame(793, $result->parts[1]->parts[1]->size);
+        self::assertSame('image/jpeg', $result->parts[1]->parts[1]->mimetype);
+        self::assertSame('base64', $result->parts[1]->parts[1]->encoding);
+        self::assertSame('inline', $result->parts[1]->parts[1]->disposition);
+        self::assertSame('photo-mini.jpg', $result->parts[1]->parts[1]->filename);
     }
 
     /**
@@ -353,9 +353,9 @@ class Framework_Mime extends TestCase
     public function test_file_content_type()
     {
         $file = INSTALL_PATH . 'program/resources/blocked.gif';
-        $this->assertSame('image/gif', rcube_mime::file_content_type($file, 'blocked.gif'));
+        self::assertSame('image/gif', rcube_mime::file_content_type($file, 'blocked.gif'));
 
-        $this->assertSame('image/gif', rcube_mime::file_content_type($file, 'blocked.gif', 'application/octet-stream', false, true));
+        self::assertSame('image/gif', rcube_mime::file_content_type($file, 'blocked.gif', 'application/octet-stream', false, true));
     }
 
     /**
@@ -363,10 +363,10 @@ class Framework_Mime extends TestCase
      */
     public function test_get_mime_extensions()
     {
-        $this->assertSame([], rcube_mime::get_mime_extensions('unknown'));
-        $this->assertSame(['gif'], rcube_mime::get_mime_extensions('image/gif'));
-        $this->assertSame(['pdf'], rcube_mime::get_mime_extensions('application/pdf'));
-        $this->assertSame(['jpg', 'jpeg', 'jpe'], rcube_mime::get_mime_extensions('image/jpg'));
+        self::assertSame([], rcube_mime::get_mime_extensions('unknown'));
+        self::assertSame(['gif'], rcube_mime::get_mime_extensions('image/gif'));
+        self::assertSame(['pdf'], rcube_mime::get_mime_extensions('application/pdf'));
+        self::assertSame(['jpg', 'jpeg', 'jpe'], rcube_mime::get_mime_extensions('image/jpg'));
     }
 
     /**
@@ -375,7 +375,7 @@ class Framework_Mime extends TestCase
     public function test_image_content_type()
     {
         $file = file_get_contents(INSTALL_PATH . 'program/resources/blocked.gif');
-        $this->assertSame('image/gif', rcube_mime::image_content_type($file));
+        self::assertSame('image/gif', rcube_mime::image_content_type($file));
     }
 
     /**
@@ -383,9 +383,9 @@ class Framework_Mime extends TestCase
      */
     public function test_fix_mimetype()
     {
-        $this->assertSame('unknown', rcube_mime::fix_mimetype('unknown'));
-        $this->assertSame('application/pdf', rcube_mime::fix_mimetype('pdf'));
-        $this->assertSame('application/pdf', rcube_mime::fix_mimetype('application/pdf.123'));
-        $this->assertSame('image/jpeg', rcube_mime::fix_mimetype('image/pjpeg'));
+        self::assertSame('unknown', rcube_mime::fix_mimetype('unknown'));
+        self::assertSame('application/pdf', rcube_mime::fix_mimetype('pdf'));
+        self::assertSame('application/pdf', rcube_mime::fix_mimetype('application/pdf.123'));
+        self::assertSame('image/jpeg', rcube_mime::fix_mimetype('image/pjpeg'));
     }
 }

--- a/tests/Framework/OutputTest.php
+++ b/tests/Framework/OutputTest.php
@@ -14,30 +14,30 @@ class Framework_Output extends TestCase
     {
         $out = rcube_output::get_edit_field('test', 'value');
 
-        $this->assertSame('<input name="_test" class="ff_test" type="text" value="value">', $out);
+        self::assertSame('<input name="_test" class="ff_test" type="text" value="value">', $out);
 
         $_POST['_test'] = 'testv';
         $out = rcube_output::get_edit_field('test', 'value');
 
-        $this->assertSame('<input name="_test" class="ff_test" type="text" value="testv">', $out);
+        self::assertSame('<input name="_test" class="ff_test" type="text" value="testv">', $out);
 
         $out = rcube_output::get_edit_field('test', 'value', ['class' => 'a'], 'checkbox');
 
-        $this->assertSame('<input class="a ff_test" name="_test" value="1" type="checkbox">', $out);
+        self::assertSame('<input class="a ff_test" name="_test" value="1" type="checkbox">', $out);
 
         $out = rcube_output::get_edit_field('test', 'value', ['class' => 'a'], 'textarea');
 
-        $this->assertSame('<textarea class="a ff_test" name="_test">testv</textarea>', $out);
+        self::assertSame('<textarea class="a ff_test" name="_test">testv</textarea>', $out);
 
         $out = rcube_output::get_edit_field('test', 'value', ['class' => 'a'], 'select');
 
-        $this->assertSame('<select class="a ff_test" name="_test">' . "\n" . '<option value="">---</option></select>', $out);
+        self::assertSame('<select class="a ff_test" name="_test">' . "\n" . '<option value="">---</option></select>', $out);
 
         $_POST['_test'] = 'tt';
         $attr = ['options' => ['tt' => 'oo']];
         $out = rcube_output::get_edit_field('test', 'value', $attr, 'select');
 
-        $this->assertSame('<select name="_test" class="ff_test">' . "\n"
+        self::assertSame('<select name="_test" class="ff_test">' . "\n"
             . '<option value="">---</option><option value="tt" selected="selected">oo</option></select>',
             $out
         );
@@ -48,12 +48,12 @@ class Framework_Output extends TestCase
      */
     public function test_json_serialize()
     {
-        $this->assertSame('""', rcube_output::json_serialize(''));
-        $this->assertSame('[]', rcube_output::json_serialize([]));
-        $this->assertSame('10', rcube_output::json_serialize(10));
-        $this->assertSame('{"test":"test"}', rcube_output::json_serialize(['test' => 'test']));
+        self::assertSame('""', rcube_output::json_serialize(''));
+        self::assertSame('[]', rcube_output::json_serialize([]));
+        self::assertSame('10', rcube_output::json_serialize(10));
+        self::assertSame('{"test":"test"}', rcube_output::json_serialize(['test' => 'test']));
 
         // Test non-utf-8 input
-        $this->assertSame('{"ab":"ab"}', rcube_output::json_serialize(["a\x8cb" => "a\x8cb"]));
+        self::assertSame('{"ab":"ab"}', rcube_output::json_serialize(["a\x8cb" => "a\x8cb"]));
     }
 }

--- a/tests/Framework/PluginApiTest.php
+++ b/tests/Framework/PluginApiTest.php
@@ -16,10 +16,10 @@ class Framework_PluginApi extends TestCase
 
         $info = $api->get_info('acl');
 
-        $this->assertSame('roundcube', $info['vendor']);
-        $this->assertSame('acl', $info['name']);
-        $this->assertSame([], $info['require']);
-        $this->assertSame('GPL-3.0+', $info['license']);
+        self::assertSame('roundcube', $info['vendor']);
+        self::assertSame('acl', $info['name']);
+        self::assertSame([], $info['require']);
+        self::assertSame('GPL-3.0+', $info['license']);
     }
 
     /**
@@ -36,14 +36,14 @@ class Framework_PluginApi extends TestCase
 
         $api->exec_hook('test', []);
 
-        $this->assertSame(1, $var);
+        self::assertSame(1, $var);
 
         $api->unregister_hook('test', $hook_handler);
 
         $api->exec_hook('test', []);
 
-        $this->assertSame(1, $var);
-        $this->assertFalse($api->is_processing());
+        self::assertSame(1, $var);
+        self::assertFalse($api->is_processing());
     }
 
     /**
@@ -53,7 +53,7 @@ class Framework_PluginApi extends TestCase
     {
         $api = rcube_plugin_api::get_instance();
 
-        $this->assertTrue($api->register_task('test', 'test'));
-        $this->assertTrue($api->is_plugin_task('test'));
+        self::assertTrue($api->register_task('test', 'test'));
+        self::assertTrue($api->is_plugin_task('test'));
     }
 }

--- a/tests/Framework/RcubeTest.php
+++ b/tests/Framework/RcubeTest.php
@@ -14,7 +14,7 @@ class Framework_Rcube extends TestCase
     {
         $object = rcube::get_instance();
 
-        $this->assertInstanceOf('rcube', $object, 'Class singleton');
+        self::assertInstanceOf('rcube', $object, 'Class singleton');
     }
 
     /**
@@ -25,7 +25,7 @@ class Framework_Rcube extends TestCase
         $rcube = rcube::get_instance();
         $result = $rcube->read_localization(INSTALL_PATH . 'plugins/acl/localization', 'pl_PL');
 
-        $this->assertSame('Zapis', $result['aclwrite']);
+        self::assertSame('Zapis', $result['aclwrite']);
     }
 
     /**
@@ -36,7 +36,7 @@ class Framework_Rcube extends TestCase
         $rcube = rcube::get_instance();
         $result = $rcube->list_languages();
 
-        $this->assertSame('English (US)', $result['en_US']);
+        self::assertSame('English (US)', $result['en_US']);
     }
 
     /**
@@ -47,14 +47,14 @@ class Framework_Rcube extends TestCase
         $rcube = rcube::get_instance();
 
         $result = $rcube->decrypt($rcube->encrypt('test'));
-        $this->assertSame('test', $result);
+        self::assertSame('test', $result);
 
         // Test AEAD cipher method
         $defaultCipherMethod = $rcube->config->get('cipher_method');
         $rcube->config->set('cipher_method', 'aes-256-gcm');
         try {
             $result = $rcube->decrypt($rcube->encrypt('test'));
-            $this->assertSame('test', $result);
+            self::assertSame('test', $result);
         } finally {
             $rcube->config->set('cipher_method', $defaultCipherMethod);
         }
@@ -68,14 +68,14 @@ class Framework_Rcube extends TestCase
     public function test_exec()
     {
         if (\PHP_OS_FAMILY === 'Windows') {
-            $this->assertSame('', rcube::exec('where.exe unknown-command-123 2> nul'));
-            $this->assertSame('12', rcube::exec('set /a 10 + {v}', ['v' => '2']));
+            self::assertSame('', rcube::exec('where.exe unknown-command-123 2> nul'));
+            self::assertSame('12', rcube::exec('set /a 10 + {v}', ['v' => '2']));
 
             return;
         }
 
-        $this->assertSame('', rcube::exec('which unknown-command-123'));
-        $this->assertSame("2038\n", rcube::exec('date --date={date} +%Y', ['date' => '@2147483647']));
+        self::assertSame('', rcube::exec('which unknown-command-123'));
+        self::assertSame("2038\n", rcube::exec('date --date={date} +%Y', ['date' => '@2147483647']));
         // TODO: More cases
     }
 }

--- a/tests/Framework/ResultIndexTest.php
+++ b/tests/Framework/ResultIndexTest.php
@@ -14,7 +14,7 @@ class Framework_ResultIndex extends TestCase
     {
         $object = new rcube_result_index();
 
-        $this->assertInstanceOf('rcube_result_index', $object, 'Class constructor');
+        self::assertInstanceOf('rcube_result_index', $object, 'Class constructor');
     }
 
     /**
@@ -25,42 +25,42 @@ class Framework_ResultIndex extends TestCase
         $text = '* SORT 2001 2002 2035 2036 2037 2038 2044 2046 2043 2045 2226 2225 2224 2223';
         $object = new rcube_result_index('INBOX', $text);
 
-        $this->assertFalse($object->is_empty(), 'Object is empty');
-        $this->assertFalse($object->is_error(), 'Object is error');
-        $this->assertSame(2226, $object->max(), 'Max message UID');
-        $this->assertSame(2001, $object->min(), 'Min message UID');
-        $this->assertSame(14, $object->count_messages(), 'Messages count');
-        $this->assertSame(14, $object->count(), 'Messages count');
-        $this->assertSame(1, $object->exists(2002, true), 'Message exists');
-        $this->assertTrue($object->exists(2002), 'Message exists (bool)');
-        $this->assertSame(2001, $object->get_element('FIRST'), 'Get first element');
-        $this->assertSame(2223, $object->get_element('LAST'), 'Get last element');
-        $this->assertSame(2035, $object->get_element(2), 'Get specified element');
-        $this->assertSame('2001:2002,2035:2038,2043:2046,2223:2226', $object->get_compressed(), 'Get compressed index');
-        $this->assertSame('INBOX', $object->get_parameters('MAILBOX'), 'Get parameter');
+        self::assertFalse($object->is_empty(), 'Object is empty');
+        self::assertFalse($object->is_error(), 'Object is error');
+        self::assertSame(2226, $object->max(), 'Max message UID');
+        self::assertSame(2001, $object->min(), 'Min message UID');
+        self::assertSame(14, $object->count_messages(), 'Messages count');
+        self::assertSame(14, $object->count(), 'Messages count');
+        self::assertSame(1, $object->exists(2002, true), 'Message exists');
+        self::assertTrue($object->exists(2002), 'Message exists (bool)');
+        self::assertSame(2001, $object->get_element('FIRST'), 'Get first element');
+        self::assertSame(2223, $object->get_element('LAST'), 'Get last element');
+        self::assertSame(2035, $object->get_element(2), 'Get specified element');
+        self::assertSame('2001:2002,2035:2038,2043:2046,2223:2226', $object->get_compressed(), 'Get compressed index');
+        self::assertSame('INBOX', $object->get_parameters('MAILBOX'), 'Get parameter');
 
         $clone = clone $object;
         $clone->filter([2035, 2002]);
 
-        $this->assertSame(2, $clone->count(), 'Messages count (filtered)');
-        $this->assertSame(2002, $clone->get_element('FIRST'), 'Get first element (filtered)');
+        self::assertSame(2, $clone->count(), 'Messages count (filtered)');
+        self::assertSame(2002, $clone->get_element('FIRST'), 'Get first element (filtered)');
 
         $clone = clone $object;
         $clone->revert();
 
-        $this->assertSame(14, $clone->count(), 'Messages count (reverted)');
-        $this->assertSame(12, $clone->exists(2002, true), 'Message exists (reverted)');
-        $this->assertTrue($clone->exists(2002), 'Message exists (bool) (reverted)');
-        $this->assertSame(2223, $clone->get_element('FIRST'), 'Get first element (reverted)');
-        $this->assertSame(2001, $clone->get_element('LAST'), 'Get last element (reverted)');
-        $this->assertSame(2225, $clone->get_element(2), 'Get specified element (reverted)');
+        self::assertSame(14, $clone->count(), 'Messages count (reverted)');
+        self::assertSame(12, $clone->exists(2002, true), 'Message exists (reverted)');
+        self::assertTrue($clone->exists(2002), 'Message exists (bool) (reverted)');
+        self::assertSame(2223, $clone->get_element('FIRST'), 'Get first element (reverted)');
+        self::assertSame(2001, $clone->get_element('LAST'), 'Get last element (reverted)');
+        self::assertSame(2225, $clone->get_element(2), 'Get specified element (reverted)');
 
         $clone = clone $object;
         $clone->slice(2, 3);
 
-        $this->assertSame(3, $clone->count(), 'Messages count (sliced)');
-        $this->assertSame(2035, $clone->get_element('FIRST'), 'Get first element (sliced)');
-        $this->assertSame(2037, $clone->get_element('LAST'), 'Get last element (sliced)');
+        self::assertSame(3, $clone->count(), 'Messages count (sliced)');
+        self::assertSame(2035, $clone->get_element('FIRST'), 'Get first element (sliced)');
+        self::assertSame(2037, $clone->get_element('LAST'), 'Get last element (sliced)');
     }
 
     /**
@@ -71,37 +71,37 @@ class Framework_ResultIndex extends TestCase
         $text = '* ESEARCH (TAG "A282") MIN 2 COUNT 3 ALL 2,10:11';
         $object = new rcube_result_index('INBOX', $text);
 
-        $this->assertFalse($object->is_empty(), 'Object is empty');
-        $this->assertFalse($object->is_error(), 'Object is error');
-        $this->assertSame(11, $object->max(), 'Max message UID');
-        $this->assertSame(2, $object->min(), 'Min message UID');
-        $this->assertSame(3, $object->count_messages(), 'Messages count');
-        $this->assertSame(3, $object->count(), 'Messages count');
-        $this->assertSame(1, $object->exists(10, true), 'Message exists');
-        $this->assertTrue($object->exists(10), 'Message exists (bool)');
-        $this->assertSame(2, $object->get_element('FIRST'), 'Get first element');
-        $this->assertSame(11, $object->get_element('LAST'), 'Get last element');
-        $this->assertSame(10, $object->get_element(1), 'Get specified element');
-        $this->assertSame('2,10:11', $object->get_compressed(), 'Get compressed index');
-        $this->assertSame('INBOX', $object->get_parameters('MAILBOX'), 'Get parameter');
+        self::assertFalse($object->is_empty(), 'Object is empty');
+        self::assertFalse($object->is_error(), 'Object is error');
+        self::assertSame(11, $object->max(), 'Max message UID');
+        self::assertSame(2, $object->min(), 'Min message UID');
+        self::assertSame(3, $object->count_messages(), 'Messages count');
+        self::assertSame(3, $object->count(), 'Messages count');
+        self::assertSame(1, $object->exists(10, true), 'Message exists');
+        self::assertTrue($object->exists(10), 'Message exists (bool)');
+        self::assertSame(2, $object->get_element('FIRST'), 'Get first element');
+        self::assertSame(11, $object->get_element('LAST'), 'Get last element');
+        self::assertSame(10, $object->get_element(1), 'Get specified element');
+        self::assertSame('2,10:11', $object->get_compressed(), 'Get compressed index');
+        self::assertSame('INBOX', $object->get_parameters('MAILBOX'), 'Get parameter');
 
         // A case without 'ALL' response
         $text = '* ESEARCH (TAG "A282") UID MAX 721 COUNT 3';
         $object = new rcube_result_index('INBOX', $text);
 
-        $this->assertFalse($object->is_empty(), 'Object is empty');
-        $this->assertFalse($object->is_error(), 'Object is error');
-        $this->assertSame(721, $object->max(), 'Max message UID');
-        $this->assertNull($object->min(), 'Min message UID');
-        $this->assertSame(3, $object->count_messages(), 'Messages count');
-        $this->assertSame(3, $object->count(), 'Messages count');
-        $this->assertFalse($object->exists(10, true), 'Message exists');
-        $this->assertFalse($object->exists(10), 'Message exists (bool)');
-        $this->assertNull($object->get_element('FIRST'), 'Get first element');
-        $this->assertNull($object->get_element('LAST'), 'Get last element');
-        $this->assertNull($object->get_element(1), 'Get specified element');
-        $this->assertSame('', $object->get_compressed(), 'Get compressed index');
-        $this->assertSame('INBOX', $object->get_parameters('MAILBOX'), 'Get parameter');
+        self::assertFalse($object->is_empty(), 'Object is empty');
+        self::assertFalse($object->is_error(), 'Object is error');
+        self::assertSame(721, $object->max(), 'Max message UID');
+        self::assertNull($object->min(), 'Min message UID');
+        self::assertSame(3, $object->count_messages(), 'Messages count');
+        self::assertSame(3, $object->count(), 'Messages count');
+        self::assertFalse($object->exists(10, true), 'Message exists');
+        self::assertFalse($object->exists(10), 'Message exists (bool)');
+        self::assertNull($object->get_element('FIRST'), 'Get first element');
+        self::assertNull($object->get_element('LAST'), 'Get last element');
+        self::assertNull($object->get_element(1), 'Get specified element');
+        self::assertSame('', $object->get_compressed(), 'Get compressed index');
+        self::assertSame('INBOX', $object->get_parameters('MAILBOX'), 'Get parameter');
     }
 
     /**
@@ -111,18 +111,18 @@ class Framework_ResultIndex extends TestCase
     {
         $object = new rcube_result_index('INBOX', '* SORT');
 
-        $this->assertTrue($object->is_empty(), 'Object is empty');
-        $this->assertFalse($object->is_error(), 'Object is error');
-        $this->assertNull($object->max(), 'Max message UID');
-        $this->assertNull($object->min(), 'Min message UID');
-        $this->assertSame(0, $object->count_messages(), 'Messages count');
-        $this->assertSame(0, $object->count(), 'Messages count');
-        $this->assertFalse($object->exists(10, true), 'Message exists');
-        $this->assertFalse($object->exists(10), 'Message exists (bool)');
-        $this->assertNull($object->get_element('FIRST'), 'Get first element');
-        $this->assertNull($object->get_element('LAST'), 'Get last element');
-        $this->assertNull($object->get_element(1), 'Get specified element');
-        $this->assertSame('', $object->get_compressed(), 'Get compressed index');
-        $this->assertSame('INBOX', $object->get_parameters('MAILBOX'), 'Get parameter');
+        self::assertTrue($object->is_empty(), 'Object is empty');
+        self::assertFalse($object->is_error(), 'Object is error');
+        self::assertNull($object->max(), 'Max message UID');
+        self::assertNull($object->min(), 'Min message UID');
+        self::assertSame(0, $object->count_messages(), 'Messages count');
+        self::assertSame(0, $object->count(), 'Messages count');
+        self::assertFalse($object->exists(10, true), 'Message exists');
+        self::assertFalse($object->exists(10), 'Message exists (bool)');
+        self::assertNull($object->get_element('FIRST'), 'Get first element');
+        self::assertNull($object->get_element('LAST'), 'Get last element');
+        self::assertNull($object->get_element(1), 'Get specified element');
+        self::assertSame('', $object->get_compressed(), 'Get compressed index');
+        self::assertSame('INBOX', $object->get_parameters('MAILBOX'), 'Get parameter');
     }
 }

--- a/tests/Framework/ResultMultifolderTest.php
+++ b/tests/Framework/ResultMultifolderTest.php
@@ -14,6 +14,6 @@ class Framework_ResultMultifolder extends TestCase
     {
         $object = new rcube_result_multifolder();
 
-        $this->assertInstanceOf('rcube_result_multifolder', $object, 'Class constructor');
+        self::assertInstanceOf('rcube_result_multifolder', $object, 'Class constructor');
     }
 }

--- a/tests/Framework/ResultSetTest.php
+++ b/tests/Framework/ResultSetTest.php
@@ -14,6 +14,6 @@ class Framework_ResultSet extends TestCase
     {
         $object = new rcube_result_set();
 
-        $this->assertInstanceOf('rcube_result_set', $object, 'Class constructor');
+        self::assertInstanceOf('rcube_result_set', $object, 'Class constructor');
     }
 }

--- a/tests/Framework/ResultThreadTest.php
+++ b/tests/Framework/ResultThreadTest.php
@@ -14,7 +14,7 @@ class Framework_ResultThread extends TestCase
     {
         $object = new rcube_result_thread();
 
-        $this->assertInstanceOf('rcube_result_thread', $object, 'Class constructor');
+        self::assertInstanceOf('rcube_result_thread', $object, 'Class constructor');
     }
 
     /**
@@ -25,17 +25,17 @@ class Framework_ResultThread extends TestCase
         $text = file_get_contents(__DIR__ . '/../src/imap_thread.txt');
         $object = new rcube_result_thread('INBOX', $text);
 
-        $this->assertFalse($object->is_empty(), 'Object is empty');
-        $this->assertFalse($object->is_error(), 'Object is error');
-        $this->assertSame(1721, $object->max(), 'Max message UID');
-        $this->assertSame(1, $object->min(), 'Min message UID');
-        $this->assertSame(731, $object->count(), 'Threads count');
-        $this->assertSame(1721, $object->count_messages(), 'Messages count');
-        $this->assertSame(1691, $object->exists(1720, true), 'Message exists');
-        $this->assertTrue($object->exists(1720), 'Message exists (bool)');
-        $this->assertSame(1, $object->get_element('FIRST'), 'Get first element');
-        $this->assertSame(1719, $object->get_element('LAST'), 'Get last element');
-        $this->assertSame(14, (int) $object->get_element(2), 'Get specified element');
+        self::assertFalse($object->is_empty(), 'Object is empty');
+        self::assertFalse($object->is_error(), 'Object is error');
+        self::assertSame(1721, $object->max(), 'Max message UID');
+        self::assertSame(1, $object->min(), 'Min message UID');
+        self::assertSame(731, $object->count(), 'Threads count');
+        self::assertSame(1721, $object->count_messages(), 'Messages count');
+        self::assertSame(1691, $object->exists(1720, true), 'Message exists');
+        self::assertTrue($object->exists(1720), 'Message exists (bool)');
+        self::assertSame(1, $object->get_element('FIRST'), 'Get first element');
+        self::assertSame(1719, $object->get_element('LAST'), 'Get last element');
+        self::assertSame(14, (int) $object->get_element(2), 'Get specified element');
 
         $tree = $object->get_tree();
         $expected = [
@@ -62,32 +62,32 @@ class Framework_ResultThread extends TestCase
             ],
         ];
 
-        $this->assertSame([], $tree[1]);
-        $this->assertSame([], $tree[2]);
-        $this->assertSame([], $tree[14]);
-        $this->assertSame([], $tree[3]);
-        $this->assertSame($expected[4], $tree[4]);
-        $this->assertSame($expected[5], $tree[5]);
-        $this->assertSame($expected[19], $tree[19]);
+        self::assertSame([], $tree[1]);
+        self::assertSame([], $tree[2]);
+        self::assertSame([], $tree[14]);
+        self::assertSame([], $tree[3]);
+        self::assertSame($expected[4], $tree[4]);
+        self::assertSame($expected[5], $tree[5]);
+        self::assertSame($expected[19], $tree[19]);
 
         $clone = clone $object;
         $clone->filter([7]);
         $clone = $clone->get_tree();
 
-        $this->assertSame(1, count($clone), 'Structure check');
-        $this->assertSame(3, count($clone[7]), 'Structure check');
-        $this->assertSame(0, count($clone[7][12]), 'Structure check');
-        $this->assertSame(1, count($clone[7][167]), 'Structure check');
-        $this->assertSame(0, count($clone[7][167][197]), 'Structure check');
-        $this->assertSame(2, count($clone[7][458]), 'Structure check');
-        $this->assertSame(1, count($clone[7][458][460]), 'Structure check');
-        $this->assertSame(0, count($clone[7][458][460][463]), 'Structure check');
-        $this->assertSame(1, count($clone[7][458][464]), 'Structure check');
-        $this->assertSame(0, count($clone[7][458][464][471]), 'Structure check');
+        self::assertSame(1, count($clone), 'Structure check');
+        self::assertSame(3, count($clone[7]), 'Structure check');
+        self::assertSame(0, count($clone[7][12]), 'Structure check');
+        self::assertSame(1, count($clone[7][167]), 'Structure check');
+        self::assertSame(0, count($clone[7][167][197]), 'Structure check');
+        self::assertSame(2, count($clone[7][458]), 'Structure check');
+        self::assertSame(1, count($clone[7][458][460]), 'Structure check');
+        self::assertSame(0, count($clone[7][458][460][463]), 'Structure check');
+        self::assertSame(1, count($clone[7][458][464]), 'Structure check');
+        self::assertSame(0, count($clone[7][458][464][471]), 'Structure check');
 
         $object->filter([784]);
-        $this->assertSame(118, $object->count_messages(), 'Messages filter');
-        $this->assertSame(1, $object->count(), 'Messages filter (count)');
+        self::assertSame(118, $object->count_messages(), 'Messages filter');
+        self::assertSame(1, $object->count(), 'Messages filter (count)');
     }
 
     /**
@@ -97,16 +97,16 @@ class Framework_ResultThread extends TestCase
     {
         $object = new rcube_result_thread('INBOX', '* THREAD');
 
-        $this->assertTrue($object->is_empty(), 'Object is empty');
-        $this->assertFalse($object->is_error(), 'Object is error');
-        $this->assertNull($object->max(), 'Max message UID');
-        $this->assertNull($object->min(), 'Min message UID');
-        $this->assertSame(0, $object->count(), 'Threads count');
-        $this->assertSame(0, $object->count_messages(), 'Messages count');
-        $this->assertFalse($object->exists(1720, true), 'Message exists');
-        $this->assertFalse($object->exists(1720), 'Message exists (bool)');
-        $this->assertNull($object->get_element('FIRST'), 'Get first element');
-        $this->assertNull($object->get_element('LAST'), 'Get last element');
-        $this->assertNull($object->get_element(2), 'Get specified element');
+        self::assertTrue($object->is_empty(), 'Object is empty');
+        self::assertFalse($object->is_error(), 'Object is error');
+        self::assertNull($object->max(), 'Max message UID');
+        self::assertNull($object->min(), 'Min message UID');
+        self::assertSame(0, $object->count(), 'Threads count');
+        self::assertSame(0, $object->count_messages(), 'Messages count');
+        self::assertFalse($object->exists(1720, true), 'Message exists');
+        self::assertFalse($object->exists(1720), 'Message exists (bool)');
+        self::assertNull($object->get_element('FIRST'), 'Get first element');
+        self::assertNull($object->get_element('LAST'), 'Get last element');
+        self::assertNull($object->get_element(2), 'Get specified element');
     }
 }

--- a/tests/Framework/SessionTest.php
+++ b/tests/Framework/SessionTest.php
@@ -20,7 +20,7 @@ class Framework_Session extends TestCase
 
         $session = rcube_session::factory($rcube->config);
 
-        $this->assertInstanceOf('rcube_session_php', $session);
+        self::assertInstanceOf('rcube_session_php', $session);
 
         // This method should not do any harm, just call it and expect no errors
         $session->reload();
@@ -37,8 +37,8 @@ class Framework_Session extends TestCase
 
         $session = rcube_session::factory($rcube->config);
 
-        $this->assertSame([], $session->unserialize(''));
-        $this->assertSame(
+        self::assertSame([], $session->unserialize(''));
+        self::assertSame(
             ['ok' => true, 'name' => 'me', 'int' => 34],
             $session->unserialize('ok|b:1;name|s:2:"me";int|i:34;')
         );

--- a/tests/Framework/SmtpTest.php
+++ b/tests/Framework/SmtpTest.php
@@ -14,7 +14,7 @@ class Framework_Smtp extends TestCase
     {
         $object = new rcube_smtp();
 
-        $this->assertInstanceOf('rcube_smtp', $object, 'Class constructor');
+        self::assertInstanceOf('rcube_smtp', $object, 'Class constructor');
     }
 
     /**
@@ -33,9 +33,9 @@ class Framework_Smtp extends TestCase
 
         $result = invokeMethod($smtp, '_prepare_headers', [$headers]);
 
-        $this->assertCount(2, $result);
-        $this->assertSame('john@domain.tld', $result[0]);
-        $this->assertSame(
+        self::assertCount(2, $result);
+        self::assertSame('john@domain.tld', $result[0]);
+        self::assertSame(
             'Received: from github.com ([10.48.109.45]) by smtp.github.com (Postfix) with ESMTPA id 8C9B4E0075'
                 . " for <john@domain.tld>; Sat, 28 Nov 2020 22:45:44 -0800 (PST)\r\n"
                 . "Subject: Test\r\n"
@@ -53,6 +53,6 @@ class Framework_Smtp extends TestCase
         $input = 'test@test1.com, "test" <test@test2.pl>, "test@test3.eu" <test@test3.uk>';
         $result = invokeMethod($smtp, '_parse_rfc822', [$input]);
 
-        $this->assertSame(['test@test1.com', 'test@test2.pl', 'test@test3.uk'], $result);
+        self::assertSame(['test@test1.com', 'test@test2.pl', 'test@test3.uk'], $result);
     }
 }

--- a/tests/Framework/SpellcheckerAtdTest.php
+++ b/tests/Framework/SpellcheckerAtdTest.php
@@ -14,7 +14,7 @@ class Framework_SpellcheckerAtd extends TestCase
     {
         $object = new rcube_spellchecker_atd(null, 'en');
 
-        $this->assertInstanceOf('rcube_spellchecker_atd', $object, 'Class constructor');
-        $this->assertInstanceOf('rcube_spellchecker_engine', $object, 'Class constructor');
+        self::assertInstanceOf('rcube_spellchecker_atd', $object, 'Class constructor');
+        self::assertInstanceOf('rcube_spellchecker_engine', $object, 'Class constructor');
     }
 }

--- a/tests/Framework/SpellcheckerEnchantTest.php
+++ b/tests/Framework/SpellcheckerEnchantTest.php
@@ -14,8 +14,8 @@ class Framework_SpellcheckerEnchant extends TestCase
     {
         $object = new rcube_spellchecker_enchant(null, 'en');
 
-        $this->assertInstanceOf('rcube_spellchecker_enchant', $object, 'Class constructor');
-        $this->assertInstanceOf('rcube_spellchecker_engine', $object, 'Class constructor');
+        self::assertInstanceOf('rcube_spellchecker_enchant', $object, 'Class constructor');
+        self::assertInstanceOf('rcube_spellchecker_engine', $object, 'Class constructor');
     }
 
     /**
@@ -24,7 +24,7 @@ class Framework_SpellcheckerEnchant extends TestCase
     public function test_languages()
     {
         if (!extension_loaded('enchant')) {
-            $this->markTestSkipped();
+            self::markTestSkipped();
         }
 
         rcube::get_instance()->config->set('spellcheck_engine', 'enchant');
@@ -33,7 +33,7 @@ class Framework_SpellcheckerEnchant extends TestCase
 
         $langs = $object->languages();
 
-        $this->assertSame('English (US)', $langs['en'] ?? $langs['en_US']);
+        self::assertSame('English (US)', $langs['en'] ?? $langs['en_US']);
     }
 
     /**
@@ -42,31 +42,31 @@ class Framework_SpellcheckerEnchant extends TestCase
     public function test_check()
     {
         if (!extension_loaded('enchant')) {
-            $this->markTestSkipped();
+            self::markTestSkipped();
         }
 
         rcube::get_instance()->config->set('spellcheck_engine', 'enchant');
 
         $object = new rcube_spellchecker();
 
-        $this->assertTrue($object->check('one'));
+        self::assertTrue($object->check('one'));
 
         // Test other methods that depend on the spellcheck result
-        $this->assertSame(0, $object->found());
-        $this->assertSame([], $object->get_words());
+        self::assertSame(0, $object->found());
+        self::assertSame([], $object->get_words());
 
-        $this->assertSame(
+        self::assertSame(
             '<?xml version="1.0" encoding="UTF-8"?><spellresult charschecked="3"></spellresult>',
             $object->get_xml()
         );
 
-        $this->assertFalse($object->check('ony'));
+        self::assertFalse($object->check('ony'));
 
         // Test other methods that depend on the spellcheck result
-        $this->assertSame(1, $object->found());
-        $this->assertSame(['ony'], $object->get_words());
+        self::assertSame(1, $object->found());
+        self::assertSame(['ony'], $object->get_words());
 
-        $this->assertMatchesRegularExpression(
+        self::assertMatchesRegularExpression(
             '|^<\?xml version="1.0" encoding="UTF-8"\?><spellresult charschecked="3"><c o="0" l="3">([a-zA-Z\t]+)</c></spellresult>$|',
             $object->get_xml()
         );
@@ -75,15 +75,15 @@ class Framework_SpellcheckerEnchant extends TestCase
         $html = '<html><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8" /></head><body>'
             . '<p><a href="http://www.redacted.com">www.redacted.com</a></div></body></html>';
 
-        $this->assertTrue($object->check($html, true));
+        self::assertTrue($object->check($html, true));
 
         $html = '<html><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8" /></head><body>'
             . '<p><a href="http://www.redacted.com">http://www.redacted.com</a></div></body></html>';
 
-        $this->assertTrue($object->check($html, true));
+        self::assertTrue($object->check($html, true));
 
-        $this->assertTrue($object->check('one http://www.redacted.com'));
-        $this->assertTrue($object->check('one www.redacted.com'));
+        self::assertTrue($object->check('one http://www.redacted.com'));
+        self::assertTrue($object->check('one www.redacted.com'));
     }
 
     /**
@@ -92,7 +92,7 @@ class Framework_SpellcheckerEnchant extends TestCase
     public function test_get_suggestions()
     {
         if (!extension_loaded('enchant')) {
-            $this->markTestSkipped();
+            self::markTestSkipped();
         }
 
         rcube::get_instance()->config->set('spellcheck_engine', 'enchant');
@@ -101,8 +101,8 @@ class Framework_SpellcheckerEnchant extends TestCase
 
         $result = $object->get_suggestions('onlx');
 
-        $this->assertContains('only', $result);
-        $this->assertContains('onyx', $result);
+        self::assertContains('only', $result);
+        self::assertContains('onyx', $result);
     }
 
     /**
@@ -111,13 +111,13 @@ class Framework_SpellcheckerEnchant extends TestCase
     public function test_get_words()
     {
         if (!extension_loaded('enchant')) {
-            $this->markTestSkipped();
+            self::markTestSkipped();
         }
 
         rcube::get_instance()->config->set('spellcheck_engine', 'enchant');
 
         $object = new rcube_spellchecker();
 
-        $this->assertSame(['ony'], $object->get_words('ony'));
+        self::assertSame(['ony'], $object->get_words('ony'));
     }
 }

--- a/tests/Framework/SpellcheckerGoogieTest.php
+++ b/tests/Framework/SpellcheckerGoogieTest.php
@@ -14,7 +14,7 @@ class Framework_SpellcheckerGoogie extends TestCase
     {
         $object = new rcube_spellchecker_googie(null, 'en');
 
-        $this->assertInstanceOf('rcube_spellchecker_googie', $object, 'Class constructor');
-        $this->assertInstanceOf('rcube_spellchecker_engine', $object, 'Class constructor');
+        self::assertInstanceOf('rcube_spellchecker_googie', $object, 'Class constructor');
+        self::assertInstanceOf('rcube_spellchecker_engine', $object, 'Class constructor');
     }
 }

--- a/tests/Framework/SpellcheckerPspellTest.php
+++ b/tests/Framework/SpellcheckerPspellTest.php
@@ -14,8 +14,8 @@ class Framework_SpellcheckerPspell extends TestCase
     {
         $object = new rcube_spellchecker_pspell(null, 'en');
 
-        $this->assertInstanceOf('rcube_spellchecker_pspell', $object, 'Class constructor');
-        $this->assertInstanceOf('rcube_spellchecker_engine', $object, 'Class constructor');
+        self::assertInstanceOf('rcube_spellchecker_pspell', $object, 'Class constructor');
+        self::assertInstanceOf('rcube_spellchecker_engine', $object, 'Class constructor');
     }
 
     /**
@@ -24,7 +24,7 @@ class Framework_SpellcheckerPspell extends TestCase
     public function test_languages()
     {
         if (!extension_loaded('pspell')) {
-            $this->markTestSkipped();
+            self::markTestSkipped();
         }
 
         rcube::get_instance()->config->set('spellcheck_engine', 'pspell');
@@ -33,7 +33,7 @@ class Framework_SpellcheckerPspell extends TestCase
 
         $langs = $object->languages();
 
-        $this->assertSame('English (US)', $langs['en']);
+        self::assertSame('English (US)', $langs['en']);
     }
 
     /**
@@ -42,31 +42,31 @@ class Framework_SpellcheckerPspell extends TestCase
     public function test_check()
     {
         if (!extension_loaded('pspell')) {
-            $this->markTestSkipped();
+            self::markTestSkipped();
         }
 
         rcube::get_instance()->config->set('spellcheck_engine', 'pspell');
 
         $object = new rcube_spellchecker();
 
-        $this->assertTrue($object->check('one'));
+        self::assertTrue($object->check('one'));
 
         // Test other methods that depend on the spellcheck result
-        $this->assertSame(0, $object->found());
-        $this->assertSame([], $object->get_words());
+        self::assertSame(0, $object->found());
+        self::assertSame([], $object->get_words());
 
-        $this->assertSame(
+        self::assertSame(
             '<?xml version="1.0" encoding="UTF-8"?><spellresult charschecked="3"></spellresult>',
             $object->get_xml()
         );
 
-        $this->assertFalse($object->check('ony'));
+        self::assertFalse($object->check('ony'));
 
         // Test other methods that depend on the spellcheck result
-        $this->assertSame(1, $object->found());
-        $this->assertSame(['ony'], $object->get_words());
+        self::assertSame(1, $object->found());
+        self::assertSame(['ony'], $object->get_words());
 
-        $this->assertMatchesRegularExpression(
+        self::assertMatchesRegularExpression(
             '|^<\?xml version="1.0" encoding="UTF-8"\?><spellresult charschecked="3"><c o="0" l="3">([a-zA-Z\t]+)</c></spellresult>$|',
             $object->get_xml()
         );
@@ -75,15 +75,15 @@ class Framework_SpellcheckerPspell extends TestCase
         $html = '<html><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8" /></head><body>'
             . '<p><a href="http://www.redacted.com">www.redacted.com</a></div></body></html>';
 
-        $this->assertTrue($object->check($html, true));
+        self::assertTrue($object->check($html, true));
 
         $html = '<html><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8" /></head><body>'
             . '<p><a href="http://www.redacted.com">http://www.redacted.com</a></div></body></html>';
 
-        $this->assertTrue($object->check($html, true));
+        self::assertTrue($object->check($html, true));
 
-        $this->assertTrue($object->check('one http://www.redacted.com'));
-        $this->assertTrue($object->check('one www.redacted.com'));
+        self::assertTrue($object->check('one http://www.redacted.com'));
+        self::assertTrue($object->check('one www.redacted.com'));
     }
 
     /**
@@ -92,7 +92,7 @@ class Framework_SpellcheckerPspell extends TestCase
     public function test_get_suggestions()
     {
         if (!extension_loaded('pspell')) {
-            $this->markTestSkipped();
+            self::markTestSkipped();
         }
 
         rcube::get_instance()->config->set('spellcheck_engine', 'pspell');
@@ -105,7 +105,7 @@ class Framework_SpellcheckerPspell extends TestCase
         sort($expected);
         sort($result);
 
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     /**
@@ -114,13 +114,13 @@ class Framework_SpellcheckerPspell extends TestCase
     public function test_get_words()
     {
         if (!extension_loaded('pspell')) {
-            $this->markTestSkipped();
+            self::markTestSkipped();
         }
 
         rcube::get_instance()->config->set('spellcheck_engine', 'pspell');
 
         $object = new rcube_spellchecker();
 
-        $this->assertSame(['ony'], $object->get_words('ony'));
+        self::assertSame(['ony'], $object->get_words('ony'));
     }
 }

--- a/tests/Framework/SpellcheckerTest.php
+++ b/tests/Framework/SpellcheckerTest.php
@@ -14,9 +14,9 @@ class Framework_Spellchecker extends TestCase
     {
         $object = new rcube_spellchecker();
 
-        $this->assertFalse($object->is_exception('test'));
+        self::assertFalse($object->is_exception('test'));
 
-        $this->assertTrue($object->is_exception('9'));
+        self::assertTrue($object->is_exception('9'));
 
         // TODO: Test other cases and dictionary
     }
@@ -26,7 +26,7 @@ class Framework_Spellchecker extends TestCase
      */
     public function test_add_word()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -34,6 +34,6 @@ class Framework_Spellchecker extends TestCase
      */
     public function test_remove_word()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 }

--- a/tests/Framework/SpoofcheckerTest.php
+++ b/tests/Framework/SpoofcheckerTest.php
@@ -36,6 +36,6 @@ class Framework_Spoofchecker extends TestCase
      */
     public function test_check($email, $expected)
     {
-        $this->assertSame($expected, rcube_spoofchecker::check($email));
+        self::assertSame($expected, rcube_spoofchecker::check($email));
     }
 }

--- a/tests/Framework/StringReplacerTest.php
+++ b/tests/Framework/StringReplacerTest.php
@@ -14,7 +14,7 @@ class Framework_StringReplacer extends TestCase
     {
         $sr = new rcube_string_replacer();
 
-        $this->assertInstanceOf('rcube_string_replacer', $sr, 'Class constructor');
+        self::assertInstanceOf('rcube_string_replacer', $sr, 'Class constructor');
     }
 
     /**
@@ -60,7 +60,7 @@ class Framework_StringReplacer extends TestCase
         $result = $replacer->replace($input);
         $result = $replacer->resolve($result);
 
-        $this->assertSame($output, $result);
+        self::assertSame($output, $result);
     }
 
     /**
@@ -76,8 +76,8 @@ class Framework_StringReplacer extends TestCase
         $result = $replacer->replace($input);
         $result = $replacer->resolve($result);
 
-        $this->assertStringContainsString('[<a href="http://en.wikipedia.org/wiki/Email">1</a>] to', $result, 'Numeric linkref replacements');
-        $this->assertStringContainsString('[<a href="http://www.link-ref.com">ref0</a>] repl', $result, 'Alphanum linkref replacements');
-        $this->assertStringContainsString('of [Roundcube].[ref<0]', $result, "Don't touch strings without an index entry");
+        self::assertStringContainsString('[<a href="http://en.wikipedia.org/wiki/Email">1</a>] to', $result, 'Numeric linkref replacements');
+        self::assertStringContainsString('[<a href="http://www.link-ref.com">ref0</a>] repl', $result, 'Alphanum linkref replacements');
+        self::assertStringContainsString('of [Roundcube].[ref<0]', $result, "Don't touch strings without an index entry");
     }
 }

--- a/tests/Framework/Text2HtmlTest.php
+++ b/tests/Framework/Text2HtmlTest.php
@@ -118,7 +118,7 @@ class Framework_Text2Html extends TestCase
 
         $html = $t2h->get_html();
 
-        $this->assertSame($output, $html);
+        self::assertSame($output, $html);
     }
 
     /**
@@ -135,7 +135,7 @@ class Framework_Text2Html extends TestCase
             . "[&lt;script&gt;evil&lt;/script&gt;]:##str_replacement_0##<br>\n"
             . '</div>';
 
-        $this->assertSame($expected, $html);
+        self::assertSame($expected, $html);
     }
 
     /**
@@ -152,7 +152,7 @@ class Framework_Text2Html extends TestCase
             . "<a rel=\"noreferrer\" target=\"_blank\" href=\"https://google.com\">https://google.com</a><br>\n"
             . '</div>';
 
-        $this->assertSame($expected, $html);
+        self::assertSame($expected, $html);
     }
 
     /**
@@ -173,7 +173,7 @@ class Framework_Text2Html extends TestCase
         $html = $t2h->get_html();
         $html = preg_replace('/ (rel|target)="(noreferrer|_blank)"/', '', $html);
 
-        $this->assertSame($expected, $html);
+        self::assertSame($expected, $html);
     }
 
     /**
@@ -212,6 +212,6 @@ class Framework_Text2Html extends TestCase
         $t2h = new rcube_text2html($input, false, ['space' => '_']);
         $html = $t2h->get_html();
 
-        $this->assertSame($expected, $html);
+        self::assertSame($expected, $html);
     }
 }

--- a/tests/Framework/TnefDecoderTest.php
+++ b/tests/Framework/TnefDecoderTest.php
@@ -16,13 +16,13 @@ class Framework_TnefDecoder extends TestCase
         $tnef = new rcube_tnef_decoder();
         $result = $tnef->decompress($body);
 
-        $this->assertSame('one-file', trim($result['message']['name']));
-        $this->assertCount(1, $result['attachments']);
-        $this->assertSame('application', $result['attachments'][0]['type']);
-        $this->assertSame('octet-stream', $result['attachments'][0]['subtype']);
-        $this->assertSame('AUTHORS', $result['attachments'][0]['name']);
-        $this->assertSame(244, $result['attachments'][0]['size']);
-        $this->assertMatchesRegularExpression('/Mark Simpson/', $result['attachments'][0]['stream']);
+        self::assertSame('one-file', trim($result['message']['name']));
+        self::assertCount(1, $result['attachments']);
+        self::assertSame('application', $result['attachments'][0]['type']);
+        self::assertSame('octet-stream', $result['attachments'][0]['subtype']);
+        self::assertSame('AUTHORS', $result['attachments'][0]['name']);
+        self::assertSame(244, $result['attachments'][0]['size']);
+        self::assertMatchesRegularExpression('/Mark Simpson/', $result['attachments'][0]['stream']);
     }
 
     /**
@@ -34,19 +34,19 @@ class Framework_TnefDecoder extends TestCase
         $tnef = new rcube_tnef_decoder();
         $result = $tnef->decompress($body);
 
-        $this->assertSame('Untitled.html', trim($result['message']['name']));
-        $this->assertCount(0, $result['attachments']);
-        $this->assertSame('text', $result['message']['type']);
-        $this->assertSame('html', $result['message']['subtype']);
-        $this->assertSame(5360, $result['message']['size']);
-        $this->assertMatchesRegularExpression('/^<\!DOCTYPE HTML/', $result['message']['stream']);
+        self::assertSame('Untitled.html', trim($result['message']['name']));
+        self::assertCount(0, $result['attachments']);
+        self::assertSame('text', $result['message']['type']);
+        self::assertSame('html', $result['message']['subtype']);
+        self::assertSame(5360, $result['message']['size']);
+        self::assertMatchesRegularExpression('/^<\!DOCTYPE HTML/', $result['message']['stream']);
 
         $tnef = new rcube_tnef_decoder();
         $result = $tnef->decompress($body, true);
 
-        $this->assertCount(0, $result['attachments']);
-        $this->assertSame(5360, strlen($result['message']));
-        $this->assertMatchesRegularExpression('/^<\!DOCTYPE HTML/', $result['message']);
+        self::assertCount(0, $result['attachments']);
+        self::assertSame(5360, strlen($result['message']));
+        self::assertMatchesRegularExpression('/^<\!DOCTYPE HTML/', $result['message']);
     }
 
     /**
@@ -57,19 +57,19 @@ class Framework_TnefDecoder extends TestCase
         $body = file_get_contents(TESTS_DIR . 'src/sample.rtf');
         $text = rcube_tnef_decoder::rtf2text($body);
 
-        $this->assertMatchesRegularExpression('/^[a-zA-Z1-6!&<,> \n\r\.]+$/', $text);
-        $this->assertTrue(strpos($text, 'Alex Skolnick') !== false);
-        $this->assertTrue(strpos($text, 'Heading 1') !== false);
-        $this->assertTrue(strpos($text, 'Heading 2') !== false);
-        $this->assertTrue(strpos($text, 'Heading 3') !== false);
-        $this->assertTrue(strpos($text, 'Heading 4') !== false);
-        $this->assertTrue(strpos($text, 'Heading 5') !== false);
-        $this->assertTrue(strpos($text, 'Heading 6') !== false);
-        $this->assertTrue(strpos($text, 'This is the first normal paragraph!') !== false);
-        $this->assertTrue(strpos($text, 'This is a chunk of normal text.') !== false);
-        $this->assertTrue(strpos($text, 'This is a chunk of normal text with specials, &, <, and >.') !== false);
-        $this->assertTrue(strpos($text, 'This is a second paragraph.') !== false);
-        $this->assertTrue(strpos($text, 'This is text with embedded  bold,  italic, and  underline styles.') !== false);
-        $this->assertTrue(strpos($text, 'Here is the  anchor style. And here is the  Image style.') !== false);
+        self::assertMatchesRegularExpression('/^[a-zA-Z1-6!&<,> \n\r\.]+$/', $text);
+        self::assertTrue(strpos($text, 'Alex Skolnick') !== false);
+        self::assertTrue(strpos($text, 'Heading 1') !== false);
+        self::assertTrue(strpos($text, 'Heading 2') !== false);
+        self::assertTrue(strpos($text, 'Heading 3') !== false);
+        self::assertTrue(strpos($text, 'Heading 4') !== false);
+        self::assertTrue(strpos($text, 'Heading 5') !== false);
+        self::assertTrue(strpos($text, 'Heading 6') !== false);
+        self::assertTrue(strpos($text, 'This is the first normal paragraph!') !== false);
+        self::assertTrue(strpos($text, 'This is a chunk of normal text.') !== false);
+        self::assertTrue(strpos($text, 'This is a chunk of normal text with specials, &, <, and >.') !== false);
+        self::assertTrue(strpos($text, 'This is a second paragraph.') !== false);
+        self::assertTrue(strpos($text, 'This is text with embedded  bold,  italic, and  underline styles.') !== false);
+        self::assertTrue(strpos($text, 'Here is the  anchor style. And here is the  Image style.') !== false);
     }
 }

--- a/tests/Framework/UserTest.php
+++ b/tests/Framework/UserTest.php
@@ -14,8 +14,8 @@ class Framework_User extends ActionTestCase
 
         $user = new rcube_user(1);
 
-        $this->assertSame(1, $user->ID);
-        $this->assertNull($user->language);
+        self::assertSame(1, $user->ID);
+        self::assertNull($user->language);
     }
 
     /**
@@ -27,9 +27,9 @@ class Framework_User extends ActionTestCase
 
         $user = new rcube_user(1);
 
-        $this->assertSame('test@example.com', $user->get_username());
-        $this->assertSame('test', $user->get_username('local'));
-        $this->assertSame('example.com', $user->get_username('domain'));
+        self::assertSame('test@example.com', $user->get_username());
+        self::assertSame('test', $user->get_username('local'));
+        self::assertSame('example.com', $user->get_username('domain'));
     }
 
     /**
@@ -41,25 +41,25 @@ class Framework_User extends ActionTestCase
 
         $user = new rcube_user(1);
 
-        $this->assertSame([], $user->get_prefs());
+        self::assertSame([], $user->get_prefs());
 
         $user->save_prefs(['test' => 'test'], true);
 
         $user = new rcube_user(1);
 
-        $this->assertSame(['test' => 'test'], $user->get_prefs());
+        self::assertSame(['test' => 'test'], $user->get_prefs());
 
         $hash = $user->get_hash();
 
-        $this->assertMatchesRegularExpression('/^[a-zA-Z0-9]{16}$/', $hash);
+        self::assertMatchesRegularExpression('/^[a-zA-Z0-9]{16}$/', $hash);
 
         $user = new rcube_user(1);
 
         $prefs = $user->get_prefs();
 
-        $this->assertSame('test', $prefs['test']);
-        $this->assertSame($hash, $prefs['client_hash']);
-        $this->assertSame($hash, $user->get_hash());
+        self::assertSame('test', $prefs['test']);
+        self::assertSame($hash, $prefs['client_hash']);
+        self::assertSame($hash, $user->get_hash());
     }
 
     /**
@@ -74,69 +74,69 @@ class Framework_User extends ActionTestCase
 
         $all = $user->list_emails();
 
-        $this->assertCount(2, $all);
-        $this->assertSame('test@example.com', $all[0]['email']);
-        $this->assertSame('test@example.org', $all[1]['email']);
+        self::assertCount(2, $all);
+        self::assertSame('test@example.com', $all[0]['email']);
+        self::assertSame('test@example.org', $all[1]['email']);
 
         $ident = $user->list_emails(true);
 
-        $this->assertSame('test@example.com', $ident['email']);
+        self::assertSame('test@example.com', $ident['email']);
 
         $ident = $user->get_identity();
 
-        $this->assertSame('test@example.com', $ident['email']);
+        self::assertSame('test@example.com', $ident['email']);
 
         $idents = $user->list_identities('', true);
 
-        $this->assertCount(2, $idents);
-        $this->assertSame('test@example.com', $idents[0]['email_ascii']);
-        $this->assertSame('test <test@example.com>', $idents[0]['ident']);
-        $this->assertSame('test@example.org', $idents[1]['email_ascii']);
-        $this->assertSame('test <test@example.org>', $idents[1]['ident']);
+        self::assertCount(2, $idents);
+        self::assertSame('test@example.com', $idents[0]['email_ascii']);
+        self::assertSame('test <test@example.com>', $idents[0]['ident']);
+        self::assertSame('test@example.org', $idents[1]['email_ascii']);
+        self::assertSame('test <test@example.org>', $idents[1]['ident']);
 
         $default = $idents[0]['identity_id'];
 
         $res = $user->update_identity($idents[1]['identity_id'], ['name' => 'test-new']);
 
-        $this->assertTrue($res);
+        self::assertTrue($res);
 
         $ident = $user->get_identity($idents[1]['identity_id']);
 
-        $this->assertSame('test-new', $ident['name']);
+        self::assertSame('test-new', $ident['name']);
 
         $id = $user->insert_identity([
             'name' => 'name',
             'email' => 'add@ident.com',
         ]);
 
-        $this->assertTrue(is_numeric($id));
+        self::assertTrue(is_numeric($id));
 
         $ident = $user->get_identity($id);
 
-        $this->assertSame('name', $ident['name']);
-        $this->assertSame('add@ident.com', $ident['email']);
+        self::assertSame('name', $ident['name']);
+        self::assertSame('add@ident.com', $ident['email']);
 
         $idents = $user->list_identities();
 
-        $this->assertCount(3, $idents);
+        self::assertCount(3, $idents);
 
         $ident = $user->set_default($id);
 
         $idents = $user->list_identities();
 
-        $this->assertCount(3, $idents);
-        $this->assertSame('add@ident.com', $idents[0]['email']);
+        self::assertCount(3, $idents);
+        self::assertSame('add@ident.com', $idents[0]['email']);
         $this->{'assertEquals'}(1, $idents[0]['standard']);
-        $this->assertSame('test@example.com', $idents[1]['email']);
+        self::assertSame('test@example.com', $idents[1]['email']);
         $this->{'assertEquals'}(0, $idents[1]['standard']);
-        $this->assertSame('test@example.org', $idents[2]['email']);
+        self::assertSame('test@example.org', $idents[2]['email']);
         $this->{'assertEquals'}(0, $idents[2]['standard']);
 
         $ident = $user->delete_identity($default);
 
         $idents = $user->list_identities();
 
-        $this->assertCount(2, $idents);
+        self::assertCount(2, $idents);
     }
 
     /**
@@ -154,7 +154,7 @@ class Framework_User extends ActionTestCase
 
         $this->{'assertEquals'}(1, $user->data['failed_login_counter']);
 
-        $this->assertFalse($user->is_locked());
+        self::assertFalse($user->is_locked());
     }
 
     /**
@@ -164,11 +164,11 @@ class Framework_User extends ActionTestCase
     {
         self::initDB('init');
 
-        $this->assertNull(rcube_user::query('test', 'localhost'));
+        self::assertNull(rcube_user::query('test', 'localhost'));
 
         $user = rcube_user::query('test@example.com', 'localhost');
 
-        $this->assertSame(1, $user->ID);
+        self::assertSame(1, $user->ID);
     }
 
     /**
@@ -180,14 +180,14 @@ class Framework_User extends ActionTestCase
 
         $user = rcube_user::create('new@example.com', 'localhost');
 
-        $this->assertSame('new@example.com', $user->get_username());
+        self::assertSame('new@example.com', $user->get_username());
 
         $user = new rcube_user($user->ID);
 
         $idents = $user->list_identities();
 
-        $this->assertCount(1, $idents);
-        $this->assertSame('new@example.com', $idents[0]['email']);
+        self::assertCount(1, $idents);
+        self::assertSame('new@example.com', $idents[0]['email']);
         $this->{'assertEquals'}(1, $idents[0]['standard']);
     }
 
@@ -196,6 +196,6 @@ class Framework_User extends ActionTestCase
      */
     public function test_saved_searches()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 }

--- a/tests/Framework/UtilsTest.php
+++ b/tests/Framework/UtilsTest.php
@@ -14,13 +14,13 @@ class Framework_Utils extends TestCase
     {
         date_default_timezone_set('Europe/Berlin');
 
-        $this->assertSame(date('d-M-Y H:i:s O'), rcube_utils::date_format());
-        $this->assertSame(date('Y-m-d H:i:s O'), rcube_utils::date_format('Y-m-d H:i:s O'));
+        self::assertSame(date('d-M-Y H:i:s O'), rcube_utils::date_format());
+        self::assertSame(date('Y-m-d H:i:s O'), rcube_utils::date_format('Y-m-d H:i:s O'));
 
         $result = rcube_utils::date_format('H:i:s,u O');
         $regexp = '/^' . preg_quote(date('H:i:s,')) . '(?<!000000)\d{6}' . preg_quote(date(' O')) . '$/';
 
-        $this->assertMatchesRegularExpression($regexp, $result);
+        self::assertMatchesRegularExpression($regexp, $result);
     }
 
     /**
@@ -28,9 +28,9 @@ class Framework_Utils extends TestCase
      */
     public function test_explode()
     {
-        $this->assertSame(['test', null], rcube_utils::explode(':', 'test'));
-        $this->assertSame(['test1', 'test2'], rcube_utils::explode(':', 'test1:test2'));
-        $this->assertSame(['', 'test1', 'test2'], rcube_utils::explode(':', ':test1:test2'));
+        self::assertSame(['test', null], rcube_utils::explode(':', 'test'));
+        self::assertSame(['test1', 'test2'], rcube_utils::explode(':', 'test1:test2'));
+        self::assertSame(['', 'test1', 'test2'], rcube_utils::explode(':', ':test1:test2'));
     }
 
     /**
@@ -98,7 +98,7 @@ class Framework_Utils extends TestCase
      */
     public function test_valid_email($email, $title)
     {
-        $this->assertTrue(rcube_utils::check_email($email, false), $title);
+        self::assertTrue(rcube_utils::check_email($email, false), $title);
     }
 
     /**
@@ -106,7 +106,7 @@ class Framework_Utils extends TestCase
      */
     public function test_invalid_email($email, $title)
     {
-        $this->assertFalse(rcube_utils::check_email($email, false), $title);
+        self::assertFalse(rcube_utils::check_email($email, false), $title);
     }
 
     /**
@@ -150,7 +150,7 @@ class Framework_Utils extends TestCase
      */
     public function test_valid_ip($ip)
     {
-        $this->assertTrue(rcube_utils::check_ip($ip));
+        self::assertTrue(rcube_utils::check_ip($ip));
     }
 
     /**
@@ -158,7 +158,7 @@ class Framework_Utils extends TestCase
      */
     public function test_invalid_ip($ip)
     {
-        $this->assertFalse(rcube_utils::check_ip($ip));
+        self::assertFalse(rcube_utils::check_ip($ip));
     }
 
     /**
@@ -189,7 +189,7 @@ class Framework_Utils extends TestCase
         $result = rcube_utils::rep_specialchars_output(
             $str, $type ?: 'html', $mode ?: 'strict');
 
-        $this->assertSame($result, $res);
+        self::assertSame($result, $res);
     }
 
     /**
@@ -200,17 +200,17 @@ class Framework_Utils extends TestCase
         $css = file_get_contents(TESTS_DIR . 'src/valid.css');
         $mod = rcube_utils::mod_css_styles($css, 'rcmbody');
 
-        $this->assertMatchesRegularExpression('/#rcmbody\s+\{/', $mod, 'Replace body style definition');
-        $this->assertMatchesRegularExpression('/#rcmbody h1\s\{/', $mod, 'Prefix tag styles (single)');
-        $this->assertMatchesRegularExpression('/#rcmbody h1, #rcmbody h2, #rcmbody h3, #rcmbody textarea\s+\{/', $mod, 'Prefix tag styles (multiple)');
-        $this->assertMatchesRegularExpression('/#rcmbody \.noscript\s+\{/', $mod, 'Prefix class styles');
+        self::assertMatchesRegularExpression('/#rcmbody\s+\{/', $mod, 'Replace body style definition');
+        self::assertMatchesRegularExpression('/#rcmbody h1\s\{/', $mod, 'Prefix tag styles (single)');
+        self::assertMatchesRegularExpression('/#rcmbody h1, #rcmbody h2, #rcmbody h3, #rcmbody textarea\s+\{/', $mod, 'Prefix tag styles (multiple)');
+        self::assertMatchesRegularExpression('/#rcmbody \.noscript\s+\{/', $mod, 'Prefix class styles');
 
         $css = file_get_contents(TESTS_DIR . 'src/media.css');
         $mod = rcube_utils::mod_css_styles($css, 'rcmbody');
 
-        $this->assertStringContainsString('#rcmbody table[class=w600]', $mod, 'Replace styles nested in @media block');
-        $this->assertStringContainsString('#rcmbody { width: 600px', $mod, 'Replace body selector nested in @media block');
-        $this->assertStringContainsString('#rcmbody { min-width: 474px', $mod, 'Replace body selector nested in @media block (#5811)');
+        self::assertStringContainsString('#rcmbody table[class=w600]', $mod, 'Replace styles nested in @media block');
+        self::assertStringContainsString('#rcmbody { width: 600px', $mod, 'Replace body selector nested in @media block');
+        self::assertStringContainsString('#rcmbody { min-width: 474px', $mod, 'Replace body selector nested in @media block (#5811)');
     }
 
     /**
@@ -219,69 +219,69 @@ class Framework_Utils extends TestCase
     public function test_mod_css_styles_xss()
     {
         $mod = rcube_utils::mod_css_styles("body.main2cols { background-image: url('../images/leftcol.png'); }", 'rcmbody');
-        $this->assertSame('/* evil! */', $mod, 'No url() values allowed');
+        self::assertSame('/* evil! */', $mod, 'No url() values allowed');
 
         $mod = rcube_utils::mod_css_styles("@import url('http://localhost/somestuff/css/master.css');", 'rcmbody');
-        $this->assertSame('/* evil! */', $mod, 'No import statements');
+        self::assertSame('/* evil! */', $mod, 'No import statements');
 
         $mod = rcube_utils::mod_css_styles('left:expression(document.body.offsetWidth-20)', 'rcmbody');
-        $this->assertSame('/* evil! */', $mod, 'No expression properties');
+        self::assertSame('/* evil! */', $mod, 'No expression properties');
 
         $mod = rcube_utils::mod_css_styles('left:exp/*  */ression( alert(&#039;xss3&#039;) )', 'rcmbody');
-        $this->assertSame('/* evil! */', $mod, "Don't allow encoding quirks");
+        self::assertSame('/* evil! */', $mod, "Don't allow encoding quirks");
 
         $mod = rcube_utils::mod_css_styles('background:\0075\0072\00006c( javascript:alert(&#039;xss&#039;) )', 'rcmbody');
-        $this->assertSame('/* evil! */', $mod, "Don't allow encoding quirks (2)");
+        self::assertSame('/* evil! */', $mod, "Don't allow encoding quirks (2)");
 
         $mod = rcube_utils::mod_css_styles("background: \\75 \\72 \\6C ('/images/img.png')", 'rcmbody');
-        $this->assertSame('/* evil! */', $mod, "Don't allow encoding quirks (3)");
+        self::assertSame('/* evil! */', $mod, "Don't allow encoding quirks (3)");
 
         $mod = rcube_utils::mod_css_styles("background: u\\r\\l('/images/img.png')", 'rcmbody');
-        $this->assertSame('/* evil! */', $mod, "Don't allow encoding quirks (4)");
+        self::assertSame('/* evil! */', $mod, "Don't allow encoding quirks (4)");
 
         // position: fixed (#5264)
         $mod = rcube_utils::mod_css_styles('.test { position: fixed; }', 'rcmbody');
-        $this->assertSame('#rcmbody .test { position: absolute; }', $mod, 'Replace position:fixed with position:absolute (0)');
+        self::assertSame('#rcmbody .test { position: absolute; }', $mod, 'Replace position:fixed with position:absolute (0)');
         $mod = rcube_utils::mod_css_styles(".test { position:\nfixed; }", 'rcmbody');
-        $this->assertSame('#rcmbody .test { position: absolute; }', $mod, 'Replace position:fixed with position:absolute (1)');
+        self::assertSame('#rcmbody .test { position: absolute; }', $mod, 'Replace position:fixed with position:absolute (1)');
         $mod = rcube_utils::mod_css_styles('.test { position:/**/fixed; }', 'rcmbody');
-        $this->assertSame('#rcmbody .test { position: absolute; }', $mod, 'Replace position:fixed with position:absolute (2)');
+        self::assertSame('#rcmbody .test { position: absolute; }', $mod, 'Replace position:fixed with position:absolute (2)');
 
         // position: fixed (#6898)
         $mod = rcube_utils::mod_css_styles('.test { position : fixed; top: 0; }', 'rcmbody');
-        $this->assertSame('#rcmbody .test { position: absolute; top: 0; }', $mod, 'Replace position:fixed with position:absolute (3)');
+        self::assertSame('#rcmbody .test { position: absolute; top: 0; }', $mod, 'Replace position:fixed with position:absolute (3)');
         $mod = rcube_utils::mod_css_styles('.test { position/**/: fixed; top: 0; }', 'rcmbody');
-        $this->assertSame('#rcmbody .test { position: absolute; top: 0; }', $mod, 'Replace position:fixed with position:absolute (4)');
+        self::assertSame('#rcmbody .test { position: absolute; top: 0; }', $mod, 'Replace position:fixed with position:absolute (4)');
         $mod = rcube_utils::mod_css_styles(".test { position\n: fixed; top: 0; }", 'rcmbody');
-        $this->assertSame('#rcmbody .test { position: absolute; top: 0; }', $mod, 'Replace position:fixed with position:absolute (5)');
+        self::assertSame('#rcmbody .test { position: absolute; top: 0; }', $mod, 'Replace position:fixed with position:absolute (5)');
 
         // allow data URIs with images (#5580)
         $mod = rcube_utils::mod_css_styles('body { background-image: url(data:image/png;base64,123); }', 'rcmbody');
-        $this->assertStringContainsString('#rcmbody { background-image: url(data:image/png;base64,123);', $mod, 'Data URIs in url() allowed [1]');
+        self::assertStringContainsString('#rcmbody { background-image: url(data:image/png;base64,123);', $mod, 'Data URIs in url() allowed [1]');
         $mod = rcube_utils::mod_css_styles('body { background-image: url(data:image/png;base64,123); }', 'rcmbody', true);
-        $this->assertStringContainsString('#rcmbody { background-image: url(data:image/png;base64,123);', $mod, 'Data URIs in url() allowed [2]');
+        self::assertStringContainsString('#rcmbody { background-image: url(data:image/png;base64,123);', $mod, 'Data URIs in url() allowed [2]');
 
         // Allow strict url()
         $mod = rcube_utils::mod_css_styles('body { background-image: url(http://example.com); }', 'rcmbody', true);
-        $this->assertStringContainsString('#rcmbody { background-image: url(http://example.com);', $mod, 'Strict URIs in url() allowed with $allow_remote=true');
+        self::assertStringContainsString('#rcmbody { background-image: url(http://example.com);', $mod, 'Strict URIs in url() allowed with $allow_remote=true');
 
         // XSS issue, HTML in 'content' property
         $style = "body { content: '</style><img src onerror=\"alert(\\'hello\\');\">'; color: red; }";
         $mod = rcube_utils::mod_css_styles($style, 'rcmbody', true);
-        $this->assertSame("#rcmbody { content: ''; color: red; }", $mod);
+        self::assertSame("#rcmbody { content: ''; color: red; }", $mod);
 
         $style = "body { content: '< page: ;/style>< page: ;img src onerror=\"alert(\\'hello\\');\">'; color: red; }";
         $mod = rcube_utils::mod_css_styles($style, 'rcmbody', true);
-        $this->assertSame("#rcmbody { content: '< page: ;/style>< page: ;img src onerror=\"alert('hello');\">'; color: red; }", $mod);
+        self::assertSame("#rcmbody { content: '< page: ;/style>< page: ;img src onerror=\"alert('hello');\">'; color: red; }", $mod);
 
         // Removing page: property
         $style = 'body { page: test; color: red }';
         $mod = rcube_utils::mod_css_styles($style, 'rcmbody', true);
-        $this->assertSame('#rcmbody { color: red; }', $mod);
+        self::assertSame('#rcmbody { color: red; }', $mod);
 
         $style = 'body { background:url(alert(&#039;URL!&#039;) ) }';
         $mod = rcube_utils::mod_css_styles($style, 'rcmbody', true);
-        $this->assertSame('#rcmbody { background: /* evil! */; }', $mod);
+        self::assertSame('#rcmbody { background: /* evil! */; }', $mod);
     }
 
     /**
@@ -306,34 +306,34 @@ class Framework_Utils extends TestCase
         ';
         $mod = rcube_utils::mod_css_styles($css, 'rc', true, 'test');
 
-        $this->assertStringContainsString('#rc .testone', $mod);
-        $this->assertStringContainsString('#rc .testthree.testfour', $mod);
-        $this->assertStringContainsString('#rc #testid1', $mod);
-        $this->assertStringContainsString('#rc #testid2.testclass:focus', $mod);
-        $this->assertStringContainsString('#rc .testfive:not(.testtest)', $mod);
-        $this->assertStringContainsString('#rc div .testsix', $mod);
-        $this->assertStringContainsString('#rc p > i ', $mod);
-        $this->assertStringContainsString('#rc div#testsome', $mod);
-        $this->assertStringContainsString('#rc li a.testbutton', $mod);
-        $this->assertStringNotContainsString(':root', $mod);
-        $this->assertStringContainsString('#rc * ', $mod);
-        $this->assertStringContainsString('#rc > * ', $mod);
+        self::assertStringContainsString('#rc .testone', $mod);
+        self::assertStringContainsString('#rc .testthree.testfour', $mod);
+        self::assertStringContainsString('#rc #testid1', $mod);
+        self::assertStringContainsString('#rc #testid2.testclass:focus', $mod);
+        self::assertStringContainsString('#rc .testfive:not(.testtest)', $mod);
+        self::assertStringContainsString('#rc div .testsix', $mod);
+        self::assertStringContainsString('#rc p > i ', $mod);
+        self::assertStringContainsString('#rc div#testsome', $mod);
+        self::assertStringContainsString('#rc li a.testbutton', $mod);
+        self::assertStringNotContainsString(':root', $mod);
+        self::assertStringContainsString('#rc * ', $mod);
+        self::assertStringContainsString('#rc > * ', $mod);
     }
 
     public function test_xss_entity_decode()
     {
         $mod = rcube_utils::xss_entity_decode('&lt;img/src=x onerror=alert(1)// </b>');
-        $this->assertStringNotContainsString('<img', $mod, 'Strip (encoded) tags from style node');
+        self::assertStringNotContainsString('<img', $mod, 'Strip (encoded) tags from style node');
 
         $mod = rcube_utils::xss_entity_decode('#foo:after{content:"\003Cimg/src=x onerror=alert(2)>";}');
-        $this->assertStringNotContainsString('<img', $mod, 'Strip (encoded) tags from content property');
+        self::assertStringNotContainsString('<img', $mod, 'Strip (encoded) tags from content property');
 
         $mod = rcube_utils::xss_entity_decode("background: u\\r\\00006c('/images/img.png')");
-        $this->assertStringContainsString('url(', $mod, 'Escape sequences resolving');
+        self::assertStringContainsString('url(', $mod, 'Escape sequences resolving');
 
         // #5747
         $mod = rcube_utils::xss_entity_decode('<!-- #foo { content:css; } -->');
-        $this->assertStringContainsString('#foo', $mod, 'Strip HTML comments from content, but not the content');
+        self::assertStringContainsString('#foo', $mod, 'Strip HTML comments from content, but not the content');
     }
 
     /**
@@ -412,7 +412,7 @@ class Framework_Utils extends TestCase
      */
     public function test_explode_style($input, $output)
     {
-        $this->assertSame($output, rcube_utils::parse_css_block($input));
+        self::assertSame($output, rcube_utils::parse_css_block($input));
     }
 
     /**
@@ -431,7 +431,7 @@ class Framework_Utils extends TestCase
 
         foreach ($data as $text => $res) {
             $result = rcube_utils::explode_quoted_string(',', $text);
-            $this->assertSame($res, $result);
+            self::assertSame($res, $result);
         }
     }
 
@@ -444,7 +444,7 @@ class Framework_Utils extends TestCase
 
         foreach ($data as $text) {
             $result = rcube_utils::explode_quoted_string(',', $text);
-            $this->assertSame(explode(',', $text), $result);
+            self::assertSame(explode(',', $text), $result);
         }
     }
 
@@ -462,7 +462,7 @@ class Framework_Utils extends TestCase
 
         foreach ($data as $text => $res) {
             $result = rcube_utils::explode_quoted_string('[\n\r]+', $text);
-            $this->assertSame($res, $result);
+            self::assertSame($res, $result);
         }
     }
 
@@ -476,7 +476,7 @@ class Framework_Utils extends TestCase
         ];
 
         foreach ($input as $idx => $value) {
-            $this->assertFalse(rcube_utils::get_boolean($value), "Invalid result for {$idx} test item");
+            self::assertFalse(rcube_utils::get_boolean($value), "Invalid result for {$idx} test item");
         }
 
         $input = [
@@ -484,7 +484,7 @@ class Framework_Utils extends TestCase
         ];
 
         foreach ($input as $idx => $value) {
-            $this->assertTrue(rcube_utils::get_boolean($value), "Invalid result for {$idx} test item");
+            self::assertTrue(rcube_utils::get_boolean($value), "Invalid result for {$idx} test item");
         }
     }
 
@@ -494,13 +494,13 @@ class Framework_Utils extends TestCase
     public function test_get_input_string()
     {
         $_GET = [];
-        $this->assertSame('', rcube_utils::get_input_string('test', rcube_utils::INPUT_GET));
+        self::assertSame('', rcube_utils::get_input_string('test', rcube_utils::INPUT_GET));
 
         $_GET = ['test' => 'val'];
-        $this->assertSame('val', rcube_utils::get_input_string('test', rcube_utils::INPUT_GET));
+        self::assertSame('val', rcube_utils::get_input_string('test', rcube_utils::INPUT_GET));
 
         $_GET = ['test' => ['val1', 'val2']];
-        $this->assertSame('', rcube_utils::get_input_string('test', rcube_utils::INPUT_GET));
+        self::assertSame('', rcube_utils::get_input_string('test', rcube_utils::INPUT_GET));
     }
 
     /**
@@ -516,7 +516,7 @@ class Framework_Utils extends TestCase
 
         foreach ($test as $v) {
             $result = rcube_utils::file2class($v[0], $v[1]);
-            $this->assertSame($v[2], $result);
+            self::assertSame($v[2], $result);
         }
     }
 
@@ -546,7 +546,7 @@ class Framework_Utils extends TestCase
 
         foreach ($test as $datetime => $ts) {
             $result = rcube_utils::strtotime($datetime);
-            $this->assertSame($ts, $result, "Error parsing date: {$datetime}");
+            self::assertSame($ts, $result, "Error parsing date: {$datetime}");
         }
     }
 
@@ -573,7 +573,7 @@ class Framework_Utils extends TestCase
 
         foreach ($test as $datetime => $ts) {
             $result = rcube_utils::anytodatetime($datetime);
-            $this->assertSame($ts, $result ? $result->format('Y-m-d') : false, "Error parsing date: {$datetime}");
+            self::assertSame($ts, $result ? $result->format('Y-m-d') : false, "Error parsing date: {$datetime}");
         }
 
         $test = [
@@ -583,7 +583,7 @@ class Framework_Utils extends TestCase
 
         foreach ($test as $datetime => $ts) {
             $result = rcube_utils::anytodatetime($datetime);
-            $this->assertSame($ts, $result ? $result->format('Y-m-d H:i:s') : false, "Error parsing date: {$datetime}");
+            self::assertSame($ts, $result ? $result->format('Y-m-d H:i:s') : false, "Error parsing date: {$datetime}");
         }
 
         $test = [
@@ -592,7 +592,7 @@ class Framework_Utils extends TestCase
 
         foreach ($test as $datetime => $ts) {
             $result = rcube_utils::anytodatetime($datetime);
-            $this->assertSame($ts, $result ? $result->format('Y-m-d H:i:s O') : false, "Error parsing date: {$datetime}");
+            self::assertSame($ts, $result ? $result->format('Y-m-d H:i:s O') : false, "Error parsing date: {$datetime}");
         }
     }
 
@@ -616,7 +616,7 @@ class Framework_Utils extends TestCase
                 // move to target timezone for comparison
                 $result->setTimezone($tz);
             }
-            $this->assertSame($ts, $result ? $result->format('Y-m-d H:i') : false, "Error parsing date: {$datetime}");
+            self::assertSame($ts, $result ? $result->format('Y-m-d H:i') : false, "Error parsing date: {$datetime}");
         }
     }
 
@@ -634,7 +634,7 @@ class Framework_Utils extends TestCase
 
         foreach ($test as $data) {
             $result = rcube_utils::format_datestr($data[0], $data[1]);
-            $this->assertSame($data[2], $result, 'Error formatting date: ' . $data[0]);
+            self::assertSame($data[2], $result, 'Error formatting date: ' . $data[0]);
         }
     }
 
@@ -653,7 +653,7 @@ class Framework_Utils extends TestCase
 
         foreach ($test as $input => $output) {
             $result = rcube_utils::tokenize_string($input);
-            $this->assertSame($output, $result);
+            self::assertSame($output, $result);
         }
     }
 
@@ -678,7 +678,7 @@ class Framework_Utils extends TestCase
 
         foreach ($test as $input => $output) {
             $result = rcube_utils::normalize_string($input);
-            $this->assertSame($output, $result, "Error normalizing '{$input}'");
+            self::assertSame($output, $result, "Error normalizing '{$input}'");
         }
     }
 
@@ -702,7 +702,7 @@ class Framework_Utils extends TestCase
 
         foreach ($test as $idx => $params) {
             $result = rcube_utils::words_match($params[0], $params[1]);
-            $this->assertSame($params[2], $result, "words_match() at index {$idx}");
+            self::assertSame($params[2], $result, "words_match() at index {$idx}");
         }
     }
 
@@ -727,7 +727,7 @@ class Framework_Utils extends TestCase
 
         foreach ($test as $input => $output) {
             $result = rcube_utils::is_absolute_path($input);
-            $this->assertSame($output, $result);
+            self::assertSame($output, $result);
         }
     }
 
@@ -736,11 +736,11 @@ class Framework_Utils extends TestCase
      */
     public function test_random_bytes()
     {
-        $this->assertMatchesRegularExpression('/^[a-zA-Z0-9]{15}$/', rcube_utils::random_bytes(15));
-        $this->assertSame(15, strlen(rcube_utils::random_bytes(15, true)));
-        $this->assertSame(1, strlen(rcube_utils::random_bytes(1)));
-        $this->assertSame(0, strlen(rcube_utils::random_bytes(0)));
-        $this->assertSame(0, strlen(rcube_utils::random_bytes(-1)));
+        self::assertMatchesRegularExpression('/^[a-zA-Z0-9]{15}$/', rcube_utils::random_bytes(15));
+        self::assertSame(15, strlen(rcube_utils::random_bytes(15, true)));
+        self::assertSame(1, strlen(rcube_utils::random_bytes(1)));
+        self::assertSame(0, strlen(rcube_utils::random_bytes(0)));
+        self::assertSame(0, strlen(rcube_utils::random_bytes(-1)));
     }
 
     /**
@@ -785,7 +785,7 @@ class Framework_Utils extends TestCase
      */
     public function test_idn_to_ascii($decoded, $encoded)
     {
-        $this->assertSame(rcube_utils::idn_to_ascii($decoded), $encoded);
+        self::assertSame(rcube_utils::idn_to_ascii($decoded), $encoded);
     }
 
     /**
@@ -798,7 +798,7 @@ class Framework_Utils extends TestCase
      */
     public function test_idn_to_utf8($decoded, $encoded)
     {
-        $this->assertSame(rcube_utils::idn_to_utf8($encoded), $decoded);
+        self::assertSame(rcube_utils::idn_to_utf8($encoded), $decoded);
     }
 
     /**
@@ -806,8 +806,8 @@ class Framework_Utils extends TestCase
      */
     public function test_idn_to_ascii_special()
     {
-        $this->assertSame(rcube_utils::idn_to_ascii('H.S'), 'H.S');
-        $this->assertSame(rcube_utils::idn_to_ascii('d.-h.lastname'), 'd.-h.lastname');
+        self::assertSame(rcube_utils::idn_to_ascii('H.S'), 'H.S');
+        self::assertSame(rcube_utils::idn_to_ascii('d.-h.lastname'), 'd.-h.lastname');
     }
 
     /**
@@ -830,7 +830,7 @@ class Framework_Utils extends TestCase
      */
     public function test_parse_host($name, $host, $result)
     {
-        $this->assertSame(rcube_utils::parse_host($name, $host), $result);
+        self::assertSame(rcube_utils::parse_host($name, $host), $result);
     }
 
     /**
@@ -860,7 +860,7 @@ class Framework_Utils extends TestCase
      */
     public function test_parse_host_uri($args, $result)
     {
-        $this->assertSame($result, call_user_func_array('rcube_utils::parse_host_uri', $args));
+        self::assertSame($result, call_user_func_array('rcube_utils::parse_host_uri', $args));
     }
 
     /**
@@ -887,7 +887,7 @@ class Framework_Utils extends TestCase
      */
     public function test_remove_subject_prefix($mode, $subject, $result)
     {
-        $this->assertSame(rcube_utils::remove_subject_prefix($subject, $mode), $result);
+        self::assertSame(rcube_utils::remove_subject_prefix($subject, $mode), $result);
     }
 
     /**
@@ -895,13 +895,13 @@ class Framework_Utils extends TestCase
      */
     public function test_server_name()
     {
-        $this->assertSame('localhost', rcube_utils::server_name('test'));
+        self::assertSame('localhost', rcube_utils::server_name('test'));
 
         $_SERVER['test'] = 'test.com:843';
-        $this->assertSame('test.com', rcube_utils::server_name('test'));
+        self::assertSame('test.com', rcube_utils::server_name('test'));
 
         $_SERVER['test'] = 'test.com';
-        $this->assertSame('test.com', rcube_utils::server_name('test'));
+        self::assertSame('test.com', rcube_utils::server_name('test'));
     }
 
     /**
@@ -915,27 +915,27 @@ class Framework_Utils extends TestCase
         $rcube->config->set('trusted_host_patterns', ['my.domain.tld']);
 
         StderrMock::start();
-        $this->assertSame('localhost', rcube_utils::server_name('test'));
+        self::assertSame('localhost', rcube_utils::server_name('test'));
         StderrMock::stop();
-        $this->assertSame("ERROR: Specified host is not trusted. Using 'localhost'.", trim(StderrMock::$output));
+        self::assertSame("ERROR: Specified host is not trusted. Using 'localhost'.", trim(StderrMock::$output));
 
         $rcube->config->set('trusted_host_patterns', ['test.com']);
 
         StderrMock::start();
-        $this->assertSame('test.com', rcube_utils::server_name('test'));
+        self::assertSame('test.com', rcube_utils::server_name('test'));
         StderrMock::stop();
 
         $_SERVER['test'] = 'subdomain.test.com';
 
         StderrMock::start();
-        $this->assertSame('localhost', rcube_utils::server_name('test'));
+        self::assertSame('localhost', rcube_utils::server_name('test'));
         StderrMock::stop();
 
         $rcube->config->set('trusted_host_patterns', ['^test.com$']);
         $_SERVER['test'] = '^test.com$';
 
         StderrMock::start();
-        $this->assertSame('localhost', rcube_utils::server_name('test'));
+        self::assertSame('localhost', rcube_utils::server_name('test'));
         StderrMock::stop();
     }
 }

--- a/tests/Framework/VCardTest.php
+++ b/tests/Framework/VCardTest.php
@@ -16,20 +16,20 @@ class Framework_VCard extends TestCase
     {
         $vcard = new rcube_vcard(file_get_contents($this->_srcpath('apple.vcf')));
 
-        $this->assertTrue($vcard->business, 'Identify as business record');
-        $this->assertSame('Apple Computer AG', $vcard->displayname, 'FN => displayname');
-        $this->assertSame('', $vcard->firstname, 'No person name set');
+        self::assertTrue($vcard->business, 'Identify as business record');
+        self::assertSame('Apple Computer AG', $vcard->displayname, 'FN => displayname');
+        self::assertSame('', $vcard->firstname, 'No person name set');
     }
 
     public function test_parse_two()
     {
         $vcard = new rcube_vcard(file_get_contents($this->_srcpath('johndoe.vcf')), null);
 
-        $this->assertFalse($vcard->business, 'Identify as private record');
-        $this->assertSame('John Doë', $vcard->displayname, 'Decode according to charset attribute');
-        $this->assertSame('roundcube.net', $vcard->organization, 'Test organization field');
-        $this->assertCount(2, $vcard->email, 'List two e-mail addresses');
-        $this->assertSame('roundcube@gmail.com', $vcard->email[0], 'Use PREF e-mail as primary');
+        self::assertFalse($vcard->business, 'Identify as private record');
+        self::assertSame('John Doë', $vcard->displayname, 'Decode according to charset attribute');
+        self::assertSame('roundcube.net', $vcard->organization, 'Test organization field');
+        self::assertCount(2, $vcard->email, 'List two e-mail addresses');
+        self::assertSame('roundcube@gmail.com', $vcard->email[0], 'Use PREF e-mail as primary');
     }
 
     /**
@@ -40,13 +40,13 @@ class Framework_VCard extends TestCase
         $vcard = new rcube_vcard(file_get_contents($this->_srcpath('johndoe.vcf')), null);
 
         $vcf = $vcard->export();
-        $this->assertMatchesRegularExpression('/TEL;CELL:\+987654321/', $vcf, 'Return CELL instead of MOBILE (import)');
+        self::assertMatchesRegularExpression('/TEL;CELL:\+987654321/', $vcf, 'Return CELL instead of MOBILE (import)');
 
         $vcard = new rcube_vcard();
         $vcard->set('phone', '+987654321', 'MOBILE');
 
         $vcf = $vcard->export();
-        $this->assertMatchesRegularExpression('/TEL;TYPE=cell:\+987654321/', $vcf, 'Return CELL instead of MOBILE (set)');
+        self::assertMatchesRegularExpression('/TEL;TYPE=cell:\+987654321/', $vcf, 'Return CELL instead of MOBILE (set)');
     }
 
     /**
@@ -58,10 +58,10 @@ class Framework_VCard extends TestCase
         $vcard = new rcube_vcard($vcard, null);
         $vcard = $vcard->get_assoc();
 
-        $this->assertSame('last;', $vcard['surname'], 'Decode backslash character');
-        $this->assertSame('first\\', $vcard['firstname'], 'Decode backslash character');
-        $this->assertSame('middle\;\\', $vcard['middlename'], 'Decode backslash character');
-        $this->assertSame('prefix', $vcard['prefix'], 'Decode backslash character');
+        self::assertSame('last;', $vcard['surname'], 'Decode backslash character');
+        self::assertSame('first\\', $vcard['firstname'], 'Decode backslash character');
+        self::assertSame('middle\;\\', $vcard['middlename'], 'Decode backslash character');
+        self::assertSame('prefix', $vcard['prefix'], 'Decode backslash character');
     }
 
     /**
@@ -73,9 +73,9 @@ class Framework_VCard extends TestCase
         $vcard = new rcube_vcard($vcard, null);
         $vcard = $vcard->get_assoc();
 
-        $this->assertSame('last\a', $vcard['surname'], 'Decode dummy backslash character');
-        $this->assertSame("fir\nst", $vcard['firstname'], 'Decode backslash character');
-        $this->assertSame('http://domain.tld', $vcard['website:other'][0], 'Decode dummy backslash character');
+        self::assertSame('last\a', $vcard['surname'], 'Decode dummy backslash character');
+        self::assertSame("fir\nst", $vcard['firstname'], 'Decode backslash character');
+        self::assertSame('http://domain.tld', $vcard['website:other'][0], 'Decode dummy backslash character');
     }
 
     /**
@@ -94,7 +94,7 @@ class Framework_VCard extends TestCase
 
         $result = $vcard->get_assoc();
 
-        $this->assertCount(1, $result['address:work'], 'ITEM1.-prefixed entry');
+        self::assertCount(1, $result['address:work'], 'ITEM1.-prefixed entry');
     }
 
     public function test_import()
@@ -104,13 +104,13 @@ class Framework_VCard extends TestCase
 
         $vcards = rcube_vcard::import($input);
 
-        $this->assertCount(2, $vcards, 'Detected 2 vcards');
-        $this->assertSame('Apple Computer AG', $vcards[0]->displayname, 'FN => displayname');
-        $this->assertSame('John Doë', $vcards[1]->displayname, 'Displayname with correct charset');
+        self::assertCount(2, $vcards, 'Detected 2 vcards');
+        self::assertSame('Apple Computer AG', $vcards[0]->displayname, 'FN => displayname');
+        self::assertSame('John Doë', $vcards[1]->displayname, 'Displayname with correct charset');
 
         // https://github.com/roundcube/roundcubemail/issues/1934
         $vcards2 = rcube_vcard::import(file_get_contents($this->_srcpath('thebat.vcf')));
-        $this->assertSame('Iksi=F1ski', quoted_printable_encode($vcards2[0]->surname));
+        self::assertSame('Iksi=F1ski', quoted_printable_encode($vcards2[0]->surname));
 
         $vcards[0]->reset();
         // TODO: Test reset() method
@@ -122,13 +122,13 @@ class Framework_VCard extends TestCase
 
         $vcards = rcube_vcard::import($input);
 
-        $this->assertCount(1, $vcards, 'Detected 1 vcard');
+        self::assertCount(1, $vcards, 'Detected 1 vcard');
 
         $vcard = $vcards[0]->get_assoc();
 
         // ENCODING=b case (#1488683)
-        $this->assertSame('/9j/4AAQSkZJRgABAQA', substr(base64_encode($vcard['photo']), 0, 19), 'Photo decoding');
-        $this->assertSame('Müller', $vcard['surname'], 'Unicode characters');
+        self::assertSame('/9j/4AAQSkZJRgABAQA', substr(base64_encode($vcard['photo']), 0, 19), 'Photo decoding');
+        self::assertSame('Müller', $vcard['surname'], 'Unicode characters');
 
         $input = str_replace('ENCODING=b:', 'ENCODING=base64;jpeg:', $input);
 
@@ -136,7 +136,7 @@ class Framework_VCard extends TestCase
         $vcard = $vcards[0]->get_assoc();
 
         // ENCODING=base64 case (#1489977)
-        $this->assertSame('/9j/4AAQSkZJRgABAQA', substr(base64_encode($vcard['photo']), 0, 19), 'Photo decoding');
+        self::assertSame('/9j/4AAQSkZJRgABAQA', substr(base64_encode($vcard['photo']), 0, 19), 'Photo decoding');
 
         $input = str_replace('PHOTO;ENCODING=base64;jpeg:', 'PHOTO:data:image/jpeg;base64,', $input);
 
@@ -144,7 +144,7 @@ class Framework_VCard extends TestCase
         $vcard = $vcards[0]->get_assoc();
 
         // vcard4.0 "PHOTO:data:image/jpeg;base64," case (#1489977)
-        $this->assertSame('/9j/4AAQSkZJRgABAQA', substr(base64_encode($vcard['photo']), 0, 19), 'Photo decoding');
+        self::assertSame('/9j/4AAQSkZJRgABAQA', substr(base64_encode($vcard['photo']), 0, 19), 'Photo decoding');
     }
 
     public function test_encodings()
@@ -152,7 +152,7 @@ class Framework_VCard extends TestCase
         $input = file_get_contents($this->_srcpath('utf-16_sample.vcf'));
 
         $vcards = rcube_vcard::import($input);
-        $this->assertSame('Ǽgean ĽdaMonté', $vcards[0]->displayname, 'Decoded from UTF-16');
+        self::assertSame('Ǽgean ĽdaMonté', $vcards[0]->displayname, 'Decoded from UTF-16');
     }
 
     /**
@@ -172,11 +172,11 @@ class Framework_VCard extends TestCase
 
         $result = $vcard->get_assoc();
 
-        $this->assertCount(1, $result['phone:home'], 'TYPE=home entry exists');
-        $this->assertTrue(!isset($result['phone:mobile']), 'TYPE=CELL entry ignored');
-        $this->assertCount(5, $result['address:home'][0], 'ADR with some fields missing');
-        $this->assertSame($result['address:home'][0]['zipcode'], 'zip', 'ADR with some fields missing (1)');
-        $this->assertSame($result['address:home'][0]['street'], 'street', 'ADR with some fields missing (2)');
+        self::assertCount(1, $result['phone:home'], 'TYPE=home entry exists');
+        self::assertTrue(!isset($result['phone:mobile']), 'TYPE=CELL entry ignored');
+        self::assertCount(5, $result['address:home'][0], 'ADR with some fields missing');
+        self::assertSame($result['address:home'][0]['zipcode'], 'zip', 'ADR with some fields missing (1)');
+        self::assertSame($result['address:home'][0]['street'], 'street', 'ADR with some fields missing (2)');
     }
 
     /**
@@ -188,7 +188,7 @@ class Framework_VCard extends TestCase
         $vcard = new rcube_vcard($vcard, null);
         $vcard = $vcard->get_assoc();
 
-        $this->assertSame('1980-02-02', $vcard['birthday'][0]);
+        self::assertSame('1980-02-02', $vcard['birthday'][0]);
     }
 
     /**
@@ -199,6 +199,6 @@ class Framework_VCard extends TestCase
         $vcard = new rcube_vcard();
         $result = $vcard->export();
 
-        $this->assertSame($result, "BEGIN:VCARD\r\nVERSION:3.0\r\nFN:\r\nN:;;;;\r\nEND:VCARD");
+        self::assertSame($result, "BEGIN:VCARD\r\nVERSION:3.0\r\nFN:\r\nN:;;;;\r\nEND:VCARD");
     }
 }

--- a/tests/Framework/WashtmlTest.php
+++ b/tests/Framework/WashtmlTest.php
@@ -30,9 +30,9 @@ class Framework_Washtml extends TestCase
         $washer = new rcube_washtml();
         $washed = $washer->wash($html);
 
-        $this->assertDoesNotMatchRegularExpression('/data:text/', $washed, 'Remove data:text/html links');
-        $this->assertDoesNotMatchRegularExpression('/vbscript:/', $washed, 'Remove vbscript: links');
-        $this->assertDoesNotMatchRegularExpression('/data:application/', $washed, 'Remove data:application links');
+        self::assertDoesNotMatchRegularExpression('/data:text/', $washed, 'Remove data:text/html links');
+        self::assertDoesNotMatchRegularExpression('/vbscript:/', $washed, 'Remove vbscript: links');
+        self::assertDoesNotMatchRegularExpression('/data:application/', $washed, 'Remove data:application links');
     }
 
     /**
@@ -45,8 +45,8 @@ class Framework_Washtml extends TestCase
         $washer = new rcube_washtml();
         $washed = $washer->wash($html);
 
-        $this->assertMatchesRegularExpression('|href="http://test\.com"|', $washed, 'Link href with newlines (#1488940)');
-        $this->assertMatchesRegularExpression('|href="http://domain\.com"|', $washed, 'Link href with no protocol (#7454)');
+        self::assertMatchesRegularExpression('|href="http://test\.com"|', $washed, 'Link href with newlines (#1488940)');
+        self::assertMatchesRegularExpression('|href="http://domain\.com"|', $washed, 'Link href with no protocol (#7454)');
     }
 
     /**
@@ -59,7 +59,7 @@ class Framework_Washtml extends TestCase
         $washer = new rcube_washtml();
         $washed = $washer->wash($html);
 
-        $this->assertSame("<p><img src=\"data:image/png;base64,12345\n\t67890\" /></p>", $this->cleanupResult($washed));
+        self::assertSame("<p><img src=\"data:image/png;base64,12345\n\t67890\" /></p>", $this->cleanupResult($washed));
     }
 
     /**
@@ -77,9 +77,9 @@ class Framework_Washtml extends TestCase
         $washer = new rcube_washtml();
         $washed = $washer->wash($html);
 
-        $this->assertDoesNotMatchRegularExpression('/data:text/', $washed, 'data:text/html in area href');
-        $this->assertDoesNotMatchRegularExpression('/vbscript:/', $washed, 'vbscript: in area href');
-        $this->assertDoesNotMatchRegularExpression('/javascript:/', $washed, 'javascript: in area href');
+        self::assertDoesNotMatchRegularExpression('/data:text/', $washed, 'data:text/html in area href');
+        self::assertDoesNotMatchRegularExpression('/vbscript:/', $washed, 'vbscript: in area href');
+        self::assertDoesNotMatchRegularExpression('/javascript:/', $washed, 'javascript: in area href');
     }
 
     /**
@@ -94,9 +94,9 @@ class Framework_Washtml extends TestCase
         $washer = new rcube_washtml();
         $washed = $washer->wash($html);
 
-        $this->assertDoesNotMatchRegularExpression('/<\/?object/', $washed, 'Remove object tag');
-        $this->assertDoesNotMatchRegularExpression('/<param/', $washed, 'Remove param tag');
-        $this->assertMatchesRegularExpression('/<p>/', $washed, 'Keep embedded tags');
+        self::assertDoesNotMatchRegularExpression('/<\/?object/', $washed, 'Remove object tag');
+        self::assertDoesNotMatchRegularExpression('/<param/', $washed, 'Remove param tag');
+        self::assertMatchesRegularExpression('/<p>/', $washed, 'Keep embedded tags');
     }
 
     /**
@@ -109,32 +109,32 @@ class Framework_Washtml extends TestCase
         $html = '<!--[if gte mso 10]><p>p1</p><!--><p>p2</p>';
         $washed = $this->cleanupResult($washer->wash($html));
 
-        $this->assertSame('<p>p2</p>', $washed, 'HTML conditional comments (#1489004)');
+        self::assertSame('<p>p2</p>', $washed, 'HTML conditional comments (#1489004)');
 
         $html = '<!--TestCommentInvalid><p>test</p>';
         $washed = $this->cleanupResult($washer->wash($html));
 
-        $this->assertSame('<p>test</p>', $washed, 'HTML invalid comments (#1487759)');
+        self::assertSame('<p>test</p>', $washed, 'HTML invalid comments (#1487759)');
 
         $html = '<p>para1</p><!-- comment --><p>para2</p>';
         $washed = $this->cleanupResult($washer->wash($html));
 
-        $this->assertSame('<p>para1</p><p>para2</p>', $washed, 'HTML comments - simple comment');
+        self::assertSame('<p>para1</p><p>para2</p>', $washed, 'HTML comments - simple comment');
 
         $html = '<p>para1</p><!-- <hr> comment --><p>para2</p>';
         $washed = $this->cleanupResult($washer->wash($html));
 
-        $this->assertSame('<p>para1</p><p>para2</p>', $washed, 'HTML comments - tags inside (#1489904)');
+        self::assertSame('<p>para1</p><p>para2</p>', $washed, 'HTML comments - tags inside (#1489904)');
 
         $html = '<p>para1</p><!-- comment => comment --><p>para2</p>';
         $washed = $this->cleanupResult($washer->wash($html));
 
-        $this->assertSame('<p>para1</p><p>para2</p>', $washed, 'HTML comments - bracket inside');
+        self::assertSame('<p>para1</p><p>para2</p>', $washed, 'HTML comments - bracket inside');
 
         $html = "<p><!-- span>1</span -->\n<span>2</span>\n<!-- >3</span --><span>4</span></p>";
         $washed = $this->cleanupResult($washer->wash($html));
 
-        $this->assertSame("<p>\n<span>2</span>\n<span>4</span></p>", $washed, 'HTML comments (#6464)');
+        self::assertSame("<p>\n<span>2</span>\n<span>4</span></p>", $washed, 'HTML comments (#6464)');
     }
 
     /**
@@ -147,7 +147,7 @@ class Framework_Washtml extends TestCase
         $washer = new rcube_washtml();
         $washed = $washer->wash($html);
 
-        $this->assertMatchesRegularExpression('|<textarea>test</textarea>|', $washed);
+        self::assertMatchesRegularExpression('|<textarea>test</textarea>|', $washed);
     }
 
     /**
@@ -160,7 +160,7 @@ class Framework_Washtml extends TestCase
         $washer = new rcube_washtml();
         $washed = $washer->wash($html);
 
-        $this->assertMatchesRegularExpression('|</a>|', $washed);
+        self::assertMatchesRegularExpression('|</a>|', $washed);
     }
 
     /**
@@ -202,7 +202,7 @@ class Framework_Washtml extends TestCase
         foreach ($data as $element) {
             rcube_washtml::fix_broken_lists($element[0]);
 
-            $this->assertSame($element[1], $element[0], 'Broken nested lists (#1488768)');
+            self::assertSame($element[1], $element[0], 'Broken nested lists (#1488768)');
         }
     }
 
@@ -216,8 +216,8 @@ class Framework_Washtml extends TestCase
         $washer = new rcube_washtml();
         $washed = $washer->wash($html);
 
-        $this->assertMatchesRegularExpression('|color: rgb\(241, 245, 218\)|', $washed, 'Color style (#1489697)');
-        $this->assertMatchesRegularExpression('|font-size: 10px|', $washed, 'Font-size style');
+        self::assertMatchesRegularExpression('|color: rgb\(241, 245, 218\)|', $washed, 'Color style (#1489697)');
+        self::assertMatchesRegularExpression('|font-size: 10px|', $washed, 'Font-size style');
     }
 
     /**
@@ -231,7 +231,7 @@ class Framework_Washtml extends TestCase
         $washer = new rcube_washtml();
         $washed = $washer->wash($html);
 
-        $this->assertMatchesRegularExpression(
+        self::assertMatchesRegularExpression(
             '|style="font-family: \&quot;新細明體\&quot;,\&quot;serif\&quot;; color: red"|',
             $washed,
             'Unicode chars in style attribute - quoted (#1489697)'
@@ -243,7 +243,7 @@ class Framework_Washtml extends TestCase
         $washer = new rcube_washtml();
         $washed = $washer->wash($html);
 
-        $this->assertMatchesRegularExpression(
+        self::assertMatchesRegularExpression(
             '|style="font-family: 新細明體; color: red"|',
             $washed,
             'Unicode chars in style attribute (#1489697)'
@@ -262,12 +262,12 @@ class Framework_Washtml extends TestCase
         $washer = new rcube_washtml(['html_elements' => ['body']]);
         $washed = $washer->wash($html);
 
-        $this->assertMatchesRegularExpression('|bgcolor="#fff"|', $washed, 'Body bgcolor attribute');
-        $this->assertMatchesRegularExpression('|text="#000"|', $washed, 'Body text attribute');
-        $this->assertMatchesRegularExpression('|background="#test"|', $washed, 'Body background attribute');
-        $this->assertMatchesRegularExpression('|link="#111"|', $washed, 'Body link attribute');
-        $this->assertMatchesRegularExpression('|alink="#222"|', $washed, 'Body alink attribute');
-        $this->assertMatchesRegularExpression('|vlink="#333"|', $washed, 'Body vlink attribute');
+        self::assertMatchesRegularExpression('|bgcolor="#fff"|', $washed, 'Body bgcolor attribute');
+        self::assertMatchesRegularExpression('|text="#000"|', $washed, 'Body text attribute');
+        self::assertMatchesRegularExpression('|background="#test"|', $washed, 'Body background attribute');
+        self::assertMatchesRegularExpression('|link="#111"|', $washed, 'Body link attribute');
+        self::assertMatchesRegularExpression('|alink="#222"|', $washed, 'Body alink attribute');
+        self::assertMatchesRegularExpression('|vlink="#333"|', $washed, 'Body vlink attribute');
     }
 
     /**
@@ -280,8 +280,8 @@ class Framework_Washtml extends TestCase
         $washer = new rcube_washtml();
         $washed = $washer->wash($html);
 
-        $this->assertMatchesRegularExpression('|line-height: 1;|', $washed, 'Untouched line-height (#1489917)');
-        $this->assertMatchesRegularExpression('|; height: 10px|', $washed, 'Fixed height units');
+        self::assertMatchesRegularExpression('|line-height: 1;|', $washed, 'Untouched line-height (#1489917)');
+        self::assertMatchesRegularExpression('|; height: 10px|', $washed, 'Fixed height units');
 
         $html = "<div style=\"padding: 0px\n   20px;border:1px solid #000;\"></div>";
         $expected = '<div style="padding: 0px 20px; border: 1px solid #000"></div>';
@@ -289,7 +289,7 @@ class Framework_Washtml extends TestCase
         $washer = new rcube_washtml();
         $washed = $washer->wash($html);
 
-        $this->assertTrue(strpos($washed, $expected) !== false, 'White-space and new-line characters handling');
+        self::assertTrue(strpos($washed, $expected) !== false, 'White-space and new-line characters handling');
     }
 
     /**
@@ -303,7 +303,7 @@ class Framework_Washtml extends TestCase
         $washer = new rcube_washtml();
         $washed = $washer->wash($html);
 
-        $this->assertTrue(strpos($washed, $exp) !== false, 'Style quotes XSS issue (#1490227)');
+        self::assertTrue(strpos($washed, $exp) !== false, 'Style quotes XSS issue (#1490227)');
 
         $html = "<img style=aaa:'&quot;/onerror=alert(1)//'>";
         $exp = "<img style=\"aaa: '&quot;/onerror=alert(1)//'\" />";
@@ -311,7 +311,7 @@ class Framework_Washtml extends TestCase
         $washer = new rcube_washtml();
         $washed = $washer->wash($html);
 
-        $this->assertTrue(strpos($washed, $exp) !== false, 'Style quotes XSS issue (#1490227)');
+        self::assertTrue(strpos($washed, $exp) !== false, 'Style quotes XSS issue (#1490227)');
     }
 
     /**
@@ -324,12 +324,12 @@ class Framework_Washtml extends TestCase
         $html = '<html><head><title>title1</title></head><body><p>test</p></body>';
         $washed = $washer->wash($html);
 
-        $this->assertSame('<p>test</p>', $this->cleanupResult($washed));
+        self::assertSame('<p>test</p>', $this->cleanupResult($washed));
 
         $html = '<html><head><title>title1<img />title2</title></head><body><p>test</p></body>';
         $washed = $washer->wash($html);
 
-        $this->assertSame('<p>test</p>', $this->cleanupResult($washed));
+        self::assertSame('<p>test</p>', $this->cleanupResult($washed));
     }
 
     /**
@@ -368,7 +368,7 @@ class Framework_Washtml extends TestCase
         $washer = new rcube_washtml();
         $washed = $washer->wash($svg);
 
-        $this->assertSame($washed, $exp, 'SVG content');
+        self::assertSame($washed, $exp, 'SVG content');
     }
 
     /**
@@ -486,7 +486,7 @@ class Framework_Washtml extends TestCase
         $washer = new rcube_washtml();
         $washed = $washer->wash($input);
 
-        $this->assertSame($expected, $this->cleanupResult($washed), 'SVG content');
+        self::assertSame($expected, $this->cleanupResult($washed), 'SVG content');
     }
 
     /**
@@ -552,7 +552,7 @@ class Framework_Washtml extends TestCase
         $washer = new rcube_washtml(['allow_remote' => true, 'html_elements' => ['body']]);
         $washed = $washer->wash($input);
 
-        $this->assertSame($expected, $this->cleanupResult($washed), 'XSS issues');
+        self::assertSame($expected, $this->cleanupResult($washed), 'XSS issues');
     }
 
     /**
@@ -566,7 +566,7 @@ class Framework_Washtml extends TestCase
         $washer = new rcube_washtml();
         $washed = $washer->wash($html);
 
-        $this->assertTrue(strpos($washed, $exp) !== false, 'Position:fixed (#5264)');
+        self::assertTrue(strpos($washed, $exp) !== false, 'Position:fixed (#5264)');
     }
 
     /**
@@ -614,7 +614,7 @@ class Framework_Washtml extends TestCase
         $washed = preg_replace('/>[\s\r\n\t]+</', '><', $washed);
         $exp = preg_replace('/>[\s\r\n\t]+</', '><', $exp);
 
-        $this->assertSame(trim($washed), trim($exp), 'MathML content');
+        self::assertSame(trim($washed), trim($exp), 'MathML content');
     }
 
     /**
@@ -627,16 +627,16 @@ class Framework_Washtml extends TestCase
         $washer = new rcube_washtml();
         $washed = $washer->wash($html);
 
-        $this->assertTrue($washer->extlinks);
-        $this->assertStringNotContainsString('TRACKING', $washed, 'Src attribute of <input> tag (#5583)');
+        self::assertTrue($washer->extlinks);
+        self::assertStringNotContainsString('TRACKING', $washed, 'Src attribute of <input> tag (#5583)');
 
         $html = '<video src="http://TRACKING_URL/">';
 
         $washer = new rcube_washtml();
         $washed = $washer->wash($html);
 
-        $this->assertTrue($washer->extlinks);
-        $this->assertStringNotContainsString('TRACKING', $washed, 'Src attribute of <video> tag (#5583)');
+        self::assertTrue($washer->extlinks);
+        self::assertStringNotContainsString('TRACKING', $washed, 'Src attribute of <video> tag (#5583)');
     }
 
     /**
@@ -656,14 +656,14 @@ class Framework_Washtml extends TestCase
             $washer = new rcube_washtml();
             $washed = $washer->wash($item[0]);
 
-            $this->assertSame($item[1], $washer->extlinks);
+            self::assertSame($item[1], $washer->extlinks);
         }
 
         foreach ($html as $item) {
             $washer = new rcube_washtml(['allow_remote' => true]);
             $washed = $washer->wash($item[0]);
 
-            $this->assertFalse($washer->extlinks);
+            self::assertFalse($washer->extlinks);
         }
     }
 
@@ -674,8 +674,8 @@ class Framework_Washtml extends TestCase
         $washer = new rcube_washtml();
         $washed = $washer->wash($html);
 
-        $this->assertStringNotContainsString('onerror=alert(1)>', $washed);
-        $this->assertStringContainsString('&lt;p style=&quot;x:', $washed);
+        self::assertStringNotContainsString('onerror=alert(1)>', $washed);
+        self::assertStringContainsString('&lt;p style=&quot;x:', $washed);
     }
 
     /**
@@ -691,17 +691,17 @@ class Framework_Washtml extends TestCase
             . '</p>';
         $washed = $washer->wash($html);
 
-        $this->assertStringContainsString('id="testmy-id"', $washed);
-        $this->assertStringContainsString('for="testmy-other-id"', $washed);
-        $this->assertStringContainsString('href="#testmy-id"', $washed);
-        $this->assertStringContainsString('class="testmy-class1 testmy-class2"', $washed);
+        self::assertStringContainsString('id="testmy-id"', $washed);
+        self::assertStringContainsString('for="testmy-other-id"', $washed);
+        self::assertStringContainsString('href="#testmy-id"', $washed);
+        self::assertStringContainsString('class="testmy-class1 testmy-class2"', $washed);
 
         // Make sure the anchor name is prefixed too
         $html = '<p><a href="#a">test link</a></p><a name="a">test anchor</a>';
         $washed = $washer->wash($html);
 
-        $this->assertStringContainsString('href="#testa"', $washed);
-        $this->assertStringContainsString('name="testa"', $washed);
+        self::assertStringContainsString('href="#testa"', $washed);
+        self::assertStringContainsString('name="testa"', $washed);
     }
 
     /**
@@ -714,14 +714,14 @@ class Framework_Washtml extends TestCase
         $washer = new rcube_washtml();
         $washed = $this->cleanupResult($washer->wash($html));
 
-        $this->assertSame($washed, '<p></p>');
+        self::assertSame($washed, '<p></p>');
 
         $html = '<?xml encoding="UTF-8"><html><body>HTML</body></html>';
 
         $washer = new rcube_washtml();
         $washed = $this->cleanupResult($washer->wash($html));
 
-        $this->assertSame($washed, 'HTML');
+        self::assertSame($washed, 'HTML');
     }
 
     /**
@@ -734,34 +734,34 @@ class Framework_Washtml extends TestCase
         $html = '<head></head>First line<br />Second line';
         $washed = $washer->wash($html);
 
-        $this->assertStringContainsString('First line', $washed);
+        self::assertStringContainsString('First line', $washed);
 
         $html = 'First line<br />Second line';
         $washed = $washer->wash($html);
 
-        $this->assertStringContainsString('First line', $washed);
+        self::assertStringContainsString('First line', $washed);
 
         $html = '<html>First line<br />Second line</html>';
         $washed = $washer->wash($html);
 
-        $this->assertStringContainsString('>First line', $washed);
+        self::assertStringContainsString('>First line', $washed);
 
         $html = '<html><head></head>First line<br />Second line</html>';
         $washed = $washer->wash($html);
 
-        $this->assertStringContainsString('First line', $washed);
+        self::assertStringContainsString('First line', $washed);
 
         // Not really valid HTML, but because its common in email world
         // and because it works with DOMDocument, we make sure its supported
         $html = 'First line<br /><html><body>Second line';
         $washed = $washer->wash($html);
 
-        $this->assertStringContainsString('First line', $washed);
+        self::assertStringContainsString('First line', $washed);
 
         $html = 'First line<br /><html>Second line';
         $washed = $washer->wash($html);
 
-        $this->assertStringContainsString('First line', $washed);
+        self::assertStringContainsString('First line', $washed);
     }
 
     /**
@@ -774,7 +774,7 @@ class Framework_Washtml extends TestCase
         $washer = new rcube_washtml();
         $washed = $washer->wash($html);
 
-        $this->assertTrue(strpos($washed, '<script>') === false, 'CDATA content');
+        self::assertTrue(strpos($washed, '<script>') === false, 'CDATA content');
     }
 
     /**
@@ -785,13 +785,13 @@ class Framework_Washtml extends TestCase
         $html = file_get_contents(TESTS_DIR . 'src/htmlbase.txt');
         $html = rcube_washtml::resolve_base($html);
 
-        $this->assertMatchesRegularExpression('|src="http://alec\.pl/dir/img1\.gif"|', $html, 'URI base resolving [1]');
-        $this->assertMatchesRegularExpression('|src="http://alec\.pl/dir/img2\.gif"|', $html, 'URI base resolving [2]');
-        $this->assertMatchesRegularExpression('|src="http://alec\.pl/img3\.gif"|', $html, 'URI base resolving [3]');
+        self::assertMatchesRegularExpression('|src="http://alec\.pl/dir/img1\.gif"|', $html, 'URI base resolving [1]');
+        self::assertMatchesRegularExpression('|src="http://alec\.pl/dir/img2\.gif"|', $html, 'URI base resolving [2]');
+        self::assertMatchesRegularExpression('|src="http://alec\.pl/img3\.gif"|', $html, 'URI base resolving [3]');
 
         // base resolving exceptions
-        $this->assertMatchesRegularExpression('|src="cid:theCID"|', $html, 'URI base resolving exception [1]');
-        $this->assertMatchesRegularExpression('|src="http://other\.domain\.tld/img3\.gif"|', $html, 'URI base resolving exception [2]');
+        self::assertMatchesRegularExpression('|src="cid:theCID"|', $html, 'URI base resolving exception [1]');
+        self::assertMatchesRegularExpression('|src="http://other\.domain\.tld/img3\.gif"|', $html, 'URI base resolving exception [2]');
     }
 
     /**
@@ -832,6 +832,6 @@ class Framework_Washtml extends TestCase
         $washer = new rcube_washtml();
         $washed = $this->cleanupResult($washer->wash($html));
 
-        $this->assertSame(trim($expected), $washed);
+        self::assertSame(trim($expected), $washed);
     }
 }

--- a/tests/Rcmail/ActionTest.php
+++ b/tests/Rcmail/ActionTest.php
@@ -12,13 +12,13 @@ class Rcmail_RcmailAction extends ActionTestCase
     {
         $rcmail = rcmail::get_instance();
 
-        $this->assertFalse($rcmail->config->get('ip_check'));
+        self::assertFalse($rcmail->config->get('ip_check'));
         rcmail_action::set_env_config(['ip_check']);
-        $this->assertNull($rcmail->output->get_env('ip_check'));
+        self::assertNull($rcmail->output->get_env('ip_check'));
 
         $rcmail->config->set('ip_check', true);
         rcmail_action::set_env_config(['ip_check']);
-        $this->assertTrue($rcmail->output->get_env('ip_check'));
+        self::assertTrue($rcmail->output->get_env('ip_check'));
     }
 
     /**
@@ -31,7 +31,7 @@ class Rcmail_RcmailAction extends ActionTestCase
 
         $result = rcmail_action::table_output($attrib, $table_data, ['id'], 'id');
         $expected = '<table border="0"><thead><tr><th class="id">[id]</th></tr></thead><tbody></tbody></table>';
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
 
         // TODO: More cases
     }
@@ -41,7 +41,7 @@ class Rcmail_RcmailAction extends ActionTestCase
      */
     public function test_quota_content()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -49,7 +49,7 @@ class Rcmail_RcmailAction extends ActionTestCase
      */
     public function test_display_server_error()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -57,7 +57,7 @@ class Rcmail_RcmailAction extends ActionTestCase
      */
     public function test_html_editor()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -65,7 +65,7 @@ class Rcmail_RcmailAction extends ActionTestCase
      */
     public function test_upload_init()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -73,7 +73,7 @@ class Rcmail_RcmailAction extends ActionTestCase
      */
     public function test_upload_form()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -81,7 +81,7 @@ class Rcmail_RcmailAction extends ActionTestCase
      */
     public function test_upload_error()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -89,7 +89,7 @@ class Rcmail_RcmailAction extends ActionTestCase
      */
     public function test_upload_failure()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -97,7 +97,7 @@ class Rcmail_RcmailAction extends ActionTestCase
      */
     public function test_display_uploaded_file()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -105,7 +105,7 @@ class Rcmail_RcmailAction extends ActionTestCase
      */
     public function test_autocomplete_init()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -114,7 +114,7 @@ class Rcmail_RcmailAction extends ActionTestCase
     public function test_font_defs()
     {
         $result = rcmail_action::font_defs();
-        $this->assertCount(13, $result);
+        self::assertCount(13, $result);
     }
 
     /**
@@ -123,7 +123,7 @@ class Rcmail_RcmailAction extends ActionTestCase
     public function test_fontsize_defs()
     {
         $result = rcmail_action::fontsize_defs();
-        $this->assertCount(9, $result);
+        self::assertCount(9, $result);
     }
 
     /**
@@ -132,14 +132,14 @@ class Rcmail_RcmailAction extends ActionTestCase
     public function test_show_bytes()
     {
         $result = rcmail_action::show_bytes(0);
-        $this->assertSame('0 B', $result);
+        self::assertSame('0 B', $result);
 
         $result = rcmail_action::show_bytes(2000, $unit);
-        $this->assertSame('2 KB', $result);
+        self::assertSame('2 KB', $result);
 
         $result = rcmail_action::show_bytes(2000000, $unit);
-        $this->assertSame('1.9 MB', $result);
-        $this->assertSame('MB', $unit);
+        self::assertSame('1.9 MB', $result);
+        self::assertSame('MB', $unit);
     }
 
     /**
@@ -147,7 +147,7 @@ class Rcmail_RcmailAction extends ActionTestCase
      */
     public function test_message_part_size()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -156,53 +156,53 @@ class Rcmail_RcmailAction extends ActionTestCase
     public function test_get_uids()
     {
         $result = rcmail_action::get_uids();
-        $this->assertSame([], $result);
+        self::assertSame([], $result);
 
         $_GET = [
             '_mbox' => 'Test<a>',
             '_uid' => '1',
         ];
         $result = rcmail_action::get_uids(null, null, $is_multifolder);
-        $this->assertSame(['Test<a>' => ['1']], $result);
-        $this->assertFalse($is_multifolder);
+        self::assertSame(['Test<a>' => ['1']], $result);
+        self::assertFalse($is_multifolder);
 
         $_GET = [
             '_uid' => '1-Test<a>',
         ];
         $result = rcmail_action::get_uids(null, null, $is_multifolder);
-        $this->assertSame(['Test<a>' => ['1']], $result);
-        $this->assertTrue($is_multifolder);
+        self::assertSame(['Test<a>' => ['1']], $result);
+        self::assertTrue($is_multifolder);
 
         $_GET = [
             '_uid' => '1-Test<a>,2-INBOX',
         ];
         $result = rcmail_action::get_uids(null, null, $is_multifolder);
-        $this->assertSame(['Test<a>' => ['1'], 'INBOX' => ['2']], $result);
-        $this->assertTrue($is_multifolder);
+        self::assertSame(['Test<a>' => ['1'], 'INBOX' => ['2']], $result);
+        self::assertTrue($is_multifolder);
 
         $_GET = [
             '_mbox' => 'INBOX',
             '_uid' => '*',
         ];
         $result = rcmail_action::get_uids(null, null, $is_multifolder);
-        $this->assertSame(['INBOX' => '*'], $result);
-        $this->assertFalse($is_multifolder);
+        self::assertSame(['INBOX' => '*'], $result);
+        self::assertFalse($is_multifolder);
 
         $_GET = [
             '_mbox' => 'INBOX',
             '_uid' => '1.1',
         ];
         $result = rcmail_action::get_uids(null, null, $is_multifolder);
-        $this->assertSame(['INBOX' => ['1.1']], $result);
-        $this->assertFalse($is_multifolder);
+        self::assertSame(['INBOX' => ['1.1']], $result);
+        self::assertFalse($is_multifolder);
 
         $_GET = [
             '_mbox' => 'INBOX',
             '_uid' => '1:2,56',
         ];
         $result = rcmail_action::get_uids(null, null, $is_multifolder);
-        $this->assertSame(['INBOX' => ['1:2', '56']], $result);
-        $this->assertFalse($is_multifolder);
+        self::assertSame(['INBOX' => ['1:2', '56']], $result);
+        self::assertFalse($is_multifolder);
     }
 
     /**
@@ -211,7 +211,7 @@ class Rcmail_RcmailAction extends ActionTestCase
     public function test_get_resource_content()
     {
         $result = rcmail_action::get_resource_content('blocked.gif');
-        $this->assertTrue(strpos($result, 'GIF89') === 0);
+        self::assertTrue(strpos($result, 'GIF89') === 0);
     }
 
     /**
@@ -219,7 +219,7 @@ class Rcmail_RcmailAction extends ActionTestCase
      */
     public function test_get_form_tags()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -227,7 +227,7 @@ class Rcmail_RcmailAction extends ActionTestCase
      */
     public function test_folder_list()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -235,6 +235,6 @@ class Rcmail_RcmailAction extends ActionTestCase
      */
     public function test_folder_selector()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 }

--- a/tests/Rcmail/AttachmentHandlerTest.php
+++ b/tests/Rcmail/AttachmentHandlerTest.php
@@ -15,6 +15,6 @@ class Rcmail_RcmailAttachmentHandler extends ActionTestCase
 
         $out = rcmail_attachment_handler::svg_filter($svg);
 
-        $this->assertSame($exp, $out);
+        self::assertSame($exp, $out);
     }
 }

--- a/tests/Rcmail/HtmlPageTest.php
+++ b/tests/Rcmail/HtmlPageTest.php
@@ -22,7 +22,7 @@ class Rcmail_RcmailHtmlPage extends ActionTestCase
         $expected_body = '<body><div class="rcmail-inline-message rcmail-inline-warning"><span>Test</span>'
             . '<p class="rcmail-inline-buttons"><button onclick="location.href = \'http://url\'">Button</button></p></div>';
 
-        $this->assertTrue(strpos($output, '<html') === 0);
-        $this->assertTrue(strpos($output, $expected_body) !== false);
+        self::assertTrue(strpos($output, '<html') === 0);
+        self::assertTrue(strpos($output, $expected_body) !== false);
     }
 }

--- a/tests/Rcmail/InstallTest.php
+++ b/tests/Rcmail/InstallTest.php
@@ -12,8 +12,8 @@ class Rcmail_RcmailInstall extends ActionTestCase
     {
         $install = rcmail_install::get_instance();
 
-        $this->assertSame('default', $install->getprop('unknown', 'default'));
-        $this->assertSame('', $install->getprop('unknown'));
+        self::assertSame('default', $install->getprop('unknown', 'default'));
+        self::assertSame('', $install->getprop('unknown'));
     }
 
     /**
@@ -25,23 +25,23 @@ class Rcmail_RcmailInstall extends ActionTestCase
 
         $config = $install->create_config();
 
-        $this->assertSame("<?php\n\n/* Local configuration for Roundcube Webmail */\n\n", $config);
+        self::assertSame("<?php\n\n/* Local configuration for Roundcube Webmail */\n\n", $config);
 
         $install->config = ['test' => 'test'];
         $config = $install->create_config();
 
-        $this->assertStringContainsString("\$config['test'] = 'test';", $config);
+        self::assertStringContainsString("\$config['test'] = 'test';", $config);
 
         $_POST['_test'] = 'new';
         $config = $install->create_config();
 
-        $this->assertStringContainsString("\$config['test'] = 'test';", $config);
+        self::assertStringContainsString("\$config['test'] = 'test';", $config);
 
         $_POST['_product_name'] = 'RC';
         $install->config = ['product_name' => 'Roundcube'];
         $config = $install->create_config();
 
-        $this->assertStringContainsString("\$config['product_name'] = 'RC';", $config);
+        self::assertStringContainsString("\$config['product_name'] = 'RC';", $config);
     }
 
     /**
@@ -54,7 +54,7 @@ class Rcmail_RcmailInstall extends ActionTestCase
 
         $result = $install->db_schema_check($rcmail->get_dbh());
 
-        $this->assertFalse($result);
+        self::assertFalse($result);
     }
 
     /**
@@ -67,7 +67,7 @@ class Rcmail_RcmailInstall extends ActionTestCase
 
         $result = $install->check_mime_detection();
 
-        $this->assertSame([], $result);
+        self::assertSame([], $result);
     }
 
     /**
@@ -84,7 +84,7 @@ class Rcmail_RcmailInstall extends ActionTestCase
 
         $result = $install->check_mime_extensions();
 
-        $this->assertSame([], $result);
+        self::assertSame([], $result);
     }
 
     /**
@@ -97,7 +97,7 @@ class Rcmail_RcmailInstall extends ActionTestCase
 
         $result = $install->list_skins();
 
-        $this->assertContains('elastic', $result);
+        self::assertContains('elastic', $result);
     }
 
     /**
@@ -116,7 +116,7 @@ class Rcmail_RcmailInstall extends ActionTestCase
             'enabled' => false,
         ];
 
-        $this->assertSame($acl, $result[0]);
+        self::assertSame($acl, $result[0]);
     }
 
     /**
@@ -135,9 +135,9 @@ class Rcmail_RcmailInstall extends ActionTestCase
 
         $install->merge_config();
 
-        $this->assertSame($config['imap_host'], $install->config['imap_host']);
-        $this->assertSame($config['smtp_host'], $install->config['smtp_host']);
+        self::assertSame($config['imap_host'], $install->config['imap_host']);
+        self::assertSame($config['smtp_host'], $install->config['smtp_host']);
 
-        $this->markTestIncomplete(); // TODO: More tests
+        self::markTestIncomplete(); // TODO: More tests
     }
 }

--- a/tests/Rcmail/OauthTest.php
+++ b/tests/Rcmail/OauthTest.php
@@ -75,7 +75,7 @@ class Rcmail_RcmailOauth extends ActionTestCase
         } catch (RuntimeException $e) {
         }
 
-        $this->assertTrue(isset($e));
+        self::assertTrue(isset($e));
     }
 
     /**
@@ -89,7 +89,7 @@ class Rcmail_RcmailOauth extends ActionTestCase
             'client_id' => 'some-client',
         ]);
         $body = $oauth->jwt_decode($jwt);
-        $this->assertSame($body['aud'], ['some-client']);
+        self::assertSame($body['aud'], ['some-client']);
     }
 
     /**
@@ -103,7 +103,7 @@ class Rcmail_RcmailOauth extends ActionTestCase
             'client_id' => 'some-client',
         ]);
         $body = $oauth->jwt_decode($jwt);
-        $this->assertSame($body['aud'], 'some-client');
+        self::assertSame($body['aud'], 'some-client');
     }
 
     /**
@@ -113,7 +113,7 @@ class Rcmail_RcmailOauth extends ActionTestCase
     {
         $oauth = rcmail_oauth::get_instance();
 
-        $this->assertFalse($oauth->is_enabled());
+        self::assertFalse($oauth->is_enabled());
     }
 
     /**
@@ -124,7 +124,7 @@ class Rcmail_RcmailOauth extends ActionTestCase
         $oauth = new rcmail_oauth($this->config);
         $oauth->init();
 
-        $this->assertTrue($oauth->is_enabled());
+        self::assertTrue($oauth->is_enabled());
     }
 
     /**
@@ -157,7 +157,7 @@ class Rcmail_RcmailOauth extends ActionTestCase
         $oauth->init();
 
         // if discovery succeed, should be enabled
-        $this->assertTrue($oauth->is_enabled());
+        self::assertTrue($oauth->is_enabled());
     }
 
     /**
@@ -167,7 +167,7 @@ class Rcmail_RcmailOauth extends ActionTestCase
     {
         $oauth = rcmail_oauth::get_instance();
 
-        $this->assertMatchesRegularExpression('|^http://.*/index.php/login/oauth$|', $oauth->get_redirect_uri());
+        self::assertMatchesRegularExpression('|^http://.*/index.php/login/oauth$|', $oauth->get_redirect_uri());
     }
 
     /**
@@ -189,18 +189,18 @@ class Rcmail_RcmailOauth extends ActionTestCase
             $ecode = $e->getCode();
         }
 
-        $this->assertSame(OutputHtmlMock::E_REDIRECT, $ecode);
-        $this->assertMatchesRegularExpression('|^Location: https://test/auth\?.*|', $result);
+        self::assertSame(OutputHtmlMock::E_REDIRECT, $ecode);
+        self::assertMatchesRegularExpression('|^Location: https://test/auth\?.*|', $result);
 
         [$base, $query] = explode('?', substr($result, 10));
         parse_str($query, $map);
 
-        $this->assertSame($this->config['scope'], $map['scope']);
-        $this->assertSame($this->config['client_id'], $map['client_id']);
-        $this->assertSame('code', $map['response_type']);
-        $this->assertSame($_SESSION['oauth_state'], $map['state']);
-        $this->assertSame($_SESSION['oauth_nonce'], $map['nonce']);
-        $this->assertMatchesRegularExpression('!http.*/login/oauth!', $map['redirect_uri']);
+        self::assertSame($this->config['scope'], $map['scope']);
+        self::assertSame($this->config['client_id'], $map['client_id']);
+        self::assertSame('code', $map['response_type']);
+        self::assertSame($_SESSION['oauth_state'], $map['state']);
+        self::assertSame($_SESSION['oauth_nonce'], $map['nonce']);
+        self::assertMatchesRegularExpression('!http.*/login/oauth!', $map['redirect_uri']);
     }
 
     /**
@@ -218,9 +218,9 @@ class Rcmail_RcmailOauth extends ActionTestCase
         StderrMock::stop();
 
         // should be false as state do not match
-        $this->assertFalse($response);
+        self::assertFalse($response);
 
-        $this->assertSame('ERROR: OAuth token request failed: state parameter mismatch', trim(StderrMock::$output));
+        self::assertSame('ERROR: OAuth token request failed: state parameter mismatch', trim(StderrMock::$output));
     }
 
     /**
@@ -256,8 +256,8 @@ class Rcmail_RcmailOauth extends ActionTestCase
         $response = $oauth->request_access_token('fake-code', 'random-state');
         StderrMock::stop();
 
-        $this->assertFalse($response);
-        $this->assertStringContainsString('identity\'s nonce mismatch', StderrMock::$output);
+        self::assertFalse($response);
+        self::assertStringContainsString('identity\'s nonce mismatch', StderrMock::$output);
     }
 
     /**
@@ -290,14 +290,14 @@ class Rcmail_RcmailOauth extends ActionTestCase
         $_SESSION['oauth_nonce'] = 'fake-nonce';
         $response = $oauth->request_access_token('fake-code', 'random-state');
 
-        $this->assertTrue($response);
+        self::assertTrue($response);
 
         $login_phase = getProperty($oauth, 'login_phase');
 
-        $this->assertSame('Bearer FAKE-ACCESS-TOKEN', $login_phase['authorization']);
-        $this->assertSame($this->identity['email'], $login_phase['username']);
-        $this->assertTrue(isset($login_phase['token']));
-        $this->assertFalse(isset($login_phase['token']['access_token']));
+        self::assertSame('Bearer FAKE-ACCESS-TOKEN', $login_phase['authorization']);
+        self::assertSame($this->identity['email'], $login_phase['username']);
+        self::assertTrue(isset($login_phase['token']));
+        self::assertFalse(isset($login_phase['token']['access_token']));
     }
 
     /**
@@ -332,13 +332,13 @@ class Rcmail_RcmailOauth extends ActionTestCase
         $_SESSION['oauth_nonce'] = 'fake-nonce'; // ensure nonce identiquals
         $response = $oauth->request_access_token('fake-code', 'random-state');
 
-        $this->assertTrue($response);
+        self::assertTrue($response);
         $login_phase = getProperty($oauth, 'login_phase');
 
-        $this->assertSame('Bearer FAKE-ACCESS-TOKEN', $login_phase['authorization']);
-        $this->assertSame($this->identity['email'], $login_phase['username']);
-        $this->assertTrue(isset($login_phase['token']));
-        $this->assertFalse(isset($login_phase['token']['access_token']));
+        self::assertSame('Bearer FAKE-ACCESS-TOKEN', $login_phase['authorization']);
+        self::assertSame($this->identity['email'], $login_phase['username']);
+        self::assertTrue(isset($login_phase['token']));
+        self::assertFalse(isset($login_phase['token']['access_token']));
     }
 
     /**
@@ -361,7 +361,7 @@ class Rcmail_RcmailOauth extends ActionTestCase
         ]);
         $answer = $oauth->user_create([]);
 
-        $this->assertSame($answer, [
+        self::assertSame($answer, [
             'user_name' => 'John Doe',
             'user_email' => 'jdoe@xn--fak-dma.xn--dmain-6ta',
             'language' => 'en_US',
@@ -392,9 +392,9 @@ class Rcmail_RcmailOauth extends ActionTestCase
         StderrMock::stop();
 
         // only user_name can be defined
-        $this->assertSame($answer, ['user_name' => 'John Doe']);
-        $this->assertStringContainsString('ignoring invalid email', StderrMock::$output);
-        $this->assertStringContainsString('ignoring language', StderrMock::$output);
+        self::assertSame($answer, ['user_name' => 'John Doe']);
+        self::assertStringContainsString('ignoring invalid email', StderrMock::$output);
+        self::assertStringContainsString('ignoring language', StderrMock::$output);
     }
 
     /**
@@ -403,6 +403,6 @@ class Rcmail_RcmailOauth extends ActionTestCase
     public function test_refresh_access_token()
     {
         // FIXME
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 }

--- a/tests/Rcmail/OutputCliTest.php
+++ b/tests/Rcmail/OutputCliTest.php
@@ -18,13 +18,13 @@ class Rcmail_RcmailOutputCli extends ActionTestCase
         $out = ob_get_contents();
         ob_end_clean();
 
-        $this->assertSame('[NOTICE] unknown', trim($out));
+        self::assertSame('[NOTICE] unknown', trim($out));
 
         ob_start();
         $output->show_message('errortitle', 'error');
         $out = ob_get_contents();
         ob_end_clean();
 
-        $this->assertSame('[ERROR] An error occurred!', trim($out));
+        self::assertSame('[ERROR] An error occurred!', trim($out));
     }
 }

--- a/tests/Rcmail/OutputHtmlTest.php
+++ b/tests/Rcmail/OutputHtmlTest.php
@@ -15,8 +15,8 @@ class Rcmail_RcmailOutputHtml extends TestCase
         $rcmail = rcube::get_instance();
         $output = new rcmail_output_html();
 
-        $this->assertTrue($output->check_skin('elastic'));
-        $this->assertFalse($output->check_skin('unknown'));
+        self::assertTrue($output->check_skin('elastic'));
+        self::assertFalse($output->check_skin('unknown'));
     }
 
     /**
@@ -29,8 +29,8 @@ class Rcmail_RcmailOutputHtml extends TestCase
 
         $output->set_skin('elastic');
 
-        $this->assertSame('skins/elastic/ui.js', $output->get_skin_file('ui.js'));
-        $this->assertFalse($output->get_skin_file('unknown'));
+        self::assertSame('skins/elastic/ui.js', $output->get_skin_file('ui.js'));
+        self::assertFalse($output->get_skin_file('unknown'));
     }
 
     /**
@@ -55,13 +55,13 @@ class Rcmail_RcmailOutputHtml extends TestCase
 
         $set_template->setValue($output, 'login');
         $result = $get_template_logo->invokeArgs($output, []);
-        $this->assertSame('img00', $result);
+        self::assertSame('img00', $result);
 
         $set_template->setValue($output, 'mail');
         $result = $get_template_logo->invokeArgs($output, ['small']);
-        $this->assertSame('img00', $result);
+        self::assertSame('img00', $result);
         $result = $get_template_logo->invokeArgs($output, ['link']);
-        $this->assertNull($result);
+        self::assertNull($result);
 
         $rcmail->config->set('skin_logo', [
             'elastic:login[small]' => 'img01',
@@ -76,115 +76,115 @@ class Rcmail_RcmailOutputHtml extends TestCase
 
         $set_template->setValue($output, 'login');
         $result = $get_template_logo->invokeArgs($output, ['favicon']);
-        $this->assertNull($result);
+        self::assertNull($result);
 
         $set_template->setValue($output, 'login');
         $result = $get_template_logo->invokeArgs($output, ['favicon', 'template']);
-        $this->assertSame('img02', $result);
+        self::assertSame('img02', $result);
 
         $set_template->setValue($output, 'login');
         $result = $get_template_logo->invokeArgs($output, ['favicon', 'all']);
-        $this->assertSame('img02', $result);
+        self::assertSame('img02', $result);
 
         $set_template->setValue($output, 'login');
         $result = $get_template_logo->invokeArgs($output, ['small']);
-        $this->assertSame('img01', $result);
+        self::assertSame('img01', $result);
 
         $set_template->setValue($output, 'login');
         $result = $get_template_logo->invokeArgs($output, []);
-        $this->assertSame('img02', $result);
+        self::assertSame('img02', $result);
 
         $set_template->setValue($output, 'mail');
         $result = $get_template_logo->invokeArgs($output, ['small']);
-        $this->assertSame('img03', $result);
+        self::assertSame('img03', $result);
 
         $set_template->setValue($output, 'mail');
         $result = $get_template_logo->invokeArgs($output, []);
-        $this->assertSame('img08', $result);
+        self::assertSame('img08', $result);
 
         $set_template->setValue($output, '_test_');
         $result = $get_template_logo->invokeArgs($output, []);
-        $this->assertSame('img08', $result);
+        self::assertSame('img08', $result);
 
         $set_template->setValue($output, '_test_');
         $result = $get_template_logo->invokeArgs($output, ['print']);
-        $this->assertSame('img07', $result);
+        self::assertSame('img07', $result);
 
         $set_template->setValue($output, '_test_');
         $result = $get_template_logo->invokeArgs($output, ['print', 'template']);
-        $this->assertSame('img07', $result);
+        self::assertSame('img07', $result);
 
         $set_skin->setValue($output, 'larry');
 
         $set_template->setValue($output, 'login');
         $result = $get_template_logo->invokeArgs($output, ['favicon']);
-        $this->assertNull($result);
+        self::assertNull($result);
 
         $set_template->setValue($output, 'login');
         $result = $get_template_logo->invokeArgs($output, ['favicon', 'template']);
-        $this->assertSame('img06', $result);
+        self::assertSame('img06', $result);
 
         $set_template->setValue($output, 'login');
         $result = $get_template_logo->invokeArgs($output, ['favicon', 'all']);
-        $this->assertSame('img04', $result);
+        self::assertSame('img04', $result);
 
         $set_template->setValue($output, 'login');
         $result = $get_template_logo->invokeArgs($output, ['small']);
-        $this->assertSame('img05', $result);
+        self::assertSame('img05', $result);
 
         $set_template->setValue($output, 'login');
         $result = $get_template_logo->invokeArgs($output, []);
-        $this->assertSame('img04', $result);
+        self::assertSame('img04', $result);
 
         $set_template->setValue($output, '_test_');
         $result = $get_template_logo->invokeArgs($output, []);
-        $this->assertSame('img04', $result);
+        self::assertSame('img04', $result);
 
         $set_template->setValue($output, '_test_');
         $result = $get_template_logo->invokeArgs($output, ['print', 'template']);
-        $this->assertSame('img07', $result);
+        self::assertSame('img07', $result);
 
         $set_template->setValue($output, '_test_');
         $result = $get_template_logo->invokeArgs($output, ['print']);
-        $this->assertSame('img07', $result);
+        self::assertSame('img07', $result);
 
         $set_skin->setValue($output, '_test_');
 
         $set_template->setValue($output, 'login');
         $result = $get_template_logo->invokeArgs($output, ['favicon']);
-        $this->assertNull($result);
+        self::assertNull($result);
 
         $set_template->setValue($output, 'login');
         $result = $get_template_logo->invokeArgs($output, ['print', 'template']);
-        $this->assertSame('img06', $result);
+        self::assertSame('img06', $result);
 
         $set_template->setValue($output, 'login');
         $result = $get_template_logo->invokeArgs($output, ['small']);
-        $this->assertSame('img05', $result);
+        self::assertSame('img05', $result);
 
         $set_template->setValue($output, 'login');
         $result = $get_template_logo->invokeArgs($output, []);
-        $this->assertSame('img06', $result);
+        self::assertSame('img06', $result);
 
         $set_template->setValue($output, '_test_');
         $result = $get_template_logo->invokeArgs($output, ['print']);
-        $this->assertSame('img07', $result);
+        self::assertSame('img07', $result);
 
         $set_template->setValue($output, '_test_');
         $result = $get_template_logo->invokeArgs($output, ['_test_']);
-        $this->assertNull($result);
+        self::assertNull($result);
 
         $set_template->setValue($output, '_test_');
         $result = $get_template_logo->invokeArgs($output, []);
-        $this->assertSame('img08', $result);
+        self::assertSame('img08', $result);
 
         $set_template->setValue($output, '_test_');
         $result = $get_template_logo->invokeArgs($output, ['print', 'template']);
-        $this->assertSame('img07', $result);
+        self::assertSame('img07', $result);
 
         $set_template->setValue($output, '_test_');
         $result = $get_template_logo->invokeArgs($output, ['print']);
-        $this->assertSame('img07', $result);
+        self::assertSame('img07', $result);
 
         $rcmail->config->set('skin_logo', [
             'elastic:login[small]' => 'img09',
@@ -201,41 +201,41 @@ class Rcmail_RcmailOutputHtml extends TestCase
 
         $set_template->setValue($output, 'login');
         $result = $get_template_logo->invokeArgs($output, ['small']);
-        $this->assertSame('img09', $result);
+        self::assertSame('img09', $result);
 
         $set_template->setValue($output, 'mail');
         $result = $get_template_logo->invokeArgs($output, ['small']);
-        $this->assertNull($result);
+        self::assertNull($result);
 
         $set_skin->setValue($output, '_test_');
 
         $set_template->setValue($output, 'login');
         $result = $get_template_logo->invokeArgs($output, ['small']);
-        $this->assertSame('img13', $result);
+        self::assertSame('img13', $result);
 
         $set_template->setValue($output, 'login');
         $result = $get_template_logo->invokeArgs($output, []);
-        $this->assertSame('img14', $result);
+        self::assertSame('img14', $result);
 
         $set_template->setValue($output, '_test_');
         $result = $get_template_logo->invokeArgs($output, ['print']);
-        $this->assertSame('img15', $result);
+        self::assertSame('img15', $result);
 
         $set_template->setValue($output, '_test_');
         $result = $get_template_logo->invokeArgs($output, ['_test_', 'all']);
-        $this->assertSame('img16', $result);
+        self::assertSame('img16', $result);
 
         $set_template->setValue($output, '_test_');
         $result = $get_template_logo->invokeArgs($output, ['_test_', 'template']);
-        $this->assertNull($result);
+        self::assertNull($result);
 
         $set_template->setValue($output, '_test_');
         $result = $get_template_logo->invokeArgs($output, ['_test_']);
-        $this->assertNull($result);
+        self::assertNull($result);
 
         $set_template->setValue($output, '_test_');
         $result = $get_template_logo->invokeArgs($output, []);
-        $this->assertSame('img16', $result);
+        self::assertSame('img16', $result);
 
         $rcmail->config->set('skin_logo', [
             'elastic:[print]' => 'img17',
@@ -247,27 +247,27 @@ class Rcmail_RcmailOutputHtml extends TestCase
 
         $set_template->setValue($output, 'login');
         $result = $get_template_logo->invokeArgs($output, ['print']);
-        $this->assertSame('img17', $result);
+        self::assertSame('img17', $result);
 
         $set_template->setValue($output, 'messageprint');
         $result = $get_template_logo->invokeArgs($output, ['_test_', 'template']);
-        $this->assertSame('img18', $result);
+        self::assertSame('img18', $result);
 
         $set_template->setValue($output, 'contactprint');
         $result = $get_template_logo->invokeArgs($output, ['print', 'template']);
-        $this->assertSame('img17', $result);
+        self::assertSame('img17', $result);
 
         $set_template->setValue($output, 'contactprint');
         $result = $get_template_logo->invokeArgs($output, ['_test_', 'template']);
-        $this->assertNull($result);
+        self::assertNull($result);
 
         $set_template->setValue($output, 'contactprint');
         $result = $get_template_logo->invokeArgs($output, ['_test_', 'all']);
-        $this->assertSame('img19', $result);
+        self::assertSame('img19', $result);
 
         $set_template->setValue($output, 'contactprint');
         $result = $get_template_logo->invokeArgs($output, []);
-        $this->assertSame('img19', $result);
+        self::assertSame('img19', $result);
     }
 
     /**
@@ -322,7 +322,7 @@ class Rcmail_RcmailOutputHtml extends TestCase
         $object = new rcmail_output_html();
         $result = $object->just_parse($input);
 
-        $this->assertSame($output, $result);
+        self::assertSame($output, $result);
     }
 
     /**
@@ -333,7 +333,7 @@ class Rcmail_RcmailOutputHtml extends TestCase
         $rcmail = rcube::get_instance();
         $output = new rcmail_output_html();
 
-        $this->assertNull($output->reset());
+        self::assertNull($output->reset());
     }
 
     /**
@@ -344,8 +344,8 @@ class Rcmail_RcmailOutputHtml extends TestCase
         $rcmail = rcube::get_instance();
         $output = new rcmail_output_html();
 
-        $this->assertSame('test', $output->abs_url('test'));
-        $this->assertSame('skins/elastic/ui.js', $output->abs_url('/ui.js'));
+        self::assertSame('test', $output->abs_url('test'));
+        self::assertSame('skins/elastic/ui.js', $output->abs_url('/ui.js'));
     }
 
     /**
@@ -356,9 +356,9 @@ class Rcmail_RcmailOutputHtml extends TestCase
         $rcmail = rcube::get_instance();
         $output = new rcmail_output_html();
 
-        $this->assertSame('http://test', $output->asset_url('http://test'));
-        $this->assertSame('/ui.js', $output->asset_url('/ui.js'));
-        $this->assertSame('skins/elastic/ui.js', $output->asset_url('/ui.js', true));
+        self::assertSame('http://test', $output->asset_url('http://test'));
+        self::assertSame('/ui.js', $output->asset_url('/ui.js'));
+        self::assertSame('skins/elastic/ui.js', $output->asset_url('/ui.js', true));
     }
 
     /**
@@ -369,10 +369,10 @@ class Rcmail_RcmailOutputHtml extends TestCase
         $rcmail = rcube::get_instance();
         $output = new rcmail_output_html();
 
-        $this->assertSame('', $output->button([]));
+        self::assertSame('', $output->button([]));
 
         // TODO: Test more cases
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -383,7 +383,7 @@ class Rcmail_RcmailOutputHtml extends TestCase
         $rcmail = rcube::get_instance();
         $output = new rcmail_output_html();
 
-        $this->assertSame('<form action="vendor/bin/phpunit?_task=cli" method="get">test</form>', $output->form_tag([], 'test'));
+        self::assertSame('<form action="vendor/bin/phpunit?_task=cli" method="get">test</form>', $output->form_tag([], 'test'));
     }
 
     /**
@@ -394,7 +394,7 @@ class Rcmail_RcmailOutputHtml extends TestCase
         $rcmail = rcube::get_instance();
         $output = new rcmail_output_html();
 
-        $this->assertSame('<form action="./" method="get">test</form>', $output->request_form([], 'test'));
+        self::assertSame('<form action="./" method="get">test</form>', $output->request_form([], 'test'));
     }
 
     /**
@@ -409,7 +409,7 @@ class Rcmail_RcmailOutputHtml extends TestCase
             . ' action="vendor/bin/phpunit?_task=cli" method="get"><label for="rcmqsearchbox" class="voice">Search terms</label>'
             . '<input name="_q" class="no-bs" id="rcmqsearchbox" placeholder="Search..." type="text"></form>';
 
-        $this->assertSame($expected, $output->search_form([]));
+        self::assertSame($expected, $output->search_form([]));
     }
 
     /**
@@ -422,7 +422,7 @@ class Rcmail_RcmailOutputHtml extends TestCase
 
         $result = $output->charset_selector([]);
 
-        $this->assertTrue(strpos($result, '<select name="_charset">') === 0);
-        $this->assertTrue(strpos($result, '<option value="UTF-8" selected="selected">UTF-8 (Unicode)</option>') !== false);
+        self::assertTrue(strpos($result, '<select name="_charset">') === 0);
+        self::assertTrue(strpos($result, '<option value="UTF-8" selected="selected">UTF-8 (Unicode)</option>') !== false);
     }
 }

--- a/tests/Rcmail/OutputJsonTest.php
+++ b/tests/Rcmail/OutputJsonTest.php
@@ -19,6 +19,6 @@ class Rcmail_RcmailOutputJson extends ActionTestCase
 
         $output->show_message('unknown');
 
-        $this->assertSame([['display_message', 'unknown', 'notice', 0]], $commands->getValue($output));
+        self::assertSame([['display_message', 'unknown', 'notice', 0]], $commands->getValue($output));
     }
 }

--- a/tests/Rcmail/RcmailTest.php
+++ b/tests/Rcmail/RcmailTest.php
@@ -35,8 +35,8 @@ class Rcmail_Rcmail extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(OutputJsonMock::E_EXIT, $e->getCode());
-        $this->assertTrue(empty($result['exec']));
+        self::assertSame(OutputJsonMock::E_EXIT, $e->getCode());
+        self::assertTrue(empty($result['exec']));
 
         // Test refresh action handler
         $output = $this->initOutput(rcmail_action::MODE_AJAX, 'settings', 'refresh');
@@ -48,8 +48,8 @@ class Rcmail_Rcmail extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertSame(OutputJsonMock::E_EXIT, $e->getCode());
-        $this->assertTrue(empty($result['exec']));
+        self::assertSame(OutputJsonMock::E_EXIT, $e->getCode());
+        self::assertTrue(empty($result['exec']));
 
         // TODO: Test non-existing action handler
     }
@@ -63,11 +63,11 @@ class Rcmail_Rcmail extends ActionTestCase
 
         $result = $rcmail->get_address_book(0);
 
-        $this->assertInstanceOf('rcube_contacts', $result);
+        self::assertInstanceOf('rcube_contacts', $result);
 
         $source_id = $rcmail->get_address_book_id($result);
 
-        $this->assertSame(0, $source_id);
+        self::assertSame(0, $source_id);
     }
 
     /**
@@ -75,7 +75,7 @@ class Rcmail_Rcmail extends ActionTestCase
      */
     public function test_get_compose_responses()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -83,7 +83,7 @@ class Rcmail_Rcmail extends ActionTestCase
      */
     public function test_login()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -91,7 +91,7 @@ class Rcmail_Rcmail extends ActionTestCase
      */
     public function test_logout_actions()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -103,15 +103,15 @@ class Rcmail_Rcmail extends ActionTestCase
 
         $result = $rcmail->get_address_sources();
 
-        $this->assertCount(3, $result);
-        $this->assertSame('Personal Addresses', $result[0]['name']);
-        $this->assertSame('Collected Recipients', $result[1]['name']);
-        $this->assertSame('Trusted Senders', $result[2]['name']);
+        self::assertCount(3, $result);
+        self::assertSame('Personal Addresses', $result[0]['name']);
+        self::assertSame('Collected Recipients', $result[1]['name']);
+        self::assertSame('Trusted Senders', $result[2]['name']);
 
         $result = $rcmail->get_address_sources(true);
 
-        $this->assertCount(1, $result);
-        $this->assertSame('Personal Addresses', $result[0]['name']);
+        self::assertCount(1, $result);
+        self::assertSame('Personal Addresses', $result[0]['name']);
 
         // TODO: Test more cases
     }
@@ -123,32 +123,32 @@ class Rcmail_Rcmail extends ActionTestCase
     {
         $rcmail = rcmail::get_instance();
 
-        $this->assertSame(
+        self::assertSame(
             '/sub/?_task=cli&_action=test',
             $rcmail->url('test'),
             'Action only'
         );
 
-        $this->assertSame(
+        self::assertSame(
             '/sub/?_task=cli&_action=test&_a=AA',
             $rcmail->url(['action' => 'test', 'a' => 'AA']),
             'Unprefixed parameters'
         );
 
-        $this->assertSame(
+        self::assertSame(
             '/sub/?_task=cli&_action=test&_b=BB',
             $rcmail->url(['_action' => 'test', '_b' => 'BB', '_c' => null]),
             'Prefixed parameters (skip empty)'
         );
-        $this->assertSame('/sub/?_task=cli', $rcmail->url([]), 'Empty input');
+        self::assertSame('/sub/?_task=cli', $rcmail->url([]), 'Empty input');
 
-        $this->assertSame(
+        self::assertSame(
             '/sub/?_task=cli&_action=test&_mode=ABS',
             $rcmail->url(['_action' => 'test', '_mode' => 'ABS'], true),
             'Absolute URL'
         );
 
-        $this->assertSame(
+        self::assertSame(
             'https://mail.example.org/sub/?_task=calendar&_action=test&_mode=FQ',
             $rcmail->url(['task' => 'calendar', '_action' => 'test', '_mode' => 'FQ'], true, true),
             'Fully Qualified URL'
@@ -156,36 +156,36 @@ class Rcmail_Rcmail extends ActionTestCase
 
         // with different SCRIPT_NAME values
         $_SERVER['SCRIPT_NAME'] = 'index.php';
-        $this->assertSame(
+        self::assertSame(
             '/?_task=cli&_action=test&_mode=ABS',
             $rcmail->url(['_action' => 'test', '_mode' => 'ABS'], true),
             'Absolute URL (root)'
         );
 
         $_SERVER['SCRIPT_NAME'] = '';
-        $this->assertSame(
+        self::assertSame(
             '/?_task=cli&_action=test&_mode=ABS',
             $rcmail->url(['_action' => 'test', '_mode' => 'ABS'], true),
             'Absolute URL (root)'
         );
 
         $_SERVER['REQUEST_URI'] = '/rc/?_task=mail';
-        $this->assertSame('/rc/?_task=cli', $rcmail->url([]), 'Empty input with REQUEST_URI prefix');
+        self::assertSame('/rc/?_task=cli', $rcmail->url([]), 'Empty input with REQUEST_URI prefix');
 
         $rcmail->config->set('request_path', 'X_FORWARDED_PATH');
-        $this->assertSame('/proxied/?_task=cli', $rcmail->url([]), 'Consider request_path config (_SERVER)');
+        self::assertSame('/proxied/?_task=cli', $rcmail->url([]), 'Consider request_path config (_SERVER)');
 
         $rcmail->config->set('request_path', '/test');
-        $this->assertSame('/test/?_task=cli', $rcmail->url([]), 'Consider request_path config (/path)');
+        self::assertSame('/test/?_task=cli', $rcmail->url([]), 'Consider request_path config (/path)');
         $rcmail->config->set('request_path', '/test/');
-        $this->assertSame('/test/?_task=cli', $rcmail->url([]), 'Consider request_path config (/path/)');
+        self::assertSame('/test/?_task=cli', $rcmail->url([]), 'Consider request_path config (/path/)');
 
         $_SERVER['REQUEST_URI'] = null;
         $rcmail->config->set('request_path', null);
 
         $_SERVER['HTTPS'] = false;
         $_SERVER['SERVER_PORT'] = '8080';
-        $this->assertSame(
+        self::assertSame(
             'http://mail.example.org:8080/?_task=cli&_action=test&_mode=ABS',
             $rcmail->url(['_action' => 'test', '_mode' => 'ABS'], true, true),
             'Full URL with port'
@@ -197,7 +197,7 @@ class Rcmail_Rcmail extends ActionTestCase
      */
     public function test_request_security_check()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -213,22 +213,22 @@ class Rcmail_Rcmail extends ActionTestCase
 
         $contact_id = $rcmail->contact_create(['email' => 'test@xn--e1aybc.xn--p1ai'], $source, $error);
 
-        $this->assertNull($error);
-        $this->assertTrue($contact_id != false);
+        self::assertNull($error);
+        self::assertTrue($contact_id != false);
 
         $sql_result = $db->query("SELECT * FROM `contacts` WHERE `contact_id` = {$contact_id}");
         $contact = $db->fetch_assoc($sql_result);
 
-        $this->assertSame('test@тест.рф', $contact['email']);
-        $this->assertSame('Test', $contact['name']);
+        self::assertSame('test@тест.рф', $contact['email']);
+        self::assertSame('Test', $contact['name']);
 
         $result = $rcmail->contact_exists('test@xn--e1aybc.xn--p1ai', rcube_addressbook::TYPE_DEFAULT);
 
-        $this->assertTrue($result);
+        self::assertTrue($result);
 
         $result = $rcmail->contact_exists('test@тест.рф', rcube_addressbook::TYPE_DEFAULT);
 
-        $this->assertTrue($result);
+        self::assertTrue($result);
     }
 
     /**
@@ -240,7 +240,7 @@ class Rcmail_Rcmail extends ActionTestCase
 
         $date = $rcmail->user_date();
 
-        $this->assertMatchesRegularExpression('/[a-z]{3}, [0-9]{1,2} [a-z]{3} ' . date('Y H:i:s') . ' [+-][0-9]{4}/i', $date);
+        self::assertMatchesRegularExpression('/[a-z]{3}, [0-9]{1,2} [a-z]{3} ' . date('Y H:i:s') . ' [+-][0-9]{4}/i', $date);
     }
 
     /**
@@ -251,10 +251,10 @@ class Rcmail_Rcmail extends ActionTestCase
         $rcmail = rcmail::get_instance();
 
         $result = $rcmail->find_asset('non-existing.js');
-        $this->assertNull($result);
+        self::assertNull($result);
 
         $result = $rcmail->find_asset('program/resources/blocked.gif');
-        $this->assertSame('program/resources/blocked.gif', $result);
+        self::assertSame('program/resources/blocked.gif', $result);
     }
 
     /**
@@ -269,18 +269,18 @@ class Rcmail_Rcmail extends ActionTestCase
         $rcmail->config->set('prettydate', true);
 
         $date = $rcmail->format_date(date('Y-m-d H:i:s'));
-        $this->assertSame('Today ' . date('H:i'), $date);
+        self::assertSame('Today ' . date('H:i'), $date);
 
         // Test various formats
         setlocale(\LC_ALL, 'en_US');
         ini_set('intl.default_locale', 'en_US');
         $date = new DateTime('2020-06-01 12:20:30', new DateTimeZone('UTC'));
 
-        $this->assertSame('2020-06-01 12:20', $rcmail->format_date($date));
-        $this->assertSame('2020-06-01 12:20', $rcmail->format_date($date, 'Y-m-d H:i'));
-        $this->assertSame(' Mon', $rcmail->format_date($date, ' D'));
-        $this->assertSame('D Monday', $rcmail->format_date($date, '\D l'));
-        $this->assertSame('Jun June', $rcmail->format_date($date, 'M F'));
+        self::assertSame('2020-06-01 12:20', $rcmail->format_date($date));
+        self::assertSame('2020-06-01 12:20', $rcmail->format_date($date, 'Y-m-d H:i'));
+        self::assertSame(' Mon', $rcmail->format_date($date, ' D'));
+        self::assertSame('D Monday', $rcmail->format_date($date, '\D l'));
+        self::assertSame('Jun June', $rcmail->format_date($date, 'M F'));
         $date_x = '6/1/20, 12:20 PM';
         // @phpstan-ignore-next-line
         if (defined('INTL_ICU_VERSION') && version_compare(\INTL_ICU_VERSION, '72.1', '>=')) {
@@ -288,8 +288,8 @@ class Rcmail_Rcmail extends ActionTestCase
             // is used instead of an ASCII space before the meridian.
             $date_x = "6/1/20, 12:20\u{202f}PM";
         }
-        $this->assertSame($date_x, $rcmail->format_date($date, 'x'));
-        $this->assertSame('1591014030', $rcmail->format_date($date, 'U'));
-        $this->assertSame('2020-06-01T12:20:30+00:00', $rcmail->format_date($date, 'c'));
+        self::assertSame($date_x, $rcmail->format_date($date, 'x'));
+        self::assertSame('1591014030', $rcmail->format_date($date, 'U'));
+        self::assertSame('2020-06-01T12:20:30+00:00', $rcmail->format_date($date, 'c'));
     }
 }

--- a/tests/Rcmail/ResendMailTest.php
+++ b/tests/Rcmail/ResendMailTest.php
@@ -16,6 +16,6 @@ class Rcmail_RcmailResendMail extends TestCase
 
         $result = $mail->headers();
 
-        $this->assertSame([], $result);
+        self::assertSame([], $result);
     }
 }

--- a/tests/Rcmail/SendmailTest.php
+++ b/tests/Rcmail/SendmailTest.php
@@ -18,10 +18,10 @@ class Rcmail_RcmailSendmail extends ActionTestCase
         $sendmail = new rcmail_sendmail();
         $headers = $sendmail->headers_input();
 
-        $this->assertSame('Test1 Test2', $headers['Subject']);
-        $this->assertSame('Sender <test@domain.tld>', $headers['From']);
-        $this->assertSame('undisclosed-recipients:;', $headers['To']);
-        $this->assertSame('test@domain.tld', $headers['X-Sender']);
+        self::assertSame('Test1 Test2', $headers['Subject']);
+        self::assertSame('Sender <test@domain.tld>', $headers['From']);
+        self::assertSame('undisclosed-recipients:;', $headers['To']);
+        self::assertSame('test@domain.tld', $headers['X-Sender']);
     }
 
     /**
@@ -29,7 +29,7 @@ class Rcmail_RcmailSendmail extends ActionTestCase
      */
     public function test_set_message_encoding()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -37,7 +37,7 @@ class Rcmail_RcmailSendmail extends ActionTestCase
      */
     public function test_create_message()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -45,7 +45,7 @@ class Rcmail_RcmailSendmail extends ActionTestCase
      */
     public function test_deliver_message()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -53,7 +53,7 @@ class Rcmail_RcmailSendmail extends ActionTestCase
      */
     public function test_save_message()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -61,7 +61,7 @@ class Rcmail_RcmailSendmail extends ActionTestCase
      */
     public function test_header_received()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -79,9 +79,9 @@ class Rcmail_RcmailSendmail extends ActionTestCase
 
         $result = $sendmail->get_identity($identity['identity_id']);
 
-        $this->assertSame($identity['identity_id'], $result['identity_id']);
-        $this->assertSame('test <test@example.com>', $result['string']);
-        $this->assertSame('test@example.com', $result['mailto']);
+        self::assertSame($identity['identity_id'], $result['identity_id']);
+        self::assertSame('test <test@example.com>', $result['string']);
+        self::assertSame('test@example.com', $result['mailto']);
     }
 
     /**
@@ -89,7 +89,7 @@ class Rcmail_RcmailSendmail extends ActionTestCase
      */
     public function test_extract_inline_images()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -154,7 +154,7 @@ class Rcmail_RcmailSendmail extends ActionTestCase
         $sendmail = new rcmail_sendmail();
         $sendmail->options['charset'] = $charset;
 
-        $this->assertSame($output, $sendmail->email_input_format($input));
+        self::assertSame($output, $sendmail->email_input_format($input));
     }
 
     /**
@@ -162,7 +162,7 @@ class Rcmail_RcmailSendmail extends ActionTestCase
      */
     public function test_generic_message_footer()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -172,23 +172,23 @@ class Rcmail_RcmailSendmail extends ActionTestCase
     {
         $input = ['test' => 'test'];
         $result = rcmail_sendmail::draftinfo_encode($input);
-        $this->assertSame('test=test', $result);
-        $this->assertSame($input, rcmail_sendmail::draftinfo_decode($result));
+        self::assertSame('test=test', $result);
+        self::assertSame($input, rcmail_sendmail::draftinfo_decode($result));
 
         $input = ['folder' => 'test'];
         $result = rcmail_sendmail::draftinfo_encode($input);
-        $this->assertSame('folder=B::dGVzdA==', $result);
-        $this->assertSame($input, rcmail_sendmail::draftinfo_decode($result));
+        self::assertSame('folder=B::dGVzdA==', $result);
+        self::assertSame($input, rcmail_sendmail::draftinfo_decode($result));
 
         $input = ['test' => 'test;test'];
         $result = rcmail_sendmail::draftinfo_encode($input);
-        $this->assertSame('test=B::dGVzdDt0ZXN0', $result);
-        $this->assertSame($input, rcmail_sendmail::draftinfo_decode($result));
+        self::assertSame('test=B::dGVzdDt0ZXN0', $result);
+        self::assertSame($input, rcmail_sendmail::draftinfo_decode($result));
 
         $input = ['test' => 'test;test', 'a' => 'b'];
         $result = rcmail_sendmail::draftinfo_encode($input);
-        $this->assertSame('test=B::dGVzdDt0ZXN0; a=b', $result);
-        $this->assertSame($input, rcmail_sendmail::draftinfo_decode($result));
+        self::assertSame('test=B::dGVzdDt0ZXN0; a=b', $result);
+        self::assertSame($input, rcmail_sendmail::draftinfo_decode($result));
     }
 
     /**
@@ -208,13 +208,13 @@ class Rcmail_RcmailSendmail extends ActionTestCase
         $sendmail->options['message'] = $message;
 
         $result = $sendmail->headers_output(['part' => 'to']);
-        $this->assertTrue(strpos($result, '<textarea name="_to" spellcheck="false"></textarea>') !== false);
+        self::assertTrue(strpos($result, '<textarea name="_to" spellcheck="false"></textarea>') !== false);
 
         $result = $sendmail->headers_output(['part' => 'from']);
-        $this->assertTrue(strpos($result, '<input name="_from" class="from_address" type="text">') !== false);
+        self::assertTrue(strpos($result, '<input name="_from" class="from_address" type="text">') !== false);
 
         // TODO: Test part=from with identities
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 
     /**
@@ -222,10 +222,10 @@ class Rcmail_RcmailSendmail extends ActionTestCase
      */
     public function test_reply_subject()
     {
-        $this->assertSame('Re: Test subject', rcmail_sendmail::reply_subject('Test subject'));
-        $this->assertSame('Re: Test subject', rcmail_sendmail::reply_subject('Re: Test subject'));
-        $this->assertSame('Re: Test subject', rcmail_sendmail::reply_subject('Re: Re: Test subject'));
-        $this->assertSame('Re: Test subject', rcmail_sendmail::reply_subject('Re: Test subject (Was: Something else)'));
+        self::assertSame('Re: Test subject', rcmail_sendmail::reply_subject('Test subject'));
+        self::assertSame('Re: Test subject', rcmail_sendmail::reply_subject('Re: Test subject'));
+        self::assertSame('Re: Test subject', rcmail_sendmail::reply_subject('Re: Re: Test subject'));
+        self::assertSame('Re: Test subject', rcmail_sendmail::reply_subject('Re: Test subject (Was: Something else)'));
     }
 
     /**
@@ -241,7 +241,7 @@ class Rcmail_RcmailSendmail extends ActionTestCase
 
         $result = $sendmail->compose_subject([]);
 
-        $this->assertTrue(strpos($result, '<input name="_subject" spellcheck="true" value="test" type="text">') !== false);
+        self::assertTrue(strpos($result, '<input name="_subject" spellcheck="true" value="test" type="text">') !== false);
     }
 
     /**
@@ -255,7 +255,7 @@ class Rcmail_RcmailSendmail extends ActionTestCase
 
         $result = $sendmail->mdn_checkbox([]);
 
-        $this->assertTrue(strpos($result, '<input id="receipt" name="_mdn" value="1" type="checkbox">') !== false);
+        self::assertTrue(strpos($result, '<input id="receipt" name="_mdn" value="1" type="checkbox">') !== false);
     }
 
     /**
@@ -269,7 +269,7 @@ class Rcmail_RcmailSendmail extends ActionTestCase
 
         $result = $sendmail->dsn_checkbox([]);
 
-        $this->assertTrue(strpos($result, '<input id="dsn" name="_dsn" value="1" type="checkbox">') !== false);
+        self::assertTrue(strpos($result, '<input id="dsn" name="_dsn" value="1" type="checkbox">') !== false);
     }
 
     /**
@@ -291,7 +291,7 @@ class Rcmail_RcmailSendmail extends ActionTestCase
             . '<option value="1">Highest</option>'
             . '</select>';
 
-        $this->assertTrue(strpos($result, $expected) !== false);
+        self::assertTrue(strpos($result, $expected) !== false);
     }
 
     /**
@@ -307,7 +307,7 @@ class Rcmail_RcmailSendmail extends ActionTestCase
         $message->headers->cc = '';
 
         $result = rcmail_sendmail::identity_select($message, []);
-        $this->assertNull($result);
+        self::assertNull($result);
 
         $identities = [
             [
@@ -343,26 +343,26 @@ class Rcmail_RcmailSendmail extends ActionTestCase
         $message->headers->from = 'from@other.domain.tld';
 
         $result = rcmail_sendmail::identity_select($message, $identities);
-        $this->assertSame($identities[2], $result);
+        self::assertSame($identities[2], $result);
 
         $message->headers->to = 'ident1@domain.tld';
         $message->headers->from = 'from@other.domain.tld';
 
         $result = rcmail_sendmail::identity_select($message, $identities);
-        $this->assertSame($identities[1], $result);
+        self::assertSame($identities[1], $result);
 
         // #7211
         $message->headers->to = 'ident1@domain.tld';
         $message->headers->from = 'ident2@domain.tld';
 
         $result = rcmail_sendmail::identity_select($message, $identities);
-        $this->assertSame($identities[1], $result);
+        self::assertSame($identities[1], $result);
 
         $message->headers->to = 'ident2@domain.tld';
         $message->headers->from = 'ident1@domain.tld';
 
         $result = rcmail_sendmail::identity_select($message, $identities);
-        $this->assertSame($identities[2], $result);
+        self::assertSame($identities[2], $result);
     }
 
     /**
@@ -393,12 +393,12 @@ class Rcmail_RcmailSendmail extends ActionTestCase
         $message->headers->set('Return-Path', '<some_thing@domain.tld>');
         $res = rcmail_sendmail::identity_select($message, $identities);
 
-        $this->assertSame($identities[0], $res);
+        self::assertSame($identities[0], $res);
 
         $message->headers->set('Return-Path', '<thing@domain.tld>');
         $res = rcmail_sendmail::identity_select($message, $identities);
 
-        $this->assertSame($identities[1], $res);
+        self::assertSame($identities[1], $res);
     }
 
     /**
@@ -434,19 +434,19 @@ class Rcmail_RcmailSendmail extends ActionTestCase
 
         $message->headers->set('From', '<addr2@domain.tld>');
         $res = rcmail_sendmail::identity_select($message, $identities);
-        $this->assertSame($identities[1], $res);
+        self::assertSame($identities[1], $res);
 
         $message->headers->set('From', 'Test 2 <addr2@domain.tld>');
         $res = rcmail_sendmail::identity_select($message, $identities);
-        $this->assertSame($identities[1], $res);
+        self::assertSame($identities[1], $res);
 
         $message->headers->set('From', 'Other <addr2@domain.tld>');
         $res = rcmail_sendmail::identity_select($message, $identities);
-        $this->assertSame($identities[1], $res);
+        self::assertSame($identities[1], $res);
 
         $message->headers->set('From', 'Test 4 <addr2@domain.tld>');
         $res = rcmail_sendmail::identity_select($message, $identities);
-        $this->assertSame($identities[3], $res);
+        self::assertSame($identities[3], $res);
     }
 
     /**
@@ -454,6 +454,6 @@ class Rcmail_RcmailSendmail extends ActionTestCase
      */
     public function test_collect_recipients()
     {
-        $this->markTestIncomplete();
+        self::markTestIncomplete();
     }
 }

--- a/tests/Rcmail/StringReplacerTest.php
+++ b/tests/Rcmail/StringReplacerTest.php
@@ -16,10 +16,10 @@ class Rcmail_RcmailStringReplacer extends TestCase
 
         $result = invokeMethod($replacer, 'mailto_callback', [['email@address.com', 'email@address.com']]);
 
-        $this->assertMatchesRegularExpression($replacer->pattern, $result);
+        self::assertMatchesRegularExpression($replacer->pattern, $result);
 
         $result = invokeMethod($replacer, 'mailto_callback', [['address.com', 'address.com']]);
 
-        $this->assertSame('address.com', $result);
+        self::assertSame('address.com', $result);
     }
 }

--- a/tests/Rcmail/UtilsTest.php
+++ b/tests/Rcmail/UtilsTest.php
@@ -12,7 +12,7 @@ class Rcmail_RcmailUtils extends ActionTestCase
     {
         $db = rcmail_utils::db();
 
-        $this->assertInstanceOf('rcube_db', $db);
+        self::assertInstanceOf('rcube_db', $db);
     }
 
     /**
@@ -22,7 +22,7 @@ class Rcmail_RcmailUtils extends ActionTestCase
     {
         $v = rcmail_utils::db_version();
 
-        $this->assertMatchesRegularExpression('/^[0-9]{10}$/', $v);
+        self::assertMatchesRegularExpression('/^[0-9]{10}$/', $v);
     }
 
     /**
@@ -35,7 +35,7 @@ class Rcmail_RcmailUtils extends ActionTestCase
         $output = ob_get_contents();
         ob_end_clean();
 
-        $this->assertTrue(strpos($output, '0 records deleted') !== false);
+        self::assertTrue(strpos($output, '0 records deleted') !== false);
     }
 
     /**
@@ -50,7 +50,7 @@ class Rcmail_RcmailUtils extends ActionTestCase
         $output = ob_get_contents();
         ob_end_clean();
 
-        $this->assertTrue(strpos($output, 'Indexing contacts for user') === 0);
+        self::assertTrue(strpos($output, 'Indexing contacts for user') === 0);
     }
 
     /**
@@ -67,14 +67,14 @@ class Rcmail_RcmailUtils extends ActionTestCase
         $output = ob_get_contents();
         ob_end_clean();
 
-        $this->assertTrue(strpos($output, 'Updating prefs for user 1') !== false);
-        $this->assertTrue(strpos($output, 'saved') !== false);
+        self::assertTrue(strpos($output, 'Updating prefs for user 1') !== false);
+        self::assertTrue(strpos($output, 'saved') !== false);
 
         $query = $db->query('SELECT preferences FROM `users` WHERE `user_id` = 1');
         $result = $db->fetch_assoc($query);
 
         $prefs = unserialize($result['preferences']);
 
-        $this->assertSame([], $prefs['test']);
+        self::assertSame([], $prefs['test']);
     }
 }


### PR DESCRIPTION
originally discussed in https://github.com/roundcube/roundcubemail/pull/9303#issuecomment-1879380051

This is non-functional change only, but I belive calling `TestCase::assertXxx` static methods as non-static like `$this->assertXxx()` should be replaced with `self::assertXxx()` because static methods should be simply called statically.

Later, we should require this using PHPStan across the whole project, for now, let's require this using PHP CS Fixer for (known) TestCase methods only.