### PR TITLE
Fix "Implicit array creation" in plugin config files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "pear/net_sieve": "~1.4.5",
         "pear/net_smtp": "~1.10.0",
         "pear/pear-core-minimal": "~1.10.1",
-        "roundcube/plugin-installer": "~0.3.1",
+        "roundcube/plugin-installer": "~0.3.3",
         "roundcube/rtf-html-php": "^2.1"
     },
     "require-dev": {

--- a/plugins/acl/composer.json
+++ b/plugins/acl/composer.json
@@ -13,6 +13,6 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": ">=0.1.3"
+        "roundcube/plugin-installer": "~0.3.3"
     }
 }

--- a/plugins/acl/config.inc.php.dist
+++ b/plugins/acl/config.inc.php.dist
@@ -1,5 +1,7 @@
 <?php
 
+$config = [];
+
 // Default look of access rights table
 // In advanced mode all access rights are displayed separately
 // In simple mode access rights are grouped into four groups: read, write, delete, full

--- a/plugins/additional_message_headers/composer.json
+++ b/plugins/additional_message_headers/composer.json
@@ -13,6 +13,6 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": ">=0.1.3"
+        "roundcube/plugin-installer": "~0.3.3"
     }
 }

--- a/plugins/additional_message_headers/config.inc.php.dist
+++ b/plugins/additional_message_headers/config.inc.php.dist
@@ -1,5 +1,7 @@
 <?php
 
+$config = [];
+
 // Header name to header value definitions.
 // Values can use variables: %u - username, %l - local part of username, %d - domain part of username
 $config['additional_message_headers'] = [];

--- a/plugins/archive/composer.json
+++ b/plugins/archive/composer.json
@@ -18,6 +18,6 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": ">=0.1.3"
+        "roundcube/plugin-installer": "~0.3.3"
     }
 }

--- a/plugins/attachment_reminder/composer.json
+++ b/plugins/attachment_reminder/composer.json
@@ -17,6 +17,6 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": ">=0.1.3"
+        "roundcube/plugin-installer": "~0.3.3"
     }
 }

--- a/plugins/autologon/composer.json
+++ b/plugins/autologon/composer.json
@@ -13,6 +13,6 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": ">=0.1.3"
+        "roundcube/plugin-installer": "~0.3.3"
     }
 }

--- a/plugins/autologout/composer.json
+++ b/plugins/autologout/composer.json
@@ -12,6 +12,6 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": ">=0.1.3"
+        "roundcube/plugin-installer": "~0.3.3"
     }
 }

--- a/plugins/database_attachments/composer.json
+++ b/plugins/database_attachments/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": ">=0.1.3",
+        "roundcube/plugin-installer": "~0.3.3",
         "roundcube/filesystem_attachments": ">=1.0.0"
     }
 }

--- a/plugins/database_attachments/config.inc.php.dist
+++ b/plugins/database_attachments/config.inc.php.dist
@@ -1,5 +1,7 @@
 <?php
 
+$config = [];
+
 // By default this plugin stores attachments in filesystem
 // and copies them into sql database.
 // You can change it to use 'memcache', 'memcached', 'redis' or 'apc'.

--- a/plugins/debug_logger/composer.json
+++ b/plugins/debug_logger/composer.json
@@ -13,6 +13,6 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": ">=0.1.3"
+        "roundcube/plugin-installer": "~0.3.3"
     }
 }

--- a/plugins/emoticons/composer.json
+++ b/plugins/emoticons/composer.json
@@ -18,6 +18,6 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": ">=0.1.3"
+        "roundcube/plugin-installer": "~0.3.3"
     }
 }

--- a/plugins/emoticons/config.inc.php.dist
+++ b/plugins/emoticons/config.inc.php.dist
@@ -1,5 +1,7 @@
 <?php
 
+$config = [];
+
 // Enable emoticons in plain text messages preview
 $config['emoticons_display'] = false;
 

--- a/plugins/enigma/composer.json
+++ b/plugins/enigma/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": "~0.1.6",
+        "roundcube/plugin-installer": "~0.3.3",
         "pear/crypt_gpg": "~1.6.3"
     }
 }

--- a/plugins/enigma/config.inc.php.dist
+++ b/plugins/enigma/config.inc.php.dist
@@ -1,5 +1,7 @@
 <?php
 
+$config = [];
+
 // Enigma Plugin options
 // --------------------
 

--- a/plugins/example_addressbook/composer.json
+++ b/plugins/example_addressbook/composer.json
@@ -13,6 +13,6 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": ">=0.1.3"
+        "roundcube/plugin-installer": "~0.3.3"
     }
 }

--- a/plugins/filesystem_attachments/composer.json
+++ b/plugins/filesystem_attachments/composer.json
@@ -18,6 +18,6 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": ">=0.1.3"
+        "roundcube/plugin-installer": "~0.3.3"
     }
 }

--- a/plugins/help/composer.json
+++ b/plugins/help/composer.json
@@ -13,6 +13,6 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": ">=0.1.3"
+        "roundcube/plugin-installer": "~0.3.3"
     }
 }

