### PR TITLE
contacts: add more gender options

### DIFF
--- a/program/actions/contacts/index.php
+++ b/program/actions/contacts/index.php
@@ -120,6 +120,8 @@ class rcmail_action_contacts_index extends rcmail_action
             'options' => [
                 'male' => 'male',
                 'female' => 'female',
+                'non-binary' => 'nonbinary',
+                'other' => 'other',
             ],
         ],
         'maidenname' => [

--- a/program/actions/contacts/index.php
+++ b/program/actions/contacts/index.php
@@ -121,7 +121,7 @@ class rcmail_action_contacts_index extends rcmail_action
                 'male' => 'male',
                 'female' => 'female',
                 'non-binary' => 'nonbinary',
-                'other' => 'other',
+                'other' => 'othergender',
             ],
         ],
         'maidenname' => [

--- a/program/localization/en_US/labels.inc
+++ b/program/localization/en_US/labels.inc
@@ -410,6 +410,7 @@ $labels['notes'] = 'Notes';
 $labels['male'] = 'male';
 $labels['female'] = 'female';
 $labels['nonbinary'] = 'non-binary';
+$labels['othergender'] = 'other';
 $labels['manager'] = 'Manager';
 $labels['assistant'] = 'Assistant';
 $labels['spouse'] = 'Spouse';

--- a/program/localization/en_US/labels.inc
+++ b/program/localization/en_US/labels.inc
@@ -409,6 +409,7 @@ $labels['instantmessenger'] = 'IM';
 $labels['notes'] = 'Notes';
 $labels['male'] = 'male';
 $labels['female'] = 'female';
+$labels['nonbinary'] = 'non-binary';
 $labels['manager'] = 'Manager';
 $labels['assistant'] = 'Assistant';
 $labels['spouse'] = 'Spouse';


### PR DESCRIPTION
add `non-binary` and `other` to the existing `male` and `female` options for the gender field in contacts