### PR TITLE
Fix double scrollbar in compose window with big body

### DIFF
--- a/skins/elastic/ui.js
+++ b/skins/elastic/ui.js
@@ -4052,7 +4052,8 @@ function rcube_elastic_ui() {
                 }
             };
 
-        $(textarea).on('input', resize).trigger('input');
+        $(textarea).on('input', resize);
+        setTimeout(resize, 100);
     }
 
     // Initializes smart list input


### PR DESCRIPTION
If editing a draft, that has a lot of text content already, previously sometimes a double scrollbar was shown, because the callback function that calculates the height for the textare was triggered too early.

This change sets the first height calculation behind a 100ms timeout. (A 0ms timeout might be feasible, too, just to put the callback execution on the call stack – it also works locally, but I'm not sure about real world behaviour, so better be safe than sorry.)

This closes #7760