### PR TITLE
Use composer autoloader for bundled plugins testing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "pear/net_sieve": "~1.4.5",
         "pear/net_smtp": "~1.10.0",
         "pear/pear-core-minimal": "~1.10.1",
-        "roundcube/plugin-installer": "~0.3.4",
+        "roundcube/plugin-installer": "~0.3.5",
         "roundcube/rtf-html-php": "^2.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,42 @@
         "phpstan/phpstan": "^1.2",
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpstan/phpstan-strict-rules": "^1.3",
-        "phpunit/phpunit": "^9.6"
+        "phpunit/phpunit": "^9.6",
+        "roundcube/acl": "*",
+        "roundcube/additional_message_headers": "*",
+        "roundcube/archive": "*",
+        "roundcube/attachment_reminder": "*",
+        "roundcube/autologon": "*",
+        "roundcube/autologout": "*",
+        "roundcube/database_attachments": "*",
+        "roundcube/debug_logger": "*",
+        "roundcube/emoticons": "*",
+        "roundcube/enigma": "*",
+        "roundcube/example_addressbook": "*",
+        "roundcube/filesystem_attachments": "*",
+        "roundcube/help": "*",
+        "roundcube/hide_blockquote": "*",
+        "roundcube/http_authentication": "*",
+        "roundcube/identicon": "*",
+        "roundcube/identity_select": "*",
+        "roundcube/jqueryui": "*",
+        "roundcube/krb_authentication": "*",
+        "roundcube/managesieve": "*",
+        "roundcube/markasjunk": "*",
+        "roundcube/new_user_dialog": "*",
+        "roundcube/new_user_identity": "*",
+        "roundcube/newmail_notifier": "*",
+        "roundcube/password": "*",
+        "roundcube/reconnect": "*",
+        "roundcube/redundant_attachments": "*",
+        "roundcube/show_additional_headers": "*",
+        "roundcube/squirrelmail_usercopy": "*",
+        "roundcube/subscriptions_option": "*",
+        "roundcube/userinfo": "*",
+        "roundcube/vcard_attachments": "*",
+        "roundcube/virtuser_file": "*",
+        "roundcube/virtuser_query": "*",
+        "roundcube/zipdownload": "*"
     },
     "suggest": {
         "bjeavons/zxcvbn-php": "^1.0 required for Zxcvbn password strength driver",
@@ -34,6 +69,146 @@
         {
             "type": "composer",
             "url": "https://plugins.roundcube.net"
+        },
+        {
+            "type": "path",
+            "url": "plugins/acl"
+        },
+        {
+            "type": "path",
+            "url": "plugins/additional_message_headers"
+        },
+        {
+            "type": "path",
+            "url": "plugins/archive"
+        },
+        {
+            "type": "path",
+            "url": "plugins/attachment_reminder"
+        },
+        {
+            "type": "path",
+            "url": "plugins/autologon"
+        },
+        {
+            "type": "path",
+            "url": "plugins/autologout"
+        },
+        {
+            "type": "path",
+            "url": "plugins/database_attachments"
+        },
+        {
+            "type": "path",
+            "url": "plugins/debug_logger"
+        },
+        {
+            "type": "path",
+            "url": "plugins/emoticons"
+        },
+        {
+            "type": "path",
+            "url": "plugins/enigma"
+        },
+        {
+            "type": "path",
+            "url": "plugins/example_addressbook"
+        },
+        {
+            "type": "path",
+            "url": "plugins/filesystem_attachments"
+        },
+        {
+            "type": "path",
+            "url": "plugins/help"
+        },
+        {
+            "type": "path",
+            "url": "plugins/hide_blockquote"
+        },
+        {
+            "type": "path",
+            "url": "plugins/http_authentication"
+        },
+        {
+            "type": "path",
+            "url": "plugins/identicon"
+        },
+        {
+            "type": "path",
+            "url": "plugins/identity_select"
+        },
+        {
+            "type": "path",
+            "url": "plugins/jqueryui"
+        },
+        {
+            "type": "path",
+            "url": "plugins/krb_authentication"
+        },
+        {
+            "type": "path",
+            "url": "plugins/managesieve"
+        },
+        {
+            "type": "path",
+            "url": "plugins/markasjunk"
+        },
+        {
+            "type": "path",
+            "url": "plugins/new_user_dialog"
+        },
+        {
+            "type": "path",
+            "url": "plugins/new_user_identity"
+        },
+        {
+            "type": "path",
+            "url": "plugins/newmail_notifier"
+        },
+        {
+            "type": "path",
+            "url": "plugins/password"
+        },
+        {
+            "type": "path",
+            "url": "plugins/reconnect"
+        },
+        {
+            "type": "path",
+            "url": "plugins/redundant_attachments"
+        },
+        {
+            "type": "path",
+            "url": "plugins/show_additional_headers"
+        },
+        {
+            "type": "path",
+            "url": "plugins/squirrelmail_usercopy"
+        },
+        {
+            "type": "path",
+            "url": "plugins/subscriptions_option"
+        },
+        {
+            "type": "path",
+            "url": "plugins/userinfo"
+        },
+        {
+            "type": "path",
+            "url": "plugins/vcard_attachments"
+        },
+        {
+            "type": "path",
+            "url": "plugins/virtuser_file"
+        },
+        {
+            "type": "path",
+            "url": "plugins/virtuser_query"
+        },
+        {
+            "type": "path",
+            "url": "plugins/zipdownload"
         }
     ],
     "autoload": {

--- a/plugins/acl/composer.json
+++ b/plugins/acl/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": "~0.3.4"
+        "roundcube/plugin-installer": "~0.3.5"
     },
     "autoload": {
         "classmap": [

--- a/plugins/acl/tests/AclTest.php
+++ b/plugins/acl/tests/AclTest.php
@@ -2,11 +2,6 @@
 
 class Acl_Plugin extends ActionTestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../acl.php';
-    }
-
     /**
      * Plugin object construction test
      */

--- a/plugins/additional_message_headers/composer.json
+++ b/plugins/additional_message_headers/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": "~0.3.4"
+        "roundcube/plugin-installer": "~0.3.5"
     },
     "autoload": {
         "classmap": [

--- a/plugins/additional_message_headers/tests/AdditionalMessageHeadersTest.php
+++ b/plugins/additional_message_headers/tests/AdditionalMessageHeadersTest.php
@@ -2,11 +2,6 @@
 
 class AdditionalMessageHeaders_Plugin extends ActionTestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../additional_message_headers.php';
-    }
-
     /**
      * Test the plugin
      */

--- a/plugins/archive/composer.json
+++ b/plugins/archive/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": "~0.3.4"
+        "roundcube/plugin-installer": "~0.3.5"
     },
     "autoload": {
         "classmap": [

--- a/plugins/archive/tests/ArchiveTest.php
+++ b/plugins/archive/tests/ArchiveTest.php
@@ -4,11 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 class Archive_Plugin extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../archive.php';
-    }
-
     /**
      * Plugin object construction test
      */

--- a/plugins/attachment_reminder/composer.json
+++ b/plugins/attachment_reminder/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": "~0.3.4"
+        "roundcube/plugin-installer": "~0.3.5"
     },
     "autoload": {
         "classmap": [

--- a/plugins/attachment_reminder/tests/AttachmentReminderTest.php
+++ b/plugins/attachment_reminder/tests/AttachmentReminderTest.php
@@ -4,11 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 class AttachmentReminder_Plugin extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../attachment_reminder.php';
-    }
-
     /**
      * Plugin object construction test
      */

--- a/plugins/autologon/composer.json
+++ b/plugins/autologon/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": "~0.3.4"
+        "roundcube/plugin-installer": "~0.3.5"
     },
     "autoload": {
         "classmap": [

--- a/plugins/autologon/tests/AutologonTest.php
+++ b/plugins/autologon/tests/AutologonTest.php
@@ -4,11 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 class Autologon_Plugin extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../autologon.php';
-    }
-
     /**
      * Plugin object construction test
      */

--- a/plugins/autologout/composer.json
+++ b/plugins/autologout/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": "~0.3.4"
+        "roundcube/plugin-installer": "~0.3.5"
     },
     "autoload": {
         "classmap": [

--- a/plugins/autologout/tests/AutologoutTest.php
+++ b/plugins/autologout/tests/AutologoutTest.php
@@ -4,11 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 class Autologout_Plugin extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../autologout.php';
-    }
-
     /**
      * Plugin object construction test
      */

--- a/plugins/database_attachments/composer.json
+++ b/plugins/database_attachments/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": "~0.3.4",
+        "roundcube/plugin-installer": "~0.3.5",
         "roundcube/filesystem_attachments": ">=1.0.0"
     },
     "autoload": {

--- a/plugins/database_attachments/tests/DatabaseAttachmentsTest.php
+++ b/plugins/database_attachments/tests/DatabaseAttachmentsTest.php
@@ -4,11 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 class DatabaseAttachments_Plugin extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../database_attachments.php';
-    }
-
     /**
      * Plugin object construction test
      */

