### PR TITLE
Run PHP-CS-Fixer in parallel

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -2,6 +2,7 @@
 
 use PhpCsFixer\Config;
 use PhpCsFixer\Finder;
+use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
 
 $finder = Finder::create()
     ->in([__DIR__])
@@ -14,7 +15,7 @@ $finder = Finder::create()
     ->name('*.sh');
 
 return (new Config())
-    ->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect())
+    ->setParallelConfig(ParallelConfigFactory::detect())
     ->setRiskyAllowed(true)
     ->setRules([
         '@PhpCsFixer' => true,

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -14,6 +14,7 @@ $finder = Finder::create()
     ->name('*.sh');
 
 return (new Config())
+    ->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect())
     ->setRiskyAllowed(true)
     ->setRules([
         '@PhpCsFixer' => true,


### PR DESCRIPTION
Speed up the php-cs-fixer by allow the tool to run in parallel (by default it only uses 1 core). 

See also: https://cs.symfony.com/doc/usage.html