### PR TITLE
vcard: Fix whitespace handling in line cont's

### DIFF
--- a/program/lib/Roundcube/rcube_vcard.php
+++ b/program/lib/Roundcube/rcube_vcard.php
@@ -681,7 +681,7 @@ class rcube_vcard
     private static function vcard_decode($vcard)
     {
         // Perform RFC2425 line unfolding and split lines
-        $vcard = preg_replace(["/\r/", "/\n\\s+/"], '', $vcard);
+        $vcard = str_replace(["\r", "\n ", "\n\t"], '', $vcard);
         $lines = explode("\n", $vcard);
         $result = [];
 
@@ -985,7 +985,7 @@ class rcube_vcard
         // This will for example exclude photos
 
         // Perform RFC2425 line unfolding and split lines
-        $string = preg_replace(["/\r/", "/\n\\s+/"], '', $string);
+        $string = str_replace(["\r", "\n ", "\n\t"], '', $string);
         $lines = explode("\n", $string);
         $string = '';
 

--- a/tests/Framework/VCardTest.php
+++ b/tests/Framework/VCardTest.php
@@ -104,17 +104,17 @@ class VCardTest extends TestCase
      */
     public function test_parse_continuation_line_with_initial_whitespace()
     {
-        $vcard_lines =
-            [ 'BEGIN:VCARD'
-            , 'VERSION:3.0'
-            , 'N:Doe;Jane;;;'
-            , 'FN:Jane Doe'
-            , 'NOTE:an'
-            , '  example'
-            , 'END:VCARD'
-            ];
+        $vcard_string = <<<'EOF'
+            BEGIN:VCARD
+            VERSION:3.0
+            N:Doe;Jane;;;
+            FN:Jane Doe
+            NOTE:an
+              example
+            END:VCARD
+            EOF;
 
-        $vcard = new \rcube_vcard(implode("\r\n", $vcard_lines) . "\r\n");
+        $vcard = new \rcube_vcard(str_replace("\n", "\r\n", $vcard_string) . "\r\n");
 
         $result = $vcard->get_assoc();
 

--- a/tests/Framework/VCardTest.php
+++ b/tests/Framework/VCardTest.php
@@ -99,6 +99,28 @@ class VCardTest extends TestCase
         $this->assertCount(1, $result['address:work'], 'ITEM1.-prefixed entry');
     }
 
+    /**
+     * Extra whitespace at start of continuation line (#9593/1).
+     */
+    public function test_parse_continuation_line_with_initial_whitespace()
+    {
+        $vcard_lines =
+            [ 'BEGIN:VCARD'
+            , 'VERSION:3.0'
+            , 'N:Doe;Jane;;;'
+            , 'FN:Jane Doe'
+            , 'NOTE:an'
+            , '  example'
+            , 'END:VCARD'
+            ];
+
+        $vcard = new \rcube_vcard(implode("\r\n", $vcard_lines) . "\r\n");
+
+        $result = $vcard->get_assoc();
+
+        $this->assertSame('an example', $result['notes'][0]);
+    }
+
     public function test_import()
     {
         $input = file_get_contents($this->_srcpath('apple.vcf'));


### PR DESCRIPTION
Previously, multiple whitespace characters at the start of a continuation line would all be dropped, instead of only the first one.

Also,
 - restrict line continuation characters to SPACE and TAB.

Note that, like before, this identifies the CR (`\r`) character with the empty string, and thereby notably does not require a CRLF (`\r\n`) sequence (which is mandated by RFCs 2426, 2425) for line termination (i.e., `\n` suffices).

Fixes: Bug 1 of issue #9593.