### PR TITLE
fix ldap sort column usage from RC config

### DIFF
--- a/program/lib/Roundcube/rcube_ldap.php
+++ b/program/lib/Roundcube/rcube_ldap.php
@@ -561,7 +561,7 @@ class rcube_ldap extends rcube_addressbook
     public function set_sort_order($sort_col = null, $sort_order = null)
     {
         if (!empty($this->coltypes[$sort_col]['attributes'])) {
-            $this->sort_col = $this->coltypes[$sort_col]['attributes'][0];
+            $this->sort_col = $this->prop['sort'];
         }
     }
 


### PR DESCRIPTION
This will fix ldap sort column usage from config in actual RC 1.6.9