### PR TITLE
Allow hiding "Keep formatting" in "dont_override" config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 - Add possibility to change ATTR_EMULATE_PREPARES via config file (#9213)
 - Use draft settings (like DSN) on "Edit as new" (#9349)
 - Use new HTML5 parser available on PHP >= 8.4
-- Allow hiding the "Keep formatting" option when composing an email (#9704)
+- Allow hiding the "Keep formatting" option (via `dont_override`) when composing an email (#9704)
 - Installer: Show NOT OK if none of the database extensions is installed (#9594, #9604)
 - Mailvelope: Add a button to enable the extension for webmail domain (#9498)
 - OAuth: Add support for SMTP without authentication (#9183)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Add possibility to change ATTR_EMULATE_PREPARES via config file (#9213)
 - Use draft settings (like DSN) on "Edit as new" (#9349)
 - Use new HTML5 parser available on PHP >= 8.4
+- Allow hiding the "Keep formatting" option when composing an email (#9704)
 - Installer: Show NOT OK if none of the database extensions is installed (#9594, #9604)
 - Mailvelope: Add a button to enable the extension for webmail domain (#9498)
 - OAuth: Add support for SMTP without authentication (#9183)

--- a/program/actions/mail/send.php
+++ b/program/actions/mail/send.php
@@ -47,9 +47,10 @@ class rcmail_action_mail_send extends rcmail_action
 
         $saveonly = !empty($_GET['_saveonly']);
         $savedraft = !empty($_POST['_draft']) && !$saveonly;
-        $keepformatting = !empty($_POST['_keepformatting']);
         if (in_array('keep_formatting', $rcmail->config->get('dont_override', []))) {
-            $keepformatting = false;
+            $keepformatting = !empty($rcmail->config->get('keep_formatting', false));
+        } else {
+            $keepformatting = !empty($_POST['_keepformatting']);
         }
         $SENDMAIL = new rcmail_sendmail($COMPOSE, [
             'sendmail' => true,

--- a/program/actions/mail/send.php
+++ b/program/actions/mail/send.php
@@ -47,6 +47,10 @@ class rcmail_action_mail_send extends rcmail_action
 
         $saveonly = !empty($_GET['_saveonly']);
         $savedraft = !empty($_POST['_draft']) && !$saveonly;
+        $keepformatting = !empty($_POST['_keepformatting']);
+        if (in_array('keep_formatting', $rcmail->config->get('dont_override', []))) {
+            $keepformatting = false;
+        }
         $SENDMAIL = new rcmail_sendmail($COMPOSE, [
             'sendmail' => true,
             'saveonly' => $saveonly,
@@ -55,7 +59,7 @@ class rcmail_action_mail_send extends rcmail_action
                 call_user_func_array([$rcmail->output, 'show_message'], $args);
                 $rcmail->output->send('iframe');
             },
-            'keepformatting' => !empty($_POST['_keepformatting']),
+            'keepformatting' => $keepformatting,
         ]);
 
         // Collect input for message headers

--- a/program/actions/mail/send.php
+++ b/program/actions/mail/send.php
@@ -47,7 +47,7 @@ class rcmail_action_mail_send extends rcmail_action
 
         $saveonly = !empty($_GET['_saveonly']);
         $savedraft = !empty($_POST['_draft']) && !$saveonly;
-        if (in_array('keep_formatting', $rcmail->config->get('dont_override', []))) {
+        if (in_array('keep_formatting', $rcmail->config->get('dont_override', []), true)) {
             $keepformatting = !empty($rcmail->config->get('keep_formatting', false));
         } else {
             $keepformatting = !empty($_POST['_keepformatting']);

--- a/program/localization/de_DE/labels.inc
+++ b/program/localization/de_DE/labels.inc
@@ -244,6 +244,7 @@ $labels['charset'] = 'Zeichensatz';
 $labels['editortype'] = 'Bearbeitungstyp';
 $labels['returnreceipt'] = 'Empfangsbestätigung (MDN)';
 $labels['dsn'] = 'Übermittlungsbestätigung (DSN)';
+$labels['keepformatting'] = 'Formatierung beibehalten';
 $labels['mailreplyintro'] = 'Am $date, schrieb $sender:';
 $labels['originalmessage'] = 'Originalnachricht';
 $labels['selectimage'] = 'Bild auswählen';

--- a/program/localization/de_DE/labels.inc
+++ b/program/localization/de_DE/labels.inc
@@ -244,7 +244,6 @@ $labels['charset'] = 'Zeichensatz';
 $labels['editortype'] = 'Bearbeitungstyp';
 $labels['returnreceipt'] = 'Empfangsbestätigung (MDN)';
 $labels['dsn'] = 'Übermittlungsbestätigung (DSN)';
-$labels['keepformatting'] = 'Formatierung beibehalten';
 $labels['mailreplyintro'] = 'Am $date, schrieb $sender:';
 $labels['originalmessage'] = 'Originalnachricht';
 $labels['selectimage'] = 'Bild auswählen';

--- a/skins/elastic/templates/compose.html
+++ b/skins/elastic/templates/compose.html
@@ -46,12 +46,14 @@
 				</div>
 			</div>
 			<roundcube:endif />
+			<roundcube:if condition="!in_array('keep_formatting', (array)config:dont_override)" />
 			<div class="form-group row form-check">
 				<label for="compose-keep-formatting" class="col-form-label col-6"><roundcube:label name="keepformatting" /></label>
 				<div class="col-6 form-check">
 					<roundcube:object name="keepFormattingCheckBox" id="compose-keep-formatting" noform="true" tabindex="2" class="form-check-input" />
 				</div>
 			</div>
+			<roundcube:endif />
 			<div class="form-group row">
 				<label for="compose-priority" class="col-form-label col-6"><roundcube:label name="priority" /></label>
 				<div class="col-6">


### PR DESCRIPTION
Fixes #9703 
According to [this blog entry](https://kolabian.wordpress.com/2021/11/07/a-few-small-improvements/), "Keep formatting" is for power users and therefore it would be nice to be removable.