### PR TITLE
Use server date year as copyright end year

### DIFF
--- a/installer/index.php
+++ b/installer/index.php
@@ -164,7 +164,7 @@ include $include_steps[$RCI->step];
 </div>
 
 <div id="footer">
-  Installer by the Roundcube Dev Team. Copyright &copy; 2008-2021 – Published under the GNU Public License;&nbsp;
+  Installer Copyright &copy; by the Roundcube Dev Team – Published under the GNU Public License;&nbsp;
   Icons by <a href="http://famfamfam.com">famfamfam</a>
 </div>
 </body>

--- a/program/actions/settings/about.php
+++ b/program/actions/settings/about.php
@@ -39,7 +39,7 @@ class rcmail_action_settings_about extends rcmail_action
             'pluginlist' => [$this, 'plugins_list'],
             'skininfo' => [$this, 'skin_info'],
             'copyright' => static function () {
-                return 'Copyright &copy; 2005-2024, The Roundcube Dev Team';
+                return 'Copyright &copy; The Roundcube Dev Team';
             },
             'license' => static function () {
                 return 'This program is free software; you can redistribute it and/or modify it under the terms '


### PR DESCRIPTION
To not have to update it every year or getting it wrong as in 1.6.8 simply use the year of the server date as copyright end year