### PR TITLE
ManageSieve: make sieve_formattime() parse all time-formatters PHP does.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - Managesieve: Add List-ID to the list of headers for creating new sieve-filters (#8307)
 - Managesieve: Support an array in managesieve_host option (#9447)
 - Managesieve: Fix the frontend datetime picker not respecting the 12h format and apending a dangling 's' to the seconds (#9688)
+- Managesieve: Add parsing for all PHP time formatters from `time_format` config to frontend the time picker (#9655)
 - Password: Add `ldap_samba_ad` driver (#8525)
 - Password: Allow LDAP access using LDAP URI and SASL binding (#8402)
 - Password: Use Guzzle HTTP Client in the `pwned` driver

--- a/plugins/managesieve/managesieve.js
+++ b/plugins/managesieve/managesieve.js
@@ -1009,6 +1009,9 @@ rcube_webmail.prototype.managesieve_tip_register = function (tips) {
 function sieve_formattime(hour, minutes) {
     var i, c, h, time = '', format = rcmail.env.time_format || 'H:i';
 
+    // Support all Time and Timezone related formatters from PHP
+    // https://www.php.net/manual/en/datetime.format.php
+    // Even if not all may make sense in this context
     for (i = 0; i < format.length; i++) {
         c = format.charAt(i);
         switch (c) {
@@ -1041,6 +1044,29 @@ function sieve_formattime(hour, minutes) {
                 break;
             case 's':
                 time += '00';
+
+                break;
+            case 'u': // Microseconds
+                time += '000000';
+
+                break;
+            case 'v': // Milliseconds
+                time += '000';
+
+                break;
+            case 'B': // Swatch Internet time: https://www.swatch.com/en-us/internet-time.html
+                s = (hour * 60 + minutes) * 60 - rcmail.env.server_timezone_info.Z + 3600;
+                time += s / (60 + 24.4);
+
+                break;
+            case 'e': // Timezone identifier
+            case 'I': // Whether the date is in daylight saving time
+            case 'O': // Difference to Greenwich time (GMT) without colon between hours and minutes
+            case 'P': // Difference to Greenwich time (GMT) with colon between hours and minutes
+            case 'p': // The same as P, but returns Z instead of +00:00
+            case 'T': // Timezone abbreviation, if known; otherwise the GMT offset
+            case 'Z': // Timezone offset in seconds. The offset for timezones west of UTC is always negative, and for those east of UTC is always positive.
+                time += rcmail.env.server_timezone_info[c];
 
                 break;
             default:

--- a/plugins/managesieve/managesieve.php
+++ b/plugins/managesieve/managesieve.php
@@ -95,6 +95,22 @@ class managesieve extends rcube_plugin
         $sieve_action = strpos($this->rc->action, 'plugin.managesieve') === 0;
 
         if ($this->rc->task == 'mail' || $sieve_action) {
+            // Injection of Timezone information into the JS Frontend.
+            // All the specifiers may be included in $config['time_format']
+            // However not all are easily parseable in the JS world, especially
+            // when it comes to Timezone abbreviation
+            $tz = new DateTimeZone($this->rc->config->get('timezone'));
+            $dt = new DateTime('now', $tz);
+
+            $this->rc->output->set_env('server_timezone_info', [
+                'e' => $dt->format('e'),
+                'I' => $dt->format('I'),
+                'O' => $dt->format('O'),
+                'P' => $dt->format('P'),
+                'p' => version_compare(\PHP_VERSION, '8.0.0') >= 0 ? $dt->format('p') : $dt->format('P'),
+                'T' => $dt->format('T'),
+                'Z' => $dt->format('Z'),
+            ]);
             $this->include_script('managesieve.js');
         }
 


### PR DESCRIPTION
Roundcube's `$config['time_format']` understands all PHP time and especially timezone format specifiers listed in the [PHP docs](https://www.php.net/manual/en/datetime.format.php); however, `sieve_formattime()` that used this value via `rcmail.env.time_format` does not.

Therefore if the config value e.g. is `$config['time_format'] = "H:i T"` to include the abbreviated timezone name (which works else where, like the message list), then forms using `sieve_formattime()`, the OOO form, will generate times like "6:00 T" and so on
![image](https://github.com/user-attachments/assets/0f3f9e9e-9c3f-476e-95af-e64d09330894)
This causes the actual time be set to "Tango Time", i.e. UTC-7
![image](https://github.com/user-attachments/assets/9ca57287-6bc6-41b0-841f-76cf3329a7d3)
Which for users outside of UTC-7 is unexpected behavior.

Therefore I changed `sieve_formattime()` to understand any formatter that may reasonably (or unreasonably, like microseconds or Unix Time. But never say never) be configured by an admin or user. For the timezone values, I opted to pass these values from PHP to JS via `set_env()` as in JS these values are extraordinarily hard to reliably to obtain without additional libraries.
![image](https://github.com/user-attachments/assets/88dad7b7-3ec1-4c3e-902f-b30d3d9ae2ed)


I also changed some thing at the beginning of `sieve_formattime()` that looked odd to me. Like per-declaring all variables. And actually used the value that `h` would have been in the `g` and `h` cases. But I'm also happy reverting these changes if they are undesired.
