### PR TITLE
Add image source label to dockerfiles

### DIFF
--- a/.ci/docker-images/Dockerfile
+++ b/.ci/docker-images/Dockerfile
@@ -1,5 +1,6 @@
 ARG PHPVERSION=8.3
 FROM php:${PHPVERSION}-cli
+LABEL org.opencontainers.image.source="https://github.com/roundcube/roundcubemail"
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
To get changelogs shown with Renovate a docker container has to add the source label described in the OCI Image Format Specification.

For reference: https://github.com/renovatebot/renovate/blob/main/lib/modules/datasource/docker/readme.md