### PR TITLE
Filter "real" attachments by being referenced

### DIFF
--- a/program/actions/mail/show.php
+++ b/program/actions/mail/show.php
@@ -621,7 +621,10 @@ class rcmail_action_mail_show extends rcmail_action_mail_index
      */
     public static function message_body($attrib)
     {
-        if (empty(self::$MESSAGE) || (empty(self::$MESSAGE->parts) && empty(self::$MESSAGE->body))) {
+        // Exit early if there's no content to be shown anyway.
+        // `mime_parts` also includes a message's body, even if it originally
+        // was the only part of the message.
+        if (empty(self::$MESSAGE) || empty(self::$MESSAGE->mime_parts)) {
             return '';
         }
 

--- a/program/actions/mail/show.php
+++ b/program/actions/mail/show.php
@@ -204,7 +204,7 @@ class rcmail_action_mail_show extends rcmail_action_mail_index
             }
 
             // Skip inline images
-            if (strpos($mimetype, 'image/') === 0 && !self::is_attachment(self::$MESSAGE, $attach_prop)) {
+            if (strpos($mimetype, 'image/') === 0 && self::$MESSAGE->is_referred_attachment($attach_prop)) {
                 continue;
             }
 
@@ -745,7 +745,7 @@ class rcmail_action_mail_show extends rcmail_action_mail_index
                 // Content-Type: image/*...
                 if ($mimetype = self::part_image_type($attach_prop)) {
                     // Skip inline images
-                    if (!self::is_attachment(self::$MESSAGE, $attach_prop)) {
+                    if (self::$MESSAGE->is_referred_attachment($attach_prop)) {
                         continue;
                     }
 
@@ -888,31 +888,5 @@ class rcmail_action_mail_show extends rcmail_action_mail_index
                 $rcmail->output->set_env('mdn_request', true);
             }
         }
-    }
-
-    /**
-     * Check whether the message part is a normal attachment
-     *
-     * @param rcube_message      $message Message object
-     * @param rcube_message_part $part    Message part
-     *
-     * @return bool
-     */
-    protected static function is_attachment($message, $part)
-    {
-        // Inline attachment with Content-Id specified
-        if (!empty($part->content_id) && $part->disposition == 'inline') {
-            return false;
-        }
-
-        // Any image attached to multipart/related message (#7184)
-        $parent_id = preg_replace('/\.[0-9]+$/', '', $part->mime_id);
-        $parent = $message->mime_parts[$parent_id] ?? null;
-
-        if ($parent && $parent->mimetype == 'multipart/related') {
-            return false;
-        }
-
-        return true;
     }
 }


### PR DESCRIPTION
This changes the way in which attachments are determined to be shown as downloadable ("standalone"), or not ("inline").
In theory this should be determined by their `Content-Disposition`, but in reality this often doesn't work.

Previously, on top of the default standard handling, edge cases have been fixed by checking for their concrete details.

Now the code checks if the `Content-ID` or `Content-Location` of the attachment is actually being used in other parts of the message. If not, the attachment is considered to be "standalone". This might make some images be shown as downloadable, which have a "inline"-disposition – but it'll happen only in cases where the message is broken, or they wouldn't have been shown at all previously. So I consider this a progression while staying a comprehensible and review-able changeset. 

This fixes #9443. 

I didn't find an email that it breaks. I also don't see how it could.

It helps #9465, too.

And it (unintendedly) also helps #9326, because now the information, which image is actually referenced in an HTML-part, ist available already after message parsing.