### PR TITLE
Added German translation for "Keep Formatting"

### DIFF
--- a/program/localization/de_DE/labels.inc
+++ b/program/localization/de_DE/labels.inc
@@ -244,6 +244,7 @@ $labels['charset'] = 'Zeichensatz';
 $labels['editortype'] = 'Bearbeitungstyp';
 $labels['returnreceipt'] = 'Empfangsbestätigung (MDN)';
 $labels['dsn'] = 'Übermittlungsbestätigung (DSN)';
+$labels['keepformatting'] = 'Formatierung beibehalten';
 $labels['mailreplyintro'] = 'Am $date, schrieb $sender:';
 $labels['originalmessage'] = 'Originalnachricht';
 $labels['selectimage'] = 'Bild auswählen';


### PR DESCRIPTION
This MR fixes #9700 and adds a German translation for "Keep formatting" while composing an email