### PR TITLE
Type confusion: preg_match(): $flags is type int

### DIFF
--- a/program/lib/Roundcube/rcube_result_thread.php
+++ b/program/lib/Roundcube/rcube_result_thread.php
@@ -368,7 +368,7 @@ class rcube_result_thread
             $regexp = '(' . $element . '|' . $item . ')';
 
             if (isset($this->meta['pos'][$index])) {
-                if (preg_match('/([0-9]+)/', $this->raw_data, $m, null, $this->meta['pos'][$index])) {
+                if (preg_match('/([0-9]+)/', $this->raw_data, $m, 0, $this->meta['pos'][$index])) {
                     $result = $m[1];
                 }
             } elseif (isset($this->meta['pos'][$index - 1])) {


### PR DESCRIPTION
No functional change intended, just makes one warning go away.

```sadness
PHP: Deprecated: preg_match(): Passing null to parameter #4 ($flags) of type int is deprecated in program/lib/Roundcube/rcube_result_thread.php
 preg_match(
    string $pattern,
    string $subject,
    array &$matches = null,
    int $flags = 0,
    int $offset = 0
): int|false
```

https://www.php.net/manual/de/function.preg-match.php