### PR TITLE
Fix Windows tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,7 +75,7 @@ jobs:
           coverage: none
 
       - name: Execute tests
-        run: .ci/run_tests.sh
+        run: bash -ex .ci/run_tests.sh
 
       - name: Upload artifacts
         uses: actions/upload-artifact@master


### PR DESCRIPTION
To fix running the tests we now don't reply on the hash-bang but call bash explicitly on MS Windows.

Closes https://github.com/roundcube/roundcubemail/issues/9602