### PR TITLE
Provide imap auth interface for plugins

### DIFF
--- a/program/actions/mail/index.php
+++ b/program/actions/mail/index.php
@@ -92,7 +92,7 @@ class rcmail_action_mail_index extends rcmail_action
         // set main env variables, labels and page title
         if (empty($rcmail->action) || $rcmail->action == 'list') {
             // connect to storage server and trigger error on failure
-            $rcmail->storage_connect();
+            $rcmail->connect_storage_from_session();
 
             $mbox_name = $rcmail->storage->get_folder();
 

--- a/program/include/rcmail.php
+++ b/program/include/rcmail.php
@@ -648,14 +648,15 @@ class rcmail extends rcube
      * Perform login to the mail server and to the webmail service.
      * This will also create a new user entry if auto_create_user is configured.
      *
-     * @param string $username    Mail storage (IMAP) user name
-     * @param string $password    Mail storage (IMAP) password
-     * @param string $host        Mail storage (IMAP) host
-     * @param bool   $cookiecheck Enables cookie check
+     * @param string $username     Mail storage (IMAP) user name
+     * @param string $password     Mail storage (IMAP) password
+     * @param string $host         Mail storage (IMAP) host
+     * @param bool   $cookiecheck  Enables cookie check
+     * @param bool   $just_connect Breaks after successful connect
      *
      * @return bool True on success, False on failure
      */
-    public function login($username, $password, $host = null, $cookiecheck = false)
+    public function login($username, $password, $host = null, $cookiecheck = false, $just_connect = false)
     {
         $this->login_error = null;
 
@@ -773,6 +774,15 @@ class rcmail extends rcube
             sleep(1);
             return false;
         }
+
+        // Only set user if just wanting to connect
+        if ($just_connect) {
+            if (is_object($user)) {
+                $this->set_user($user);
+            }
+            return true;
+        }
+
 
         // user already registered -> update user's record
         if (is_object($user)) {

--- a/program/include/rcmail.php
+++ b/program/include/rcmail.php
@@ -765,24 +765,18 @@ class rcmail extends rcube
         $storage = $this->get_storage();
 
         // try to log in
-        if (!$storage->connect($host, $username, $password, $port, $ssl)) {
-            if ($user) {
-                $user->failed_login();
-            }
-
-            // Wait a second to slow down brute-force attacks (#1490549)
-            sleep(1);
+        if (!$this->imap_connect($storage, $host, $username, $password, $port, $ssl, $user)) {
             return false;
         }
 
-        // Only set user if just wanting to connect
+        // Only set user if just wanting to connect.
+        // Note that for other scenarios user will also be set after successful login.
         if ($just_connect) {
             if (is_object($user)) {
                 $this->set_user($user);
             }
             return true;
         }
-
 
         // user already registered -> update user's record
         if (is_object($user)) {

--- a/program/lib/Roundcube/rcube.php
+++ b/program/lib/Roundcube/rcube.php
@@ -1862,6 +1862,41 @@ class rcube
 
         return $sent;
     }
+
+    /**
+     * Helper method to establish connection to an IMAP backend.
+     *
+     * @param rcube_storage $imap         IMAP storage handler
+     * @param string        $host         IMAP host
+     * @param string        $username     IMAP username
+     * @param string        $password     IMAP password
+     * @param int           $port         IMAP port to connect to
+     * @param string        $ssl          SSL schema or false if plain connection
+     * @param rcube_user    $user         Roundcube user (if it already exists)
+     * @param array         $imap_options Additional IMAP options
+     *
+     * @return bool Return true on successful login
+     */
+    public function imap_connect($imap, $host, $username, $password, $port, $ssl, $user = null, $imap_options = [])
+    {
+        // enable proxy authentication
+        if (!empty($imap_options)) {
+            $imap->set_options($imap_options);
+        }
+
+        // try to log in
+        if (!$imap->connect($host, $username, $password, $port, $ssl)) {
+            if ($user) {
+                $user->failed_login();
+            }
+
+            // Wait a second to slow down brute-force attacks (#1490549)
+            sleep(1);
+            return false;
+        }
+
+        return true;
+    }
 }
 
 /**


### PR DESCRIPTION
Addresses #9377 .

Main change: Allows to use the `rcmail::login()` function for merely logging into IMAP by introducing a new flag `$just_connect`. This allows applications using the Roundcube Framework to reuse IMAP authentication logic.

Background: It would be beneficial for applications like Roundcube JMAP (see https://github.com/audriga/roundcube-jmap/pull/6 ) or Kolab's FreeBusy to reuse large parts of the existing IMAP Authentcation logic of Roundcube. This is my try at providing an interface for reusing that.

Minor additional change: Adds a function in rcube to connect to IMAP.  I actually consider this optional as its only beneficial for FreeBusy for now. This would basically allow FreeBusy to just call `rcube::imap_connect()` instead of what they are doing right now (from [lib/Kolab/FreeBusy/SourceIMAP.php](https://git.kolab.org/source/freebusy/browse/master/lib/Kolab/FreeBusy/SourceIMAP.php$298)):

```
// enable proxy authentication
if (!empty($config['proxy_auth'])) {
	$imap->set_options(array('auth_cid' => $config['proxy_auth'], 'auth_pw' => $config['pass']));
}

// authenticate user in IMAP
if (!$imap->connect($host, $config['user'], $config['pass'], $port, $ssl)) {
	Logger::get('imap')->addWarning("Failed to connect to IMAP server: " . $imap->get_error_code(), $config);
	return false;
}
```