### PR TITLE
Backport change to SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,10 +6,11 @@ Check our website's [download page](https://roundcube.net/download/) to see whic
 
 ## Reporting a Vulnerability
 
-If you found a security issue or vulnerability of the software, please report with direct and encrypted email to *thomas[at]roundcube.net*
-and *alec[at]alec.pl*. You can find the according PGP public keys on the major public keyservers like [pgp.key-server.io](https://pgp.key-server.io).
+If you found a security issue or vulnerability of the software, please report it to [Nextcloud's HackerOne](https://hackerone.com/nextcloud).
 
 Your report should include clear steps for reproduction and a classification of the found vulnerability.
+
+If you prefer, you can also send an encrypted email message to `security [at] roundcube.net`. The [PGP key](https://roundcube.net/download/security.roundcube.net.pub)'s fingerprint is `ACFCF63232B79518E632EC4B0127B799F939816F`.
 
 ## Publishing and Credits
 


### PR DESCRIPTION
Backport of #9690 to branch `release-1.6`.

The change is a little bigger than in the original PR/commit, because in branch `release-1.6` a much older version of the file was still present. Now the files in both branches are identical.