### PR TITLE
ManageSieve: Fix timeformat processing for frontend the time picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - Managesieve: Support :encodeurl (RFC 5435) (#8917)
 - Managesieve: Add List-ID to the list of headers for creating new sieve-filters (#8307)
 - Managesieve: Support an array in managesieve_host option (#9447)
+- Managesieve: Fix the frontend datetime picker not respecting the 12h format and apending a dangling 's' to the seconds (#9688)
 - Password: Add `ldap_samba_ad` driver (#8525)
 - Password: Allow LDAP access using LDAP URI and SASL binding (#8402)
 - Password: Use Guzzle HTTP Client in the `pwned` driver

--- a/plugins/managesieve/managesieve.js
+++ b/plugins/managesieve/managesieve.js
@@ -1022,8 +1022,9 @@ function sieve_formattime(hour, minutes) {
                 break;
             case 'g':
             case 'h':
-                h = hour == 0 ? 12 : hour > 12 ? hour - 12 : hour;
-                time += (c == 'h' && hour < 10 ? '0' : '') + hour;
+                h = hour % 12;
+                h = h === 0 ? 12 : h;
+                time += (c === 'h' && h < 10 ? '0' : '') + h;
 
                 break;
             case 'G':

--- a/plugins/managesieve/managesieve.js
+++ b/plugins/managesieve/managesieve.js
@@ -1041,6 +1041,8 @@ function sieve_formattime(hour, minutes) {
                 break;
             case 's':
                 time += '00';
+
+                break;
             default:
                 time += c;
         }


### PR DESCRIPTION
Additionally to the missing time formatters described in #9655, the function `sieve_formattime()` has also two additional bugs processing the existing time formats.

First the 12h format is not processed properly e.g. resulting in 24h format with am/pm specifiers in the timeformat is set to `h:i a`. This is the result of the calculated 12h value not actually being used to the string construction.
![image](https://github.com/user-attachments/assets/bb35f1d4-8087-4959-b9c1-3595584d83b1)


And second having seconds in the timeformat will append a dangling `s` to the number due the fall through of the last switch case in the function.
![image](https://github.com/user-attachments/assets/ad3e0b78-f21c-4b9b-9bd5-ba5c07ab27e0)

This PR fix both issues (in separate commits).
