### PR TITLE
Make pgpmime-support known after Mailvelope init

### DIFF
--- a/program/js/app.js
+++ b/program/js/app.js
@@ -3997,6 +3997,9 @@ function rcube_webmail() {
 
     // Load Mailvelope functionality (and initialize keyring if needed)
     this.mailvelope_load = function (action) {
+        // Make the server code aware that this browser now knows about
+        // PGP/MIME (would otherwise only be recognized after the next login.
+        this.env.browser_capabilities.pgpmime = 1;
         var keyring = this.env.mailvelope_main_keyring ? undefined : this.env.user_id,
             fn = function (kr) {
                 ref.mailvelope_keyring = kr;


### PR DESCRIPTION
The support for pgpmime was only checked initially after the login. If a user e.g. authorizes a domain in Mailvelope only after a login, Mailvelope now instantly works, instead of (silently and undocumentedly) requireing a logout+login-cycle.