### PR TITLE
Documents redis as supported imap_cache backend

### DIFF
--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -241,7 +241,7 @@ $config['imap_disabled_caps'] = [];
 // This is used to relate IMAP session with Roundcube user sessions
 $config['imap_log_session'] = false;
 
-// Type of IMAP indexes cache. Supported values: 'db', 'apc' and 'memcache' or 'memcached'.
+// Type of IMAP indexes cache. Supported values: 'db', 'apc', 'redis' and 'memcache' or 'memcached'.
 $config['imap_cache'] = null;
 
 // Enables messages cache. Only 'db' cache is supported.


### PR DESCRIPTION

As stated in https://github.com/roundcube/roundcubemail/issues/5574#issuecomment-577577717 redis is supported, adding it to supported backed