### PR TITLE
Show quota only if sensible

### DIFF
--- a/program/js/app.js
+++ b/program/js/app.js
@@ -8892,7 +8892,10 @@ function rcube_webmail() {
 
     // replace content of quota display
     this.set_quota = function (content) {
-        if (this.gui_objects.quotadisplay && content && content.type == 'text') {
+        if (!content || !content.total) {
+            return;
+        }
+        if (this.gui_objects.quotadisplay && content.type == 'text') {
             $(this.gui_objects.quotadisplay).text((content.percent || 0) + '%').attr('title', content.title || '');
         }
 

--- a/skins/elastic/templates/folders.html
+++ b/skins/elastic/templates/folders.html
@@ -29,7 +29,7 @@
 	</div>
 	<div class="footer small">
 		<roundcube:if condition="env:quota" />
-			<div id="quotadisplay" class="quota-widget">
+			<div id="quotadisplay" class="quota-widget hidden">
 				<span class="voice"><roundcube:label name="quota"></span>
 				<roundcube:object name="quotaDisplay" class="count" display="text" />
 			</div>

--- a/skins/elastic/templates/mail.html
+++ b/skins/elastic/templates/mail.html
@@ -17,7 +17,7 @@
 	</div>
 	<div class="footer small">
 		<roundcube:if condition="env:quota" />
-			<div id="quotadisplay" class="quota-widget">
+			<div id="quotadisplay" class="quota-widget hidden">
 				<span class="voice"><roundcube:label name="quota"></span>
 				<roundcube:object name="quotaDisplay" class="count" display="text" />
 			</div>

--- a/skins/elastic/ui.js
+++ b/skins/elastic/ui.js
@@ -3326,6 +3326,7 @@ function rcube_elastic_ui() {
         } else {
             element.tooltip('dispose').tooltip({ trigger: is_mobile() ? 'click' : 'hover' });
         }
+        element.removeClass('hidden');
     }
 
     /**


### PR DESCRIPTION
If a quota is not supported, or its value is unknown or unlimited, don't show the info element.
This approach simply hides the element until a value is added via JavaScript. The change looks bigger than it actually is because of indention (whitespace) changes.