### PR TITLE
Make dependabot check dependencies for NPM and composer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-  - package-ecosystem: "npm"
-    directory: "/skins/elastic"
-    schedule:
-      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,15 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/skins/elastic"
+    schedule:
+      interval: "weekly"

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ roundcubemail-git: buildtools
 	(cd roundcubemail-git/bin; rm -f transifexpull.sh package2composer.sh)
 	(cd roundcubemail-git; find . -name '.gitignore' | xargs rm -f)
 	(cd roundcubemail-git; find . -name '.travis.yml' | xargs rm -f)
-	(cd roundcubemail-git; rm -rf tests plugins/*/tests .git* .tx* .ci* .editorconfig* index-test.php Dockerfile Makefile)
+	(cd roundcubemail-git; rm -rf tests plugins/*/tests .git* .tx* .ci* .editorconfig* index-test.php Dockerfile Makefile package.json package-lock.json node_modules)
 	(cd roundcubemail-git; $(SEDI) 's/1.7-git/$(VERSION)/' index.php public_html/index.php installer/index.php program/include/iniset.php program/lib/Roundcube/bootstrap.php)
 	(cd roundcubemail-git; $(SEDI) 's/# Unreleased/# Release $(VERSION)'/ CHANGELOG.md)
 

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ roundcubemail-git: buildtools
 	(cd roundcubemail-git; $(SEDI) 's/# Unreleased/# Release $(VERSION)'/ CHANGELOG.md)
 
 buildtools: /tmp/composer.phar
-	npm install --include=dev
+	npm install --include=dev --omit=optional
 
 /tmp/composer.phar:
 	curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp/

--- a/Makefile
+++ b/Makefile
@@ -61,9 +61,9 @@ roundcubemail-git: buildtools
 	git clone --branch=$(GITBRANCH) --depth=1 $(GITREMOTE) roundcubemail-git
 	(cd roundcubemail-git; bin/jsshrink.sh; bin/updatecss.sh; bin/cssshrink.sh)
 	(cd roundcubemail-git/skins/elastic; \
-		lessc --clean-css="--s1 --advanced" styles/styles.less > styles/styles.min.css; \
-		lessc --clean-css="--s1 --advanced" styles/print.less > styles/print.min.css; \
-		lessc --clean-css="--s1 --advanced" styles/embed.less > styles/embed.min.css)
+		../../node_modules/.bin/lessc --clean-css="--s1 --advanced" styles/styles.less > styles/styles.min.css; \
+		../../node_modules/.bin/lessc --clean-css="--s1 --advanced" styles/print.less > styles/print.min.css; \
+		../../node_modules/.bin/lessc --clean-css="--s1 --advanced" styles/embed.less > styles/embed.min.css)
 	(cd roundcubemail-git/bin; rm -f transifexpull.sh package2composer.sh)
 	(cd roundcubemail-git; find . -name '.gitignore' | xargs rm -f)
 	(cd roundcubemail-git; find . -name '.travis.yml' | xargs rm -f)
@@ -72,10 +72,7 @@ roundcubemail-git: buildtools
 	(cd roundcubemail-git; $(SEDI) 's/# Unreleased/# Release $(VERSION)'/ CHANGELOG.md)
 
 buildtools: /tmp/composer.phar
-	npm install uglify-js
-	npm install lessc
-	npm install less-plugin-clean-css
-	npm install csso-cli
+	npm install --include=dev
 
 /tmp/composer.phar:
 	curl -sS https://getcomposer.org/installer | php -- --install-dir=/tmp/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "devDependencies": {
+    "csso-cli": "^4.0.2",
+    "eslint": "^8.57.0",
+    "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-plugin-import": "^2.29.1",
+    "eslint-plugin-unicorn": "^53.0.0",
+    "less": "^4.2.0",
+    "less-plugin-clean-css": "^1.5.1",
+    "uglify-js": "^3.17.4"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,5 +8,13 @@
     "less": "^4.2.0",
     "less-plugin-clean-css": "^1.5.1",
     "uglify-js": "^3.17.4"
+  },
+  "optionalDependencies": {
+    "jquery": "^3.7.1",
+    "tinymce": "^5.10.9",
+    "openpgp": "^5.0.0",
+    "codemirror": "^5.58.3",
+    "bootstrap": "^4.5.3",
+    "less": "^4.1.3"
   }
 }


### PR DESCRIPTION
This makes dependabot check dependencies of composer in the root-directory, and NPM in both, the root-directory and in `skins/elastic`.

It will create a pull request for newer versions of dependencies, so we don't get behind on updates, or even miss important ones.

Roundcube's dependencies are not that many, but we can still make our life a little easier with this automation.