### PR TITLE
Introduce security@roundcube.net as security contact

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ If you found a security issue or vulnerability of the software, please report it
 
 Your report should include clear steps for reproduction and a classification of the found vulnerability.
 
-You can also send an encrypted email message to *alec[at]alec.pl*. You can find the PGP public key on the major public keyservers like [pgp.key-server.io](https://pgp.key-server.io).
+If you prefer, you can also send an encrypted email message to `security [at] roundcube.net`. The [PGP key](https://roundcube.net/download/security.roundcube.net.pub)'s fingerprint is `ACFCF63232B79518E632EC4B0127B799F939816F`.
 
 ## Publishing and Credits
 


### PR DESCRIPTION
Using a dedicated email address with a dedicated PGP key allows to give multiple people access while still keeping things under wrap.

A single, private email address as security contact is such a huge bus factor, which we should avoid. Event just a holiday or illness could lead to escalation due to missing replies.

Also, in case of potentially severe security issues Nextcloud's security team must have access to all details and communication. This is already given for all issues reported via hackerone.com, and with this change is now also enabled for issues reported by email.