### PR TITLE
Changed character encoding for password to iconv()

### DIFF
--- a/plugins/password/drivers/ldap_samba_ad.php
+++ b/plugins/password/drivers/ldap_samba_ad.php
@@ -50,9 +50,9 @@ class rcube_ldap_samba_ad_password extends rcube_ldap_simple_password
             return $ret;
         }
 
-        $hash = password::hash_password($passwd, 'ad');
-
-        $entry = ['unicodePwd' => $hash];
+        $entry = [
+            'unicodePwd' => iconv("UTF-8", "UTF-16LE", '"' . $passwd . '"')
+        ];
 
         $this->_debug("C: Replace password for {$this->user}: " . print_r($entry, true));
 


### PR DESCRIPTION
To ensure that password for LDAP Samba AD is saved correctly, iconv() must be used instead of password::hash_password().