### PR TITLE
add skin info to about dialog

### DIFF
--- a/program/actions/settings/about.php
+++ b/program/actions/settings/about.php
@@ -36,6 +36,7 @@ class rcmail_action_settings_about extends rcmail_action
         $rcmail->output->add_handlers([
             'supportlink' => [$this, 'supportlink'],
             'pluginlist' => [$this, 'plugins_list'],
+            'skininfo' => [$this, 'skin_info'],
             'copyright' => static function () {
                 return 'Copyright &copy; 2005-2024, The Roundcube Dev Team';
             },
@@ -142,5 +143,20 @@ class rcmail_action_settings_about extends rcmail_action
         }
 
         return $table->show();
+    }
+
+    public static function skin_info($attrib)
+    {
+        $rcmail = rcmail::get_instance();
+        $meta = $rcmail->output->get_skin_info();
+
+        $content = html::p(null,
+            html::span('skinitem', html::span('skinname', rcube::Q($meta['name'])) . (!empty($meta['version']) ? '&nbsp;(' . $meta['version'] . ')' : '') . html::br() .
+                (!empty($meta['author_link']) ? html::span('skinauthor', $rcmail->gettext(['name' => 'skinauthor', 'vars' => ['author' => $meta['author_link']]])) . html::br() : '') .
+                (!empty($meta['license_link']) ? html::span('skinlicense', $rcmail->gettext('license') . ':&nbsp;' . $meta['license_link']) . html::br() : '') .
+                (!empty($meta['uri']) ? html::span('skinhomepage', $rcmail->gettext('source') . ':&nbsp;' . html::a(['href' => $meta['uri'], 'target' => '_blank', 'tabindex' => '-1'], rcube::Q($rcmail->gettext('download')))) : ''))
+        );
+
+        return $content;
     }
 }

--- a/program/actions/settings/index.php
+++ b/program/actions/settings/index.php
@@ -326,21 +326,12 @@ class rcmail_action_settings_index extends rcmail_action
                             $input = new html_radiobutton(['name' => '_skin']);
 
                             foreach ($skins as $skin) {
-                                $skinname = ucfirst($skin);
-                                $author_link = '';
-                                $license_link = '';
-                                $meta = @json_decode(@file_get_contents(INSTALL_PATH . "skins/{$skin}/meta.json"), true);
-
-                                if (is_array($meta) && !empty($meta['name'])) {
-                                    $skinname = $meta['name'];
-                                    $author_link = !empty($meta['url']) ? html::a(['href' => $meta['url'], 'target' => '_blank'], rcube::Q($meta['author'])) : rcube::Q($meta['author']);
-                                    $license_link = !empty($meta['license-url']) ? html::a(['href' => $meta['license-url'], 'target' => '_blank', 'tabindex' => '-1'], rcube::Q($meta['license'])) : rcube::Q($meta['license']);
-                                }
+                                $meta = $rcmail->output->get_skin_info($skin);
 
                                 $img = html::img([
                                     'src' => $rcmail->output->asset_url("skins/{$skin}/thumbnail.png"),
                                     'class' => 'skinthumbnail',
-                                    'alt' => $skin,
+                                    'alt' => $meta['name'],
                                     'width' => 64,
                                     'height' => 64,
                                     'onerror' => "this.onerror = null; this.src = 'data:image/gif;base64," . rcmail_output::BLANK_GIF . "';",
@@ -349,9 +340,9 @@ class rcmail_action_settings_index extends rcmail_action
                                 $blocks['skin']['options'][$skin]['content'] = html::label(['class' => 'skinselection'],
                                     html::span('skinitem', $input->show($config['skin'], ['value' => $skin, 'id' => $field_id . $skin])) .
                                     html::span('skinitem', $img) .
-                                    html::span('skinitem', html::span('skinname', rcube::Q($skinname)) . html::br() .
-                                        html::span('skinauthor', $author_link ? 'by ' . $author_link : '') . html::br() .
-                                        html::span('skinlicense', $license_link ? $rcmail->gettext('license') . ':&nbsp;' . $license_link : ''))
+                                    html::span('skinitem', html::span('skinname', rcube::Q($meta['name'])) . html::br() .
+                                        html::span('skinauthor', !empty($meta['author_link']) ? $rcmail->gettext(['name' => 'skinauthor', 'vars' => ['author' => $meta['author_link']]]) : '') . html::br() .
+                                        html::span('skinlicense', !empty($meta['license_link']) ? $rcmail->gettext('license') . ':&nbsp;' . $meta['license_link'] : ''))
                                 );
                             }
                         }

--- a/program/include/rcmail_output.php
+++ b/program/include/rcmail_output.php
@@ -63,6 +63,33 @@ abstract class rcmail_output extends rcube_output
     }
 
     /**
+     * Getter for the current skin meta data
+     */
+    public function get_skin_info($name = null)
+    {
+        $skin = $name ?? $this->config->get('skin');
+        $data = ['name' => ucfirst($skin)];
+
+        $meta = INSTALL_PATH . "skins/{$skin}/meta.json";
+        if (is_readable($meta) && ($json = json_decode(file_get_contents($meta), true))) {
+            $data = $json;
+            $data['author_link'] = !empty($json['url']) ? html::a(['href' => $json['url'], 'target' => '_blank'], rcube::Q($json['author'])) : rcube::Q($json['author']);
+            $data['license_link'] = !empty($json['license-url']) ? html::a(['href' => $json['license-url'], 'target' => '_blank', 'tabindex' => '-1'], rcube::Q($json['license'])) : rcube::Q($json['license']);
+        }
+
+        $composer = INSTALL_PATH . "/skins/{$skin}/composer.json";
+        if (is_readable($composer) && ($json = json_decode(file_get_contents($composer), true))) {
+            $data['version'] = $json['version'] ?? null;
+
+            if (!empty($json['homepage'])) {
+                $data['uri'] = $json['homepage'];
+            }
+        }
+
+        return $data;
+    }
+
+    /**
      * Delete all stored env variables and commands
      */
     public function reset()

