### PR TITLE
Notification focus on click in Chrome

### DIFF
--- a/plugins/newmail_notifier/newmail_notifier.js
+++ b/plugins/newmail_notifier/newmail_notifier.js
@@ -108,6 +108,9 @@ function newmail_notifier_desktop(body, disabled_callback) {
                 icon: icon,
             });
             popup.onclick = function () {
+                if (window.parent) {
+                    window.parent.focus();
+                }
                 this.close();
             };
             setTimeout(function () {


### PR DESCRIPTION
For Windows, it seems at some point Chrome stopped focusing on the window/tab that sent the notification when you click it. Firefox still behaves correctly, but to get this to work again for Chrome, I had to call `window.parent.focus()`.

Edit: I did test this change in other browsers. This fixes the same issue in Edge (because it's basically just Chrome now) and it doesn't break anything in Firefox.