### PR TITLE
Fix virtuser_file plugin email2user() function not accounting for backward slashes in username

### DIFF
--- a/plugins/virtuser_file/virtuser_file.php
+++ b/plugins/virtuser_file/virtuser_file.php
@@ -68,6 +68,8 @@ class virtuser_file extends rcube_plugin
             $arr = preg_split('/\s+/', trim($r[$i]));
 
             if (count($arr) > 0) {
+                // Replace '\@' with '@' to handle cases where internal usernames include an '@' character.
+                // Sometimes usernames with '@' are saved with a leading '\' to avoid conflicts.
                 $p['user'] = trim(str_replace('\@', '@', $arr[count($arr) - 1]));
                 break;
             }

--- a/plugins/virtuser_file/virtuser_file.php
+++ b/plugins/virtuser_file/virtuser_file.php
@@ -68,7 +68,7 @@ class virtuser_file extends rcube_plugin
             $arr = preg_split('/\s+/', trim($r[$i]));
 
             if (count($arr) > 0) {
-                $p['user'] = trim(str_replace('\@', '@', $arr[count($arr)-1]));
+                $p['user'] = trim(str_replace('\@', '@', $arr[count($arr) - 1]));
                 break;
             }
         }

--- a/plugins/virtuser_file/virtuser_file.php
+++ b/plugins/virtuser_file/virtuser_file.php
@@ -68,7 +68,7 @@ class virtuser_file extends rcube_plugin
             $arr = preg_split('/\s+/', trim($r[$i]));
 
             if (count($arr) > 0) {
-                $p['user'] = trim($arr[count($arr) - 1]);
+                $p['user'] = trim(str_replace('\@', '@', $arr[count($arr)-1]));
                 break;
             }
         }


### PR DESCRIPTION
This addresses login issues when using aliases, if the resolved username includes a '@' character.
In the **/etc/postfix/virtual** file, usernames including a '@' character are saved with a leading '\' character.

For example:
rocky.balboa@company.com becomes rocky.balboa**\@**company.com 

The function right above (user2email()) is accounting for this issue, it just seems it was forgotten for email2user().

I discovered this because I am using Roundcube with Webmin/Virtualmin.
Starting recent versions, Virtualmin includes the '@' character in internal usernames. In previous versions it was replaced by a '%' character, thus there was no need for a leading '\'.