### PR TITLE
csv2vard: store labels by key not value

### DIFF
--- a/program/lib/Roundcube/rcube_csv2vcard.php
+++ b/program/lib/Roundcube/rcube_csv2vcard.php
@@ -402,9 +402,6 @@ class rcube_csv2vcard
                 $this->local_label_map = array_merge($this->label_map, $map);
             }
         }
-
-        $this->label_map = array_flip($this->label_map);
-        $this->local_label_map = array_flip($this->local_label_map);
     }
 
     /**
@@ -481,7 +478,6 @@ class rcube_csv2vcard
         // get all vcard fields
         $fields = array_unique($this->csv2vcard_map);
         $local_field_names = $this->local_label_map ?: $this->label_map;
-        $local_field_names = array_flip($local_field_names);
 
         // translate with the local map
         $map = [];
@@ -539,6 +535,9 @@ class rcube_csv2vcard
     {
         $elements = $this->parse_line($lines[0]);
 
+        $label_map = array_flip($this->label_map);
+        $local_label_map = array_flip($this->local_label_map);
+
         if (count($lines) == 2) {
             // first line of contents needed to properly identify fields in gmail CSV
             $contents = $this->parse_line($lines[1]);
@@ -550,8 +549,8 @@ class rcube_csv2vcard
 
         // check English labels
         for ($i = 0; $i < $size; $i++) {
-            if (!empty($this->label_map[$elements[$i]])) {
-                $label = $this->label_map[$elements[$i]];
+            if (!empty($label_map[$elements[$i]])) {
+                $label = $label_map[$elements[$i]];
                 if ($label && !empty($this->csv2vcard_map[$label])) {
                     $map1[$i] = $this->csv2vcard_map[$label];
                 }
@@ -559,9 +558,9 @@ class rcube_csv2vcard
         }
 
         // check localized labels
-        if (!empty($this->local_label_map)) {
+        if (!empty($local_label_map)) {
             for ($i = 0; $i < $size; $i++) {
-                $label = $this->local_label_map[$elements[$i]];
+                $label = $local_label_map[$elements[$i]];
 
                 // special localization label
                 if ($label && $label[0] == '_') {


### PR DESCRIPTION
fixes #9393

In csv2vcard the labels are currently stored by their value e.g. "First Name" but in `pt_BR/csv2vcard.inc` there are labels with the same value e.g. `$map['company'] = "Empresa";` and `$map['work_company'] = "Empresa";` and when the array is flipped these values are lost due to the duplicate key names they create. This is a mistake in the pt_BR translation but it should not cause interface issues. By only flipping the array to do the header mapping no labels are lost for building the interface.

