### PR TITLE
Fix downloading files in tests with new Chromiums

### DIFF
--- a/.ci/compose.yaml
+++ b/.ci/compose.yaml
@@ -3,6 +3,10 @@ services:
     image: docker.io/greenmail/standalone
   browserhost:
     image: docker.io/selenium/standalone-chromium
+    ports:
+      # Allow to watch the remote controlled browser (comment out the
+      # `--headless` argument in TestCase::driver() before).
+      - '127.0.0.1:7900:7900'
     volumes:
       - '/dev/shm:/dev/shm'
       - '../tests/Browser/downloads:/downloads'

--- a/tests/Browser/TestCase.php
+++ b/tests/Browser/TestCase.php
@@ -56,6 +56,8 @@ abstract class TestCase extends PHPUnitTestCase
             '--disable-gpu',
             '--headless',
             '--no-sandbox',
+            '--disable-features=InsecureDownloadWarnings',
+            '--unsafely-treat-insecure-origin-as-secure=' . self::getServerUrl(),
         ]);
 
         // For file download handling
@@ -110,7 +112,7 @@ abstract class TestCase extends PHPUnitTestCase
 
         $this->app = \rcmail::get_instance();
 
-        Browser::$baseUrl = getenv('SERVER_URL') ?: 'http://localhost:8000';
+        Browser::$baseUrl = self::getServerUrl();
         Browser::$storeScreenshotsAt = TESTS_DIR . 'screenshots';
         Browser::$storeConsoleLogAt = TESTS_DIR . 'console';
 
@@ -166,5 +168,10 @@ abstract class TestCase extends PHPUnitTestCase
         static::afterClass(static function () {
             static::$phpProcess->stop();
         });
+    }
+
+    protected static function getServerUrl()
+    {
+        return getenv('SERVER_URL') ?: 'http://localhost:8000';
     }
 }


### PR DESCRIPTION
Newer versions of chromium apparently need these flags to download files without prompting the user.

This PR also includes a small config change that allows to expose another HTTP port in order to watch the remote controlled browser in your browser at<http://localhost:7900/?autoconnect=1&resize=scale&password=secret>(you have to comment out the `--headless` argument in TestCase::driver() before).
