### PR TITLE
Some wording changes to the issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Report a bug
-description: Describet a bug or issue you may have identified in Roundcube.
+description: Describe a bug or issue you may have identified in Roundcube.
 title: "Provide a general summary of the issue"
 labels: []
 assignees: []

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
 contact_links:
-  - name: Ask the community
+  - name: Ask for help
     url: https://www.roundcubeforum.net/
     about: Ask and discuss questions with other Roundcube community members.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,5 @@
-name: Feature request
-description: Suggest new or updated features to include in Roundcube.
+name: Suggest a new feature
+description: Suggest a new feature to be developed for Roundcube.
 title: "Suggest a new feature"
 labels: []
 assignees: []


### PR DESCRIPTION
* make it clearer that if you're looking for help, the forum is the right place.
* make all headlines full sentences
* fix a typo