### PR TITLE
Add managesieve_host array handler

### DIFF
--- a/plugins/managesieve/config.inc.php.dist
+++ b/plugins/managesieve/config.inc.php.dist
@@ -12,6 +12,9 @@ $config = [];
 // function, with 4190 as a fallback.
 // Note: Add tls:// prefix to enable explicit STARTTLS
 // or add ssl:// prefix to enable implicit SSL.
+// To specify different sieve servers for different hosts, provide an array
+// of a hostname (no prefix or port) and sieve server e.g.:
+// ['example.com' => 'sieve.example.net']
 $config['managesieve_host'] = 'localhost';
 
 // authentication method. Can be CRAM-MD5, DIGEST-MD5, PLAIN, LOGIN, EXTERNAL

--- a/plugins/managesieve/lib/Roundcube/rcube_sieve_engine.php
+++ b/plugins/managesieve/lib/Roundcube/rcube_sieve_engine.php
@@ -165,8 +165,16 @@ class rcube_sieve_engine
     {
         $host = $this->rc->config->get('managesieve_host', 'localhost');
         if (is_array($host)) {
-            $rcmail = rcmail::get_instance();
-            $host = $host[$rcmail->autoselect_host()];
+            // Extract the host name from the session
+            if (array_key_exists($_SESSION['storage_host'], $host)) {
+                $host = $host[$this->rc->config->mail_domain($_SESSION['storage_host'])];
+            } else {
+                rcube::raise_error([
+                    'code' => 500,
+                    'message' => "Can't locate the sieve server. Please check the 'managesieve_host' config option.",
+                ], true, false);
+                return rcmail::ERROR_INVALID_HOST;
+            }
         }
         $host = rcube_utils::parse_host($host);
 

--- a/plugins/managesieve/lib/Roundcube/rcube_sieve_engine.php
+++ b/plugins/managesieve/lib/Roundcube/rcube_sieve_engine.php
@@ -181,7 +181,7 @@ class rcube_sieve_engine
                     'code' => 500,
                     'message' => "Can't locate the sieve server. Please check the 'managesieve_host' config option.",
                 ], true, false);
-                return rcmail::ERROR_INVALID_HOST;
+                return rcube_sieve::ERROR_CONNECTION;
             }
         }
         $host = rcube_utils::parse_host($host);

--- a/plugins/managesieve/lib/Roundcube/rcube_sieve_engine.php
+++ b/plugins/managesieve/lib/Roundcube/rcube_sieve_engine.php
@@ -164,6 +164,10 @@ class rcube_sieve_engine
     public function connect($username, $password)
     {
         $host = $this->rc->config->get('managesieve_host', 'localhost');
+        if (is_array($host)) {
+            $rcmail = rcmail::get_instance();
+            $host = $host[$rcmail->autoselect_host()];
+        }
         $host = rcube_utils::parse_host($host);
 
         $plugin = $this->rc->plugins->exec_hook('managesieve_connect', [

--- a/plugins/managesieve/lib/Roundcube/rcube_sieve_engine.php
+++ b/plugins/managesieve/lib/Roundcube/rcube_sieve_engine.php
@@ -164,8 +164,16 @@ class rcube_sieve_engine
     public function connect($username, $password)
     {
         $host = $this->rc->config->get('managesieve_host', 'localhost');
+        // $config['managesieve_host'] parameter now can be configured in two ways:
+        // - as an array, which allows to switch between different servers. E.g.,
+        //   a user can log in as user@some.host, or as otheruser@other.host and
+        //   have different sieve servers for different hosts.
+        // - as a string (default).
         if (is_array($host)) {
-            // Extract the host name from the session
+            // By now, the $_SESSION['storage_host'] variable should contain the host name
+            // of a mail server, user logged in. This entry should match the mapping in the
+            // $config['managesieve_host'] parameter in the configuration, e.g.:
+            // ['example.com' => 'sieve.example.net'].
             if (array_key_exists($_SESSION['storage_host'], $host)) {
                 $host = $host[$this->rc->config->mail_domain($_SESSION['storage_host'])];
             } else {

--- a/plugins/managesieve/lib/Roundcube/rcube_sieve_engine.php
+++ b/plugins/managesieve/lib/Roundcube/rcube_sieve_engine.php
@@ -164,6 +164,7 @@ class rcube_sieve_engine
     public function connect($username, $password)
     {
         $host = $this->rc->config->get('managesieve_host', 'localhost');
+
         // $config['managesieve_host'] parameter now can be configured in two ways:
         // - as an array, which allows to switch between different servers. E.g.,
         //   a user can log in as user@some.host, or as otheruser@other.host and
@@ -184,6 +185,7 @@ class rcube_sieve_engine
                 return rcube_sieve::ERROR_CONNECTION;
             }
         }
+
         $host = rcube_utils::parse_host($host);
 
         $plugin = $this->rc->plugins->exec_hook('managesieve_connect', [


### PR DESCRIPTION
To use different sieve hosts for different domains, the rcube_sieve_engine.php was updated and the connect() function was extended to handle managesive_host config option being configured as an array.
One use case scenario now could be to use the managesieve_host option the following way:

```
$config['managesieve_host'] = array(
    'some.domain' => 'localhost',
    'another.doman' => 'tls://yet.another.domain,
);
```
Where `some.domain` should match corresponding `username_domain` entry.