--- a/plugins/debug_logger/composer.json
+++ b/plugins/debug_logger/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": "~0.3.4"
+        "roundcube/plugin-installer": "~0.3.5"
     },
     "autoload": {
         "classmap": [

--- a/plugins/debug_logger/tests/DebugLoggerTest.php
+++ b/plugins/debug_logger/tests/DebugLoggerTest.php
@@ -4,11 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 class DebugLogger_Plugin extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../debug_logger.php';
-    }
-
     /**
      * Plugin object construction test
      */

--- a/plugins/emoticons/composer.json
+++ b/plugins/emoticons/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": "~0.3.4"
+        "roundcube/plugin-installer": "~0.3.5"
     },
     "autoload": {
         "classmap": [

--- a/plugins/emoticons/tests/EmoticonsTest.php
+++ b/plugins/emoticons/tests/EmoticonsTest.php
@@ -4,11 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 class Emoticons_Plugin extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../emoticons.php';
-    }
-
     /**
      * Plugin object construction test
      */

--- a/plugins/enigma/composer.json
+++ b/plugins/enigma/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": "~0.3.4",
+        "roundcube/plugin-installer": "~0.3.5",
         "pear/crypt_gpg": "~1.6.3"
     },
     "autoload": {

--- a/plugins/enigma/tests/EnigmaDriverGnupgTest.php
+++ b/plugins/enigma/tests/EnigmaDriverGnupgTest.php
@@ -4,12 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 class Enigma_EnigmaDriverGnupg extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../lib/enigma_driver.php';
-        include_once __DIR__ . '/../lib/enigma_driver_gnupg.php';
-    }
-
     /**
      * Test constructor
      */

