### PR TITLE
Fix Code Spell check by disabling `String.raw` rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -177,6 +177,7 @@ module.exports = {
         'unicorn/prefer-string-replace-all': 'off', // (43 matches)
         'unicorn/prefer-string-slice': 'off', // (39 matches)
         'unicorn/prefer-string-starts-ends-with': 'off', // (2 matches)
+        'unicorn/prefer-string-raw': 'off', // (2 matches)
         'unicorn/prefer-ternary': 'off', // (16 matches)
         'unicorn/require-array-join-separator': 'off', // (5 matches)
         'unicorn/switch-case-braces': 'off', // (161 matches)


### PR DESCRIPTION
The eslint package "eslint-plugin-unicorn" introduced a new rule in version 53.0.0 that suggests to use `String.raw` in order to avoid the need for escaping backslashes.

While this certainly is a good idea we cannot follow that rule as long as we support Internet Explorer 11+, which doesn't support template literals (and thus `String.raw`).