--- a/plugins/help/config.inc.php.dist
+++ b/plugins/help/config.inc.php.dist
@@ -1,5 +1,7 @@
 <?php
 
+$config = [];
+
 // Help content iframe source
 // %l will be replaced by the language code resolved using the 'help_language_map' option
 // If you are serving roundcube via https, then change this URL to https also.

--- a/plugins/hide_blockquote/composer.json
+++ b/plugins/hide_blockquote/composer.json
@@ -13,6 +13,6 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": ">=0.1.3"
+        "roundcube/plugin-installer": "~0.3.3"
     }
 }

--- a/plugins/http_authentication/composer.json
+++ b/plugins/http_authentication/composer.json
@@ -13,6 +13,6 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": ">=0.1.3"
+        "roundcube/plugin-installer": "~0.3.3"
     }
 }

--- a/plugins/http_authentication/config.inc.php.dist
+++ b/plugins/http_authentication/config.inc.php.dist
@@ -1,5 +1,7 @@
 <?php
 
+$config = [];
+
 // HTTP Basic Authentication Plugin options
 // ----------------------------------------
 // Default mail host to log-in using user/password from HTTP Authentication.

--- a/plugins/identicon/composer.json
+++ b/plugins/identicon/composer.json
@@ -14,6 +14,6 @@
     "require": {
         "php": ">=7.3.0",
         "ext-gd": "*",
-        "roundcube/plugin-installer": ">=0.1.3"
+        "roundcube/plugin-installer": "~0.3.3"
     }
 }

--- a/plugins/identity_select/composer.json
+++ b/plugins/identity_select/composer.json
@@ -13,6 +13,6 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": ">=0.1.3"
+        "roundcube/plugin-installer": "~0.3.3"
     }
 }

--- a/plugins/jqueryui/composer.json
+++ b/plugins/jqueryui/composer.json
@@ -18,6 +18,6 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": ">=0.1.3"
+        "roundcube/plugin-installer": "~0.3.3"
     }
 }

--- a/plugins/jqueryui/config.inc.php.dist
+++ b/plugins/jqueryui/config.inc.php.dist
@@ -1,5 +1,7 @@
 <?php
 
+$config = [];
+
 // if you want to load localization strings for specific sub-libraries of jquery-ui, configure them here
 $config['jquery_ui_i18n'] = ['datepicker'];
 

--- a/plugins/krb_authentication/composer.json
+++ b/plugins/krb_authentication/composer.json
@@ -13,6 +13,6 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": ">=0.1.3"
+        "roundcube/plugin-installer": "~0.3.3"
     }
 }

--- a/plugins/krb_authentication/config.inc.php.dist
+++ b/plugins/krb_authentication/config.inc.php.dist
@@ -1,5 +1,7 @@
 <?php
 
+$config = [];
+
 // Kerberos/GSSAPI Authentication Plugin options
 // ---------------------------------------------
 

--- a/plugins/managesieve/composer.json
+++ b/plugins/managesieve/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": ">=0.1.3",
+        "roundcube/plugin-installer": "~0.3.3",
         "pear/net_sieve": "~1.4.4"
     }
 }

--- a/plugins/managesieve/config.inc.php.dist
+++ b/plugins/managesieve/config.inc.php.dist
@@ -1,5 +1,7 @@
 <?php
 
+$config = [];
+
 // Managesieve server host (and optional port). Default: localhost.
 // Replacement variables supported in host name:
 // %h - user's IMAP hostname

--- a/plugins/markasjunk/composer.json
+++ b/plugins/markasjunk/composer.json
@@ -18,6 +18,6 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": ">=0.1.3"
+        "roundcube/plugin-installer": "~0.3.3"
     }
 }

--- a/plugins/markasjunk/config.inc.php.dist
+++ b/plugins/markasjunk/config.inc.php.dist
@@ -1,5 +1,7 @@
 <?php
 
+$config = [];
+
 // Learning driver
 // Use an external process such as sa-learn to learn from spam/ham messages. Default: null.
 // Please see the README for more information

--- a/plugins/new_user_dialog/composer.json
+++ b/plugins/new_user_dialog/composer.json
@@ -13,6 +13,6 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": ">=0.1.3"
+        "roundcube/plugin-installer": "~0.3.3"
     }
 }

--- a/plugins/new_user_identity/composer.json
+++ b/plugins/new_user_identity/composer.json
@@ -13,6 +13,6 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": ">=0.1.3"
+        "roundcube/plugin-installer": "~0.3.3"
     }
 }

--- a/plugins/new_user_identity/config.inc.php.dist
+++ b/plugins/new_user_identity/config.inc.php.dist
@@ -1,5 +1,7 @@
 <?php
 
+$config = [];
+
 // The id of the address book to use to automatically set a
 // user's full name in their new identity. (This should be an
 // string, which refers to the $config['ldap_public'] array.)