--- a/plugins/enigma/tests/EnigmaEngineTest.php
+++ b/plugins/enigma/tests/EnigmaEngineTest.php
@@ -4,12 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 class Enigma_EnigmaEngine extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        // include_once __DIR__ . '/../enigma.php';
-        include_once __DIR__ . '/../lib/enigma_engine.php';
-    }
-
     /**
      * Test password_handler()
      */

--- a/plugins/enigma/tests/EnigmaErrorTest.php
+++ b/plugins/enigma/tests/EnigmaErrorTest.php
@@ -4,11 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 class Enigma_EnigmaError extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../lib/enigma_error.php';
-    }
-
     /**
      * Test constructor
      */

--- a/plugins/enigma/tests/EnigmaKeyTest.php
+++ b/plugins/enigma/tests/EnigmaKeyTest.php
@@ -4,11 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 class Enigma_EnigmaKey extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../lib/enigma_key.php';
-    }
-
     /**
      * Test "empty" key
      */

--- a/plugins/enigma/tests/EnigmaMimeMessageTest.php
+++ b/plugins/enigma/tests/EnigmaMimeMessageTest.php
@@ -4,11 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 class Enigma_EnigmaMimeMessage extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../lib/enigma_mime_message.php';
-    }
-
     /**
      * Test isMultipart()
      */

--- a/plugins/enigma/tests/EnigmaSignatureTest.php
+++ b/plugins/enigma/tests/EnigmaSignatureTest.php
@@ -4,11 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 class Enigma_EnigmaSignature extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../lib/enigma_signature.php';
-    }
-
     /**
      * Test constructor
      */

--- a/plugins/enigma/tests/EnigmaSubkeyTest.php
+++ b/plugins/enigma/tests/EnigmaSubkeyTest.php
@@ -4,11 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 class Enigma_EnigmaSubkey extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../lib/enigma_subkey.php';
-    }
-
     /**
      * Test constructor
      */

--- a/plugins/enigma/tests/EnigmaTest.php
+++ b/plugins/enigma/tests/EnigmaTest.php
@@ -4,11 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 class Enigma_Plugin extends TestCase
 {
-    protected function setUp(): void
-    {
-        include_once __DIR__ . '/../enigma.php';
-    }
-
     /**
      * Plugin object construction test
      */

--- a/plugins/enigma/tests/EnigmaUseridTest.php
+++ b/plugins/enigma/tests/EnigmaUseridTest.php
@@ -4,11 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 class Enigma_EnigmaUserid extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../lib/enigma_userid.php';
-    }
-
     /**
      * Test constructor
      */

