### PR TITLE
Add orphan inline images below the message body

### DIFF
--- a/program/actions/mail/index.php
+++ b/program/actions/mail/index.php
@@ -985,10 +985,10 @@ class rcmail_action_mail_index extends rcmail_action
      * Convert the given message part to proper HTML
      * which can be displayed the message view
      *
-     * @param string             $body Message part body
-     * @param rcube_message_part $part Message part
-     * @param array              $p    Display parameters array
-     * @param array  $used_cids    List of CIDs appearing in message body
+     * @param string             $body      Message part body
+     * @param rcube_message_part $part      Message part
+     * @param array              $p         Display parameters array
+     * @param array              $used_cids List of CIDs appearing in message body
      *
      * @return string Formatted HTML string
      */

--- a/program/lib/Roundcube/rcube_message.php
+++ b/program/lib/Roundcube/rcube_message.php
@@ -1032,7 +1032,9 @@ class rcube_message
 
     /**
      * Return list of orphan parts: inline images that are not included in the message HTML body
-     * @param  array $used_cids List of used CIDs in body
+     *
+     * @param array $used_cids List of used CIDs in body
+     *
      * @return array
      */
     public function get_orphan_inline_parts($used_cids)
@@ -1049,9 +1051,10 @@ class rcube_message
 
             if (isset($part->content_id)) {
                 $find = 'cid:' . $part->content_id;
-            }
-            elseif (!empty($part->content_location)) {
+            } elseif (!empty($part->content_location)) {
                 $find = $part->content_location;
+            } else {
+                continue;
             }
 
             if (!in_array($find, $used_cids)) {

--- a/program/lib/Roundcube/rcube_message.php
+++ b/program/lib/Roundcube/rcube_message.php
@@ -1031,6 +1031,38 @@ class rcube_message
     }
 
     /**
+     * Return list of orphan parts: inline images that are not included in the message HTML body
+     * @param  array $used_cids List of used CIDs in body
+     * @return array
+     */
+    public function get_orphan_inline_parts($used_cids)
+    {
+        $orphan_parts = [];
+
+        foreach ($this->inline_parts as $i => $part) {
+            $id = (string) $part->mime_id;
+
+            // The orphan part will not be returned if it is already in the attachments list
+            if (array_key_exists($id, $this->attachments)) {
+                continue;
+            }
+
+            if (isset($part->content_id)) {
+                $find = 'cid:' . $part->content_id;
+            }
+            elseif (!empty($part->content_location)) {
+                $find = $part->content_location;
+            }
+
+            if (!in_array($find, $used_cids)) {
+                $orphan_parts[$id] = $part;
+            }
+        }
+
+        return $orphan_parts;
+    }
+
+    /**
      * Fill a flat array with references to all parts, indexed by part numbers
      *
      * @param rcube_message_part $part Message body structure

--- a/program/lib/Roundcube/rcube_washtml.php
+++ b/program/lib/Roundcube/rcube_washtml.php
@@ -183,6 +183,9 @@ class rcube_washtml
     /** @var string A prefix to be added to id/class/for attribute values */
     private $_css_prefix;
 
+    /** @var array List of CIDs used in body */
+    private $_used_cids = [];
+
     /** @var int Max nesting level */
     private $max_nesting_level;
 
@@ -227,6 +230,16 @@ class rcube_washtml
         if (!isset($this->config['charset'])) {
             $this->config['charset'] = RCUBE_CHARSET;
         }
+    }
+
+    /**
+     * Return list of CIDs that haven't been used in HTML
+     *
+     * @return array
+     */
+    public function get_used_cids()
+    {
+        return array_keys($this->_used_cids);
     }
 
     /**
@@ -387,11 +400,13 @@ class rcube_washtml
     private function wash_uri($uri, $blocked_source = false, $is_image = true)
     {
         if (!empty($this->config['cid_map'][$uri])) {
+            $this->_used_cids[$uri] = true;
             return $this->config['cid_map'][$uri];
         }
 
         $key = $this->config['base_url'] . $uri;
         if (!empty($this->config['cid_map'][$key])) {
+            $this->_used_cids[$key] = true;
             return $this->config['cid_map'][$key];
         }
 


### PR DESCRIPTION
* In plaintext mode: all inline images will be displayed below the message body
* In HTML mode: all inline images that are **not** referenced in the message HTML body will be listed below the message body

This doesn't add more CPU usage as it is using the already called HTML filtering function to discover if an inline part is referenced or not.

This fixes issue #5051 and is a bit better than #9150