--- a/program/include/rcmail_output_html.php
+++ b/program/include/rcmail_output_html.php
@@ -302,7 +302,7 @@ class rcmail_output_html extends rcmail_output
         // register skin path(s)
         $this->skin_paths = [];
         $this->skins = [];
-        $this->load_skin($skin_path);
+        $this->load_skin($skin);
 
         $this->skin_name = $skin;
         $this->set_env('skin', $skin);
@@ -341,13 +341,13 @@ class rcmail_output_html extends rcmail_output
     /**
      * Helper method to recursively read skin meta files and register search paths
      */
-    private function load_skin($skin_path)
+    private function load_skin($skin_name)
     {
+        $skin_path = 'skins/' . $skin_name;
         $this->skin_paths[] = $skin_path;
 
         // read meta file and check for dependencies
-        $meta = @file_get_contents(RCUBE_INSTALL_PATH . $skin_path . '/meta.json');
-        $meta = @json_decode($meta, true);
+        $meta = $this->get_skin_info($skin_name);
 
         $meta['path'] = $skin_path;
         $path_elements = explode('/', $skin_path);
@@ -365,7 +365,7 @@ class rcmail_output_html extends rcmail_output
         if (!empty($meta['extends'])) {
             $path = RCUBE_INSTALL_PATH . 'skins/';
             if (is_dir($path . $meta['extends']) && is_readable($path . $meta['extends'])) {
-                $_SESSION['skin_config'] = $this->load_skin('skins/' . $meta['extends']);
+                $_SESSION['skin_config'] = $this->load_skin($meta['extends']);
             }
         }
 

--- a/program/localization/en_US/labels.inc
+++ b/program/localization/en_US/labels.inc
@@ -691,6 +691,7 @@ $labels['version'] = 'Version';
 $labels['source'] = 'Source';
 $labels['destination'] = 'Destination';
 $labels['license'] = 'License';
+$labels['skinauthor'] = 'by $author';
 $labels['support'] = 'Get support';
 $labels['savedsearches'] = 'Saved searches';
 

--- a/skins/elastic/templates/about.html
+++ b/skins/elastic/templates/about.html
@@ -8,6 +8,8 @@
 	<p class="copyright"><roundcube:object name="copyright" /></p>
 	<p class="license"><roundcube:object name="license" /></p>
 	<div class="readtext">
+        <h3><roundcube:label name="skin" /></h3>
+        <roundcube:object name="skininfo" />
 		<h3><roundcube:label name="installedplugins" /></h3>
 		<roundcube:object name="pluginlist" id="pluginlist" class="records-table" />
 	</div>


### PR DESCRIPTION
mostly for the benefit of 3rd party skins this PR adds an `Interface Skin` section to the `About` dialog.

![Untitled-1](https://github.com/roundcube/roundcubemail/assets/88682/f16a1975-0d4f-4a3b-92cf-f2171adb3ad0)

The difference to the `Settings` section is that this includes version info and a download link (when available).

Also `meta.json` is read in a couple of different places so this PR unifies that into a single function.