### PR TITLE
Mailvelope: Facilitate adding custom domains

### DIFF
--- a/program/actions/settings/index.php
+++ b/program/actions/settings/index.php
@@ -1478,6 +1478,7 @@ class rcmail_action_settings_index extends rcmail_action
 
                         $field_id = 'rcmfd_mailvelope_main_keyring';
                         $input = new html_checkbox(['name' => '_mailvelope_main_keyring', 'id' => $field_id, 'value' => 1]);
+                        $mailvelope_enable_button = new html_button(['type' => 'button', 'class' => 'btn btn-secondary', 'onclick' => rcmail_output::JS_OBJECT_NAME . '.mailvelope_enable()']);
 
                         $blocks['mailvelope']['options']['mailvelope_status'] = [
                             'content' => html::div(
@@ -1487,6 +1488,7 @@ class rcmail_action_settings_index extends rcmail_action
                                     rcube::Q($rcmail->gettext('mailvelopenotfound'))
                                 )
                                 . html::script([], "if (!parent.mailvelope) \$('#mailvelope-warning').show()")
+                                . $mailvelope_enable_button->show(rcube::Q($rcmail->gettext('mailvelopeenable')))
                             ),
                         ];
 

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -3982,6 +3982,19 @@ function rcube_webmail() {
         }
     };
 
+    /**
+     * Triggger Mailvelope to add the current domain to the list of authorized
+     * domains (with API access).
+     */
+    this.mailvelope_enable = function () {
+        // Remove warning and enabling button if mailvelope was enabled.
+        window.addEventListener('mailvelope', function (ev) {
+            $('#mailvelope-warning').hide();
+        });
+        // Trigger Mailvelope.
+        $('body').append('<iframe style="display: none;" src="https://api.mailvelope.com/authorize-domain/?api=true" />');
+    };
+
     // Load Mailvelope functionality (and initialize keyring if needed)
     this.mailvelope_load = function (action) {
         var keyring = this.env.mailvelope_main_keyring ? undefined : this.env.user_id,

--- a/program/localization/en_US/labels.inc
+++ b/program/localization/en_US/labels.inc
@@ -681,6 +681,7 @@ $labels['encryption'] = 'Encryption';
 $labels['mailvelopeoptions'] = 'Mailvelope options';
 $labels['mailvelopemainkeyring'] = 'Use Mailvelope main keyring';
 $labels['mailvelopenotfound'] = 'Mailvelope extension is not enabled/installed in your browser.';
+$labels['mailvelopeenable'] = 'Enable';
 
 $labels['sortby'] = 'Sort by';
 $labels['sortasc'] = 'Sort ascending';


### PR DESCRIPTION
This facilitates using Mailvelope (properly, i.e. with API-access) a
lot, because people don't have to manually add their domain into
Mailvelope's options but just click a button in Roundcube's settings. This will make Mailvelope open a popup to confirm this, and after that it will Just Work™️.

---
Screenshot:

![image](https://github.com/roundcube/roundcubemail/assets/57864086/8c96f863-9100-40f7-85f7-82215ef2d024)

---

This includes a new way to allow server code to specify events on attributes without using
inline event listeners (which require a very lax CSP and should be avoided). I'm curious for comments on that, too.

Closes #9498