### PR TITLE
Reminders bot

### DIFF
--- a/.github/workflows/bot-create-manual-reminder.yml
+++ b/.github/workflows/bot-create-manual-reminder.yml
@@ -1,0 +1,17 @@
+name: 'Create reminder from comment'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+on:
+  issue_comment:
+    types: [created, edited]
+
+jobs:
+  reminder:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 👀 check for reminder
+        uses: agrc/create-reminder-action@v1

--- a/.github/workflows/bot-manual-reminder.yml
+++ b/.github/workflows/bot-manual-reminder.yml
@@ -1,0 +1,17 @@
+name: 'Notify manually requested reminders'
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  reminder:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: check reminders and notify
+        uses: agrc/reminder-action@v1

--- a/.github/workflows/bot-remind-stale-pull-requests.yml
+++ b/.github/workflows/bot-remind-stale-pull-requests.yml
@@ -1,0 +1,19 @@
+name: "Send comment to stale PRs"
+on:
+  schedule:
+    # Run everyday at midnight
+    - cron: "0 0 * * *"
+
+jobs:
+  review-reminder:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: sojusan/github-action-reminder@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reminder_message: "🛎️ This PR has had no activity in two weeks."
+          # Remind after two weeks of inactivity
+          inactivity_deadline_hours: 336
+          default_users_to_notify: |
+            @pabzm
+            @alecpl


### PR DESCRIPTION
This adds two bots to this repo:

1. Automatically comment on every PR that is stale for two weeks.
2. Allow to manually specify when someone shall be reminded of something.

The latter's usage is  `/remind [who] [what] [when]`.

Examples:

```
/remind me to deploy on Oct 10
/remind me next Monday to review the requirements
/remind me that the specs on the rotary girder need checked in 6 months
/remind @<username> to fix this issue tomorrow
```