### PR TITLE
BUG: get_variable for postgres never returns a value.

### DIFF
--- a/program/lib/Roundcube/db/pgsql.php
+++ b/program/lib/Roundcube/db/pgsql.php
@@ -173,7 +173,10 @@ class rcube_db_pgsql extends rcube_db
             return rcube::get_instance()->config->get('db_' . $varname, $default);
         }
 
-        $this->variables[$varname] = rcube::get_instance()->config->get('db_' . $varname);
+        $cfgval = rcube::get_instance()->config->get('db_' . $varname);
+        if (isset($cfgval)) {
+            return $cfgval;
+        }
 
         if (!isset($this->variables)) {
             $this->variables = [];


### PR DESCRIPTION
 $this->variables[$varname] = rcube::get_instance()->config->get('db_' . $varname);
 if (!isset($this->variables)) {

The first line always creates an array "variables" and because of this the server variables are never read.

Because of this, the insert_or_update() method never uses the

  "INSERT INTO ... ON CONFLICT DO UPDATE SET ..."

command, and the logs constantly show errors adding records to the message cache due to "duplicate key".