### PR TITLE
"Add field" widget: set `width` to `fit-content`

### DIFF
--- a/skins/elastic/styles/widgets/forms.less
+++ b/skins/elastic/styles/widgets/forms.less
@@ -249,7 +249,7 @@ input.smart-upload {
         margin: 0;
 
         select {
-            width: 8rem;
+            width: fit-content;
             margin-top: .5rem;
         }
     }


### PR DESCRIPTION
Hi,

The address books’ `Add field...` widget currently has its width fixed to `8rem`, truncating some translations; this PR sets the width to `fit-content`.

Before/After:
![Before: "Ajouter un champ..." is truncated to "Ajouter un c".](https://github.com/user-attachments/assets/3147c13e-3999-4b7a-8f65-012ed1c6f08e)
![After: "Ajouter un champ..." is not truncated.](https://github.com/user-attachments/assets/ef133beb-2523-4a93-8c47-2c15c429d04a)