--- a/plugins/example_addressbook/composer.json
+++ b/plugins/example_addressbook/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": "~0.3.4"
+        "roundcube/plugin-installer": "~0.3.5"
     },
     "autoload": {
         "classmap": [

--- a/plugins/example_addressbook/tests/ExampleAddressbookTest.php
+++ b/plugins/example_addressbook/tests/ExampleAddressbookTest.php
@@ -4,12 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 class ExampleAddressbook_Plugin extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../example_addressbook.php';
-        include_once __DIR__ . '/../example_addressbook_backend.php';
-    }
-
     /**
      * Plugin object construction test
      */

--- a/plugins/filesystem_attachments/composer.json
+++ b/plugins/filesystem_attachments/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": "~0.3.4"
+        "roundcube/plugin-installer": "~0.3.5"
     },
     "autoload": {
         "classmap": [

--- a/plugins/filesystem_attachments/filesystem_attachments.php
+++ b/plugins/filesystem_attachments/filesystem_attachments.php
@@ -12,8 +12,7 @@
  *
  * Developers may wish to extend this class when creating attachment
  * handler plugins:
- *   require_once('plugins/filesystem_attachments/filesystem_attachments.php');
- *   class myCustom_attachments extends filesystem_attachments
+ *   class myCustom_attachments extends filesystem_attachments { ... }
  *
  * Note for developers: It is plugin's responsibility to care about security.
  * So, e.g. if the plugin is asked about some file path it should check

--- a/plugins/filesystem_attachments/tests/FilesystemAttachmentsTest.php
+++ b/plugins/filesystem_attachments/tests/FilesystemAttachmentsTest.php
@@ -4,11 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 class FilesystemAttachments_Plugin extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../filesystem_attachments.php';
-    }
-
     /**
      * Plugin object construction test
      */

--- a/plugins/help/composer.json
+++ b/plugins/help/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": "~0.3.4"
+        "roundcube/plugin-installer": "~0.3.5"
     },
     "autoload": {
         "classmap": [

--- a/plugins/help/tests/HelpTest.php
+++ b/plugins/help/tests/HelpTest.php
@@ -4,11 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 class Help_Plugin extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../help.php';
-    }
-
     /**
      * Plugin object construction test
      */

--- a/plugins/hide_blockquote/composer.json
+++ b/plugins/hide_blockquote/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": "~0.3.4"
+        "roundcube/plugin-installer": "~0.3.5"
     },
     "autoload": {
         "classmap": [

--- a/plugins/hide_blockquote/tests/HideBlockquoteTest.php
+++ b/plugins/hide_blockquote/tests/HideBlockquoteTest.php
@@ -4,11 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 class HideBlockquote_Plugin extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../hide_blockquote.php';
-    }
-
     /**
      * Plugin object construction test
      */

--- a/plugins/http_authentication/composer.json
+++ b/plugins/http_authentication/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": "~0.3.4"
+        "roundcube/plugin-installer": "~0.3.5"
     },
     "autoload": {
         "classmap": [

--- a/plugins/http_authentication/tests/HttpAuthenticationTest.php
+++ b/plugins/http_authentication/tests/HttpAuthenticationTest.php
@@ -4,11 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 class HttpAuthentication_Plugin extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../http_authentication.php';
-    }
-
     /**
      * Plugin object construction test
      */

--- a/plugins/identicon/composer.json
+++ b/plugins/identicon/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=7.3.0",
         "ext-gd": "*",
-        "roundcube/plugin-installer": "~0.3.4"
+        "roundcube/plugin-installer": "~0.3.5"
     },
     "autoload": {
         "classmap": [

--- a/plugins/identicon/tests/IdenticonEngineTest.php
+++ b/plugins/identicon/tests/IdenticonEngineTest.php
@@ -4,11 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 class Identicon_IdenticonEngine extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../identicon_engine.php';
-    }
-
     /**
      * Test icon generation
      */

--- a/plugins/identicon/tests/IdenticonTest.php
+++ b/plugins/identicon/tests/IdenticonTest.php
@@ -4,11 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 class Identicon_Plugin extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../identicon.php';
-    }
-
     /**
      * Plugin object construction test
      */

