### PR TITLE
trigger error when config files are not readable

### DIFF
--- a/program/lib/Roundcube/rcube_config.php
+++ b/program/lib/Roundcube/rcube_config.php
@@ -300,8 +300,8 @@ class rcube_config
 
         foreach ($this->resolve_paths($file) as $fpath) {
             if ($fpath && is_file($fpath)) {
-                if(false === is_readable($fpath)) {
-                    trigger_error($fpath . ' is not readable. Please check ownership of file', \E_USER_WARNING);
+                if (false === is_readable($fpath)) {
+                    trigger_error($fpath . ' is not readable', \E_USER_WARNING);
                 } else {
                     // use output buffering, we don't need any output here
                     ob_start();

--- a/program/lib/Roundcube/rcube_config.php
+++ b/program/lib/Roundcube/rcube_config.php
@@ -300,12 +300,12 @@ class rcube_config
 
         foreach ($this->resolve_paths($file) as $fpath) {
             if ($fpath && is_file($fpath)) {
-                if (false === is_readable($fpath)) {
+                if (is_readable($fpath) === false) {
                     trigger_error($fpath . ' is not readable', \E_USER_WARNING);
                 } else {
                     // use output buffering, we don't need any output here
                     ob_start();
-                    include($fpath);
+                    include $fpath;
                     ob_end_clean();
 
                     if (isset($config) && is_array($config)) {

--- a/program/lib/Roundcube/rcube_config.php
+++ b/program/lib/Roundcube/rcube_config.php
@@ -299,20 +299,25 @@ class rcube_config
         $success = false;
 
         foreach ($this->resolve_paths($file) as $fpath) {
-            if ($fpath && is_file($fpath) && is_readable($fpath)) {
-                // use output buffering, we don't need any output here
-                ob_start();
-                require $fpath;
-                ob_end_clean();
+            if ($fpath && is_file($fpath)) {
+                if(false === is_readable($fpath)) {
+                    trigger_error($fpath . ' is not readable. Please check ownership of file', \E_USER_WARNING);
+                } else {
+                    // use output buffering, we don't need any output here
+                    ob_start();
+                    include($fpath);
+                    ob_end_clean();
 
-                if (isset($config) && is_array($config)) {
-                    $this->merge($config);
-                    $success = true;
-                }
-                // deprecated name of config variable
-                if (isset($rcmail_config) && is_array($rcmail_config)) {
-                    $this->merge($rcmail_config);
-                    $success = true;
+                    if (isset($config) && is_array($config)) {
+                        $this->merge($config);
+                        $success = true;
+                    }
+                    // deprecated name of config variable
+                    if (isset($rcmail_config) && is_array($rcmail_config)) {
+                        $this->merge($rcmail_config);
+                        $success = true;
+                    }
+
                 }
             }
         }

--- a/program/lib/Roundcube/rcube_config.php
+++ b/program/lib/Roundcube/rcube_config.php
@@ -317,7 +317,6 @@ class rcube_config
                         $this->merge($rcmail_config);
                         $success = true;
                     }
-
                 }
             }
         }

--- a/program/lib/Roundcube/rcube_config.php
+++ b/program/lib/Roundcube/rcube_config.php
@@ -305,7 +305,7 @@ class rcube_config
                 } else {
                     // use output buffering, we don't need any output here
                     ob_start();
-                    include $fpath;
+                    require $fpath;
                     ob_end_clean();
 
                     if (isset($config) && is_array($config)) {


### PR DESCRIPTION
fixes issue #9549

I just tested on my own installation and it is working correctly, when any config file has the wrong ownership I am now seeing in the logs:
```bash
[15-Jul-2024 18:03:36 UTC] PHP Warning:  /usr/share/psa-roundcube/config/config.inc.php is not readable. Please check ownership of file in /usr/share/psa-roundcube/program/lib/Roundcube/rcube_config.php on line 312
```