### PR TITLE
Limit reminder-bots to our repo

### DIFF
--- a/.github/workflows/bot-create-manual-reminder.yml
+++ b/.github/workflows/bot-create-manual-reminder.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   reminder:
+    if: github.repository == 'roundcube/roundcubemail'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/bot-manual-reminder.yml
+++ b/.github/workflows/bot-manual-reminder.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   reminder:
+    if: github.repository == 'roundcube/roundcubemail'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/bot-remind-stale-pull-requests.yml
+++ b/.github/workflows/bot-remind-stale-pull-requests.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   review-reminder:
+    if: github.repository == 'roundcube/roundcubemail'
     runs-on: ubuntu-latest
     steps:
       - uses: sojusan/github-action-reminder@v1

--- a/.github/workflows/bot-remind-stale-pull-requests.yml
+++ b/.github/workflows/bot-remind-stale-pull-requests.yml
@@ -6,12 +6,13 @@ on:
 
 jobs:
   review-reminder:
+    permissions:
+      pull-requests: write
     if: github.repository == 'roundcube/roundcubemail'
     runs-on: ubuntu-latest
     steps:
       - uses: sojusan/github-action-reminder@v1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           reminder_message: "🛎️ This PR has had no activity in two weeks."
           # Remind after two weeks of inactivity
           inactivity_deadline_hours: 336


### PR DESCRIPTION
Currently the reminders are also active on forks, which isn't very nice. It's also a bad default, but here's a small change that keeps them active only on our repository.