--- a/plugins/identity_select/composer.json
+++ b/plugins/identity_select/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": "~0.3.4"
+        "roundcube/plugin-installer": "~0.3.5"
     },
     "autoload": {
         "classmap": [

--- a/plugins/identity_select/tests/IdentitySelectTest.php
+++ b/plugins/identity_select/tests/IdentitySelectTest.php
@@ -4,11 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 class IdentitySelect_Plugin extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../identity_select.php';
-    }
-
     /**
      * Plugin object construction test
      */

--- a/plugins/jqueryui/composer.json
+++ b/plugins/jqueryui/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": "~0.3.4"
+        "roundcube/plugin-installer": "~0.3.5"
     },
     "autoload": {
         "classmap": [

--- a/plugins/jqueryui/tests/JqueryuiTest.php
+++ b/plugins/jqueryui/tests/JqueryuiTest.php
@@ -4,11 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 class Jqueryui_Plugin extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../jqueryui.php';
-    }
-
     /**
      * Plugin object construction test
      */

--- a/plugins/krb_authentication/composer.json
+++ b/plugins/krb_authentication/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": "~0.3.4"
+        "roundcube/plugin-installer": "~0.3.5"
     },
     "autoload": {
         "classmap": [

--- a/plugins/krb_authentication/tests/KrbAuthenticationTest.php
+++ b/plugins/krb_authentication/tests/KrbAuthenticationTest.php
@@ -4,11 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 class KrbAuthentication_Plugin extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../krb_authentication.php';
-    }
-
     /**
      * Plugin object construction test
      */

--- a/plugins/managesieve/composer.json
+++ b/plugins/managesieve/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": "~0.3.4",
+        "roundcube/plugin-installer": "~0.3.5",
         "pear/net_sieve": "~1.4.4"
     },
     "autoload": {

--- a/plugins/managesieve/tests/EngineTest.php
+++ b/plugins/managesieve/tests/EngineTest.php
@@ -4,7 +4,6 @@ class Managesieve_Engine extends ActionTestCase
 {
     public static function setUpBeforeClass(): void
     {
-        include_once __DIR__ . '/../managesieve.php';
         include_once __DIR__ . '/../lib/Roundcube/rcube_sieve_engine.php';
         include_once __DIR__ . '/../lib/Roundcube/rcube_sieve_vacation.php';
     }

--- a/plugins/managesieve/tests/EngineTest.php
+++ b/plugins/managesieve/tests/EngineTest.php
@@ -2,12 +2,6 @@
 
 class Managesieve_Engine extends ActionTestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../lib/Roundcube/rcube_sieve_engine.php';
-        include_once __DIR__ . '/../lib/Roundcube/rcube_sieve_vacation.php';
-    }
-
     /**
      * Test filter_form()
      */

--- a/plugins/managesieve/tests/ForwardTest.php
+++ b/plugins/managesieve/tests/ForwardTest.php
@@ -2,13 +2,6 @@
 
 class Managesieve_Forward extends ActionTestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../managesieve.php';
-        include_once __DIR__ . '/../lib/Roundcube/rcube_sieve_engine.php';
-        include_once __DIR__ . '/../lib/Roundcube/rcube_sieve_forward.php';
-    }
-
     /**
      * Test vacation_form()
      */

--- a/plugins/managesieve/tests/ManagesieveTest.php
+++ b/plugins/managesieve/tests/ManagesieveTest.php
@@ -4,11 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 class Managesieve_Plugin extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../managesieve.php';
-    }
-
     /**
      * Plugin object construction test
      */

--- a/plugins/managesieve/tests/ScriptTest.php
+++ b/plugins/managesieve/tests/ScriptTest.php
@@ -4,11 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 class Managesieve_Script extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../lib/Roundcube/rcube_sieve_script.php';
-    }
-
     /**
      * Sieve script parsing
      *

--- a/plugins/managesieve/tests/VacationTest.php
+++ b/plugins/managesieve/tests/VacationTest.php
@@ -2,13 +2,6 @@
 
 class Managesieve_Vacation extends ActionTestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../managesieve.php';
-        include_once __DIR__ . '/../lib/Roundcube/rcube_sieve_engine.php';
-        include_once __DIR__ . '/../lib/Roundcube/rcube_sieve_vacation.php';
-    }
-
     /**
      * Test vacation_form()
      */

