### PR TITLE
Re-introduce Ctype extension as dependency

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -12,7 +12,7 @@ REQUIREMENTS
 * An IMAP, HTTP and SMTP server
 * .htaccess support allowing overrides for DirectoryIndex
 * PHP Version 7.3 or greater including:
-   - PCRE, DOM, JSON, Session, Sockets, OpenSSL, Mbstring, Filter, Intl (required)
+   - PCRE, DOM, JSON, Session, Sockets, OpenSSL, Mbstring, Filter, Ctype, Intl (required)
    - PHP PDO with driver for either MySQL, PostgreSQL or SQLite (required)
    - Iconv, Zip, Fileinfo, Exif (recommended)
    - LDAP for LDAP addressbook support (optional)

--- a/installer/check.php
+++ b/installer/check.php
@@ -29,6 +29,7 @@ $required_php_exts = [
     'Multibyte' => 'mbstring',
     'OpenSSL' => 'openssl',
     'Filter' => 'filter',
+    'Ctype' => 'ctype',
 ];
 
 $optional_php_exts = [
@@ -87,6 +88,7 @@ $source_urls = [
     'XMLWriter' => 'https://www.php.net/manual/en/book.xmlwriter.php',
     'Zip' => 'https://www.php.net/manual/en/book.zip.php',
     'Filter' => 'https://www.php.net/manual/en/book.filter.php',
+    'Ctype' => 'https://www.php.net/manual/en/book.ctype.php',
     'pdo_mysql' => 'https://www.php.net/manual/en/ref.pdo-mysql.php',
     'pdo_pgsql' => 'https://www.php.net/manual/en/ref.pdo-pgsql.php',
     'pdo_sqlite' => 'https://www.php.net/manual/en/ref.pdo-sqlite.php',

--- a/program/lib/Roundcube/README.md
+++ b/program/lib/Roundcube/README.md
@@ -19,7 +19,7 @@ tasks:
 REQUIREMENTS
 ------------
 PHP Version 7.3 or greater including:
-   - PCRE, DOM, JSON, Session, Sockets, OpenSSL, Mbstring, Filter, Intl (required)
+   - PCRE, DOM, JSON, Session, Sockets, OpenSSL, Mbstring, Filter, Ctype, Intl (required)
    - PHP PDO with driver for either MySQL, PostgreSQL, or SQLite (required)
    - Iconv, Zip, Fileinfo, Exif (recommended)
    - LDAP for LDAP addressbook support (optional)


### PR DESCRIPTION
It is required by Bacon, the QR-encoding tool.

This partially reverts commit deba22aaa960ca2802eac64479ecc2ec4cf59de1.