### PR TITLE
Fix getting IMAP vendor name

### DIFF
--- a/program/lib/Roundcube/rcube_imap.php
+++ b/program/lib/Roundcube/rcube_imap.php
@@ -655,7 +655,7 @@ class rcube_imap extends rcube_storage
             $ident = null;
         }
 
-        $vendor = (string) (!empty($ident) ? $ident['name'] : '');
+        $vendor = (string) ($ident['name'] ?? $ident['NAME'] ?? '');
         $ident = strtolower($vendor . ' ' . $this->conn->data['GREETING']);
         $vendors = ['cyrus', 'dovecot', 'uw-imap', 'gimap', 'hmail', 'greenmail'];
 


### PR DESCRIPTION
In some cases, the array's keys where upper case, and the previous code produced a warning and resulted in an empty string, even though the name was present.

Closes #9650 