--- a/plugins/markasjunk/composer.json
+++ b/plugins/markasjunk/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": "~0.3.4"
+        "roundcube/plugin-installer": "~0.3.5"
     },
     "autoload": {
         "classmap": [

--- a/plugins/markasjunk/tests/MarkasjunkTest.php
+++ b/plugins/markasjunk/tests/MarkasjunkTest.php
@@ -4,11 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 class Markasjunk_Plugin extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../markasjunk.php';
-    }
-
     /**
      * Plugin object construction test
      */

--- a/plugins/new_user_dialog/composer.json
+++ b/plugins/new_user_dialog/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": "~0.3.4"
+        "roundcube/plugin-installer": "~0.3.5"
     },
     "autoload": {
         "classmap": [

--- a/plugins/new_user_dialog/tests/NewUserDialogTest.php
+++ b/plugins/new_user_dialog/tests/NewUserDialogTest.php
@@ -4,11 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 class NewUserDialog_Plugin extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../new_user_dialog.php';
-    }
-
     /**
      * Plugin object construction test
      */

--- a/plugins/new_user_identity/composer.json
+++ b/plugins/new_user_identity/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": "~0.3.4"
+        "roundcube/plugin-installer": "~0.3.5"
     },
     "autoload": {
         "classmap": [

--- a/plugins/new_user_identity/tests/NewUserIdentityTest.php
+++ b/plugins/new_user_identity/tests/NewUserIdentityTest.php
@@ -4,11 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 class NewUserIdentity_Plugin extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../new_user_identity.php';
-    }
-
     /**
      * Plugin object construction test
      */

--- a/plugins/newmail_notifier/composer.json
+++ b/plugins/newmail_notifier/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": "~0.3.4"
+        "roundcube/plugin-installer": "~0.3.5"
     },
     "autoload": {
         "classmap": [

--- a/plugins/newmail_notifier/tests/NewmailNotifierTest.php
+++ b/plugins/newmail_notifier/tests/NewmailNotifierTest.php
@@ -4,11 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 class NewmailNotifier_Plugin extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../newmail_notifier.php';
-    }
-
     /**
      * Plugin object construction test
      */

--- a/plugins/password/composer.json
+++ b/plugins/password/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": "~0.3.4"
+        "roundcube/plugin-installer": "~0.3.5"
     },
     "autoload": {
         "classmap": [

--- a/plugins/password/drivers/ldap.php
+++ b/plugins/password/drivers/ldap.php
@@ -34,6 +34,7 @@ class rcube_ldap_password
     public function save($curpass, $passwd)
     {
         $rcmail = rcmail::get_instance();
+
         require_once 'Net/LDAP2.php';
         require_once __DIR__ . '/ldap_simple.php';
 

--- a/plugins/password/tests/PasswordTest.php
+++ b/plugins/password/tests/PasswordTest.php
@@ -4,11 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 class Password_Plugin extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../password.php';
-    }
-
     /**
      * Plugin object construction test
      */

--- a/plugins/password/tests/PasswordTest.php
+++ b/plugins/password/tests/PasswordTest.php
@@ -78,9 +78,8 @@ class Password_Plugin extends TestCase
      *
      * @return string driver's class name, example: "rcube_chpasswd_password"
      */
-    public function load_driver($driver)
+    protected function load_driver($driver)
     {
-        include_once __DIR__ . "/../drivers/{$driver}.php";
         $driver_class = "rcube_{$driver}_password";
         $this->assertTrue(class_exists($driver_class));
         return $driver_class;

--- a/plugins/reconnect/composer.json
+++ b/plugins/reconnect/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": "~0.3.4"
+        "roundcube/plugin-installer": "~0.3.5"
     },
     "autoload": {
         "classmap": [

--- a/plugins/reconnect/tests/ReconnectTest.php
+++ b/plugins/reconnect/tests/ReconnectTest.php
@@ -4,11 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 class Reconnect_Plugin extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../reconnect.php';
-    }
-
     /**
      * Plugin object construction test
      */

--- a/plugins/redundant_attachments/composer.json
+++ b/plugins/redundant_attachments/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": "~0.3.4",
+        "roundcube/plugin-installer": "~0.3.5",
         "roundcube/filesystem_attachments": ">=1.0.0"
     },
     "autoload": {

--- a/plugins/redundant_attachments/tests/RedundantAttachmentsTest.php
+++ b/plugins/redundant_attachments/tests/RedundantAttachmentsTest.php
@@ -4,11 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 class RedundantAttachments_Plugin extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../redundant_attachments.php';
-    }
-
     /**
      * Plugin object construction test
      */

--- a/plugins/show_additional_headers/composer.json
+++ b/plugins/show_additional_headers/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": "~0.3.4"
+        "roundcube/plugin-installer": "~0.3.5"
     },
     "autoload": {
         "classmap": [

--- a/plugins/show_additional_headers/tests/ShowAdditionalHeadersTest.php
+++ b/plugins/show_additional_headers/tests/ShowAdditionalHeadersTest.php
@@ -4,11 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 class ShowAdditionalHeaders_Plugin extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../show_additional_headers.php';
-    }
-
     /**
      * Plugin object construction test
      */

--- a/plugins/squirrelmail_usercopy/composer.json
+++ b/plugins/squirrelmail_usercopy/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": "~0.3.4"
+        "roundcube/plugin-installer": "~0.3.5"
     },
     "autoload": {
         "classmap": [

--- a/plugins/squirrelmail_usercopy/tests/SquirrelmailUsercopyTest.php
+++ b/plugins/squirrelmail_usercopy/tests/SquirrelmailUsercopyTest.php
@@ -4,11 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 class SquirrelmailUsercopy_Plugin extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../squirrelmail_usercopy.php';
-    }
-
     /**
      * Plugin object construction test
      */

--- a/plugins/subscriptions_option/composer.json
+++ b/plugins/subscriptions_option/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": "~0.3.4"
+        "roundcube/plugin-installer": "~0.3.5"
     },
     "autoload": {
         "classmap": [

--- a/plugins/subscriptions_option/tests/SubscriptionsOptionTest.php
+++ b/plugins/subscriptions_option/tests/SubscriptionsOptionTest.php
@@ -2,11 +2,6 @@
 
 class SubscriptionsOption_Plugin extends ActionTestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../subscriptions_option.php';
-    }
-
     /**
      * Plugin object construction test
      */

--- a/plugins/userinfo/composer.json
+++ b/plugins/userinfo/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": "~0.3.4"
+        "roundcube/plugin-installer": "~0.3.5"
     },
     "autoload": {
         "classmap": [

--- a/plugins/userinfo/tests/UserinfoTest.php
+++ b/plugins/userinfo/tests/UserinfoTest.php
@@ -4,11 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 class Userinfo_Plugin extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../userinfo.php';
-    }
-
     /**
      * Plugin object construction test
      */

--- a/plugins/vcard_attachments/composer.json
+++ b/plugins/vcard_attachments/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": "~0.3.4"
+        "roundcube/plugin-installer": "~0.3.5"
     },
     "autoload": {
         "classmap": [

--- a/plugins/vcard_attachments/tests/VcardAttachmentsTest.php
+++ b/plugins/vcard_attachments/tests/VcardAttachmentsTest.php
@@ -4,11 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 class VcardAttachments_Plugin extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../vcard_attachments.php';
-    }
-
     /**
      * Plugin object construction test
      */

--- a/plugins/virtuser_file/composer.json
+++ b/plugins/virtuser_file/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": "~0.3.4"
+        "roundcube/plugin-installer": "~0.3.5"
     },
     "autoload": {
         "classmap": [

--- a/plugins/virtuser_file/tests/VirtuserFileTest.php
+++ b/plugins/virtuser_file/tests/VirtuserFileTest.php
@@ -4,11 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 class VirtuserFile_Plugin extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../virtuser_file.php';
-    }
-
     /**
      * Plugin object construction test
      */

--- a/plugins/virtuser_query/composer.json
+++ b/plugins/virtuser_query/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": "~0.3.4"
+        "roundcube/plugin-installer": "~0.3.5"
     },
     "autoload": {
         "classmap": [

--- a/plugins/virtuser_query/tests/VirtuserQueryTest.php
+++ b/plugins/virtuser_query/tests/VirtuserQueryTest.php
@@ -4,11 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 class VirtuserQuery_Plugin extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../virtuser_query.php';
-    }
-
     /**
      * Plugin object construction test
      */

--- a/plugins/zipdownload/composer.json
+++ b/plugins/zipdownload/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": ">=7.3.0",
-        "roundcube/plugin-installer": "~0.3.4",
+        "roundcube/plugin-installer": "~0.3.5",
         "ext-zip": "*"
     },
     "autoload": {

--- a/plugins/zipdownload/tests/ZipdownloadTest.php
+++ b/plugins/zipdownload/tests/ZipdownloadTest.php
@@ -4,11 +4,6 @@ use PHPUnit\Framework\TestCase;
 
 class Zipdownload_Plugin extends TestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        include_once __DIR__ . '/../zipdownload.php';
-    }
-
     /**
      * Plugin object construction test
      */

--- a/program/actions/settings/index.php
+++ b/program/actions/settings/index.php
@@ -1687,7 +1687,7 @@ class rcmail_action_settings_index extends rcmail_action
             $lang = $_SESSION['language'] ?? 'en_US';
             if ($lang && $lang != 'en_US') {
                 if (file_exists(RCUBE_LOCALIZATION_DIR . "{$lang}/timezones.inc")) {
-                    include RCUBE_LOCALIZATION_DIR . "{$lang}/timezones.inc";
+                    require RCUBE_LOCALIZATION_DIR . "{$lang}/timezones.inc";
                 }
             }
         }