--- a/plugins/newmail_notifier/composer.json
+++ b/plugins/newmail_notifier/composer.json
@@ -13,6 +13,6 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": ">=0.1.3"
+        "roundcube/plugin-installer": "~0.3.3"
     }
 }

--- a/plugins/newmail_notifier/config.inc.php.dist
+++ b/plugins/newmail_notifier/config.inc.php.dist
@@ -1,5 +1,7 @@
 <?php
 
+$config = [];
+
 // Enables basic notification
 $config['newmail_notifier_basic'] = false;
 

--- a/plugins/password/composer.json
+++ b/plugins/password/composer.json
@@ -13,6 +13,6 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": ">=0.1.3"
+        "roundcube/plugin-installer": "~0.3.3"
     }
 }

--- a/plugins/password/config.inc.php.dist
+++ b/plugins/password/config.inc.php.dist
@@ -1,5 +1,7 @@
 <?php
 
+$config = [];
+
 // Password Plugin options
 // -----------------------
 // A driver to use for password change. Default: "sql".

--- a/plugins/reconnect/composer.json
+++ b/plugins/reconnect/composer.json
@@ -12,6 +12,6 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": ">=0.1.3"
+        "roundcube/plugin-installer": "~0.3.3"
     }
 }

--- a/plugins/reconnect/config.inc.php.dist
+++ b/plugins/reconnect/config.inc.php.dist
@@ -1,4 +1,6 @@
 <?php
 
+$config = [];
+
 // Maximum attempts to connect the IMAP server
 $config['reconnect_imap_max_attempts'] = 5;

--- a/plugins/redundant_attachments/composer.json
+++ b/plugins/redundant_attachments/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": ">=0.1.3",
+        "roundcube/plugin-installer": "~0.3.3",
         "roundcube/filesystem_attachments": ">=1.0.0"
     }
 }

--- a/plugins/redundant_attachments/config.inc.php.dist
+++ b/plugins/redundant_attachments/config.inc.php.dist
@@ -1,5 +1,7 @@
 <?php
 
+$config = [];
+
 // By default this plugin stores attachments in filesystem and copies them into sql database.
 // In environments with replicated database it is possible to use memcache or redis
 // as a fallback when write-master is unavailable.

--- a/plugins/show_additional_headers/composer.json
+++ b/plugins/show_additional_headers/composer.json
@@ -13,6 +13,6 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": ">=0.1.3"
+        "roundcube/plugin-installer": "~0.3.3"
     }
 }

--- a/plugins/squirrelmail_usercopy/composer.json
+++ b/plugins/squirrelmail_usercopy/composer.json
@@ -13,6 +13,6 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": ">=0.1.3"
+        "roundcube/plugin-installer": "~0.3.3"
     }
 }

--- a/plugins/squirrelmail_usercopy/config.inc.php.dist
+++ b/plugins/squirrelmail_usercopy/config.inc.php.dist
@@ -1,5 +1,7 @@
 <?php
 
+$config = [];
+
 // Driver - 'file' or 'sql'
 $config['squirrelmail_driver'] = 'sql';
 

--- a/plugins/subscriptions_option/composer.json
+++ b/plugins/subscriptions_option/composer.json
@@ -18,6 +18,6 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": ">=0.1.3"
+        "roundcube/plugin-installer": "~0.3.3"
     }
 }

--- a/plugins/userinfo/composer.json
+++ b/plugins/userinfo/composer.json
@@ -13,6 +13,6 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": ">=0.1.3"
+        "roundcube/plugin-installer": "~0.3.3"
     }
 }

--- a/plugins/vcard_attachments/composer.json
+++ b/plugins/vcard_attachments/composer.json
@@ -18,6 +18,6 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": ">=0.1.3"
+        "roundcube/plugin-installer": "~0.3.3"
     }
 }

--- a/plugins/virtuser_file/composer.json
+++ b/plugins/virtuser_file/composer.json
@@ -13,6 +13,6 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": ">=0.1.3"
+        "roundcube/plugin-installer": "~0.3.3"
     }
 }

--- a/plugins/virtuser_query/composer.json
+++ b/plugins/virtuser_query/composer.json
@@ -13,6 +13,6 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": ">=0.1.3"
+        "roundcube/plugin-installer": "~0.3.3"
     }
 }

--- a/plugins/zipdownload/composer.json
+++ b/plugins/zipdownload/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": ">=0.1.3",
+        "roundcube/plugin-installer": "~0.3.3",
         "ext-zip": "*"
     }
 }

--- a/plugins/zipdownload/config.inc.php.dist
+++ b/plugins/zipdownload/config.inc.php.dist
@@ -1,5 +1,7 @@
 <?php
 
+$config = [];
+
 // ZipDownload configuration file
 
 // Zip attachments


### PR DESCRIPTION
extracted from #9241

"Implicit array creation" PHPStan error is otherwise present once the plugins are installed.

Also require Roundcube for all the bundled plugins - https://github.com/roundcube/plugin-installer/pull/44.