--- a/program/include/iniset.php
+++ b/program/include/iniset.php
@@ -75,7 +75,7 @@ if (!empty($_SERVER['PATH_INFO']) && preg_match('!^/([a-z]+)/([a-z]+)$!', $_SERV
 }
 
 // include Roundcube Framework
-require_once 'Roundcube/bootstrap.php';
+require_once __DIR__ . '/../lib/Roundcube/bootstrap.php';
 
 // register autoloader for rcmail app classes
 spl_autoload_register('rcmail_autoload');
@@ -83,7 +83,7 @@ spl_autoload_register('rcmail_autoload');
 /**
  * PHP5 autoloader routine for dynamic class loading
  */
-function rcmail_autoload($classname)
+function rcmail_autoload(string $classname): bool
 {
     if (strpos($classname, 'rcmail') === 0) {
         if (preg_match('/^rcmail_action_([^_]+)_(.*)$/', $classname, $matches)) {

--- a/program/include/rcmail_install.php
+++ b/program/include/rcmail_install.php
@@ -149,7 +149,7 @@ class rcmail_install
         $config = [];
         $rcmail_config = []; // deprecated var name
 
-        include $file;
+        require $file;
 
         // read comments from config file
         if (function_exists('token_get_all')) {

--- a/program/lib/Roundcube/bootstrap.php
+++ b/program/lib/Roundcube/bootstrap.php
@@ -407,14 +407,9 @@ function version_parse($version)
 /**
  * Use PHP5 autoload for dynamic class loading
  *
- * @param string $classname Class name
- *
  * @return bool True when the class file has been found
- *
- * @todo Make Zend, PEAR etc play with this
- * @todo Make our classes conform to a more straight forward CS.
  */
-function rcube_autoload($classname)
+function rcube_autoload(string $classname): bool
 {
     if (strpos($classname, 'rcube') === 0) {
         $classname = preg_replace('/^rcube_(cache|db|session|spellchecker)_/', '\1/', $classname);
@@ -430,8 +425,7 @@ function rcube_autoload($classname)
     }
 
     // Translate PHP namespaces into directories,
-    // i.e. use \Sabre\VObject; $vcf = VObject\Reader::read(...)
-    //      -> Sabre/VObject/Reader.php
+    // i.e. 'Sabre\Reader' -> 'Sabre/Reader.php'
     $classname = str_replace('\\', '/', $classname);
 
     if ($fp = @fopen("{$classname}.php", 'r', true)) {

--- a/program/lib/Roundcube/rcube.php
+++ b/program/lib/Roundcube/rcube.php
@@ -792,7 +792,7 @@ class rcube
 
             // use buffering to handle empty lines/spaces after closing PHP tag
             ob_start();
-            include $file;
+            require $file;
             ob_end_clean();
 
             // @phpstan-ignore-next-line

--- a/program/lib/Roundcube/rcube_config.php
+++ b/program/lib/Roundcube/rcube_config.php
@@ -302,7 +302,7 @@ class rcube_config
             if ($fpath && is_file($fpath) && is_readable($fpath)) {
                 // use output buffering, we don't need any output here
                 ob_start();
-                include $fpath;
+                require $fpath;
                 ob_end_clean();
 
                 if (isset($config) && is_array($config)) {

--- a/tests/Framework/Csv2vcardTest.php
+++ b/tests/Framework/Csv2vcardTest.php
@@ -20,7 +20,7 @@ class Framework_Csv2vcard extends TestCase
     {
         foreach (glob(RCUBE_LOCALIZATION_DIR . '*/csv2vcard.inc') as $filename) {
             $map = null;
-            include $filename;
+            require $filename;
             $this->assertTrue(count($map) > 0);
         }
     }


### PR DESCRIPTION
extracted from #9241

Utilize #9407 for testing, tests cannot be run without composer, there is no need to load the plugins manually in tests.

Fully BC and no functional change for regular Roundcube root/plugins autoloading.