### PR TITLE
Fix displaying message/rfc822 parts

### DIFF
--- a/program/lib/Roundcube/rcube_message.php
+++ b/program/lib/Roundcube/rcube_message.php
@@ -663,10 +663,10 @@ class rcube_message
 
             // parse headers from message/rfc822 part
             if (!isset($structure->headers['subject']) && !isset($structure->headers['from'])) {
-                $part_body = $headers = $this->get_part_body($structure->mime_id, false, 32768);
+                $part_body = $this->get_part_body($structure->mime_id, false, 32768);
 
-                if (($pos = strpos($headers, "\r\n\r\n")) !== false) {
-                    $headers = substr($headers, $pos);
+                if (strpos($part_body, "\r\n\r\n") !== false) {
+                    [$headers] = explode("\r\n\r\n", $part_body, 2);
                 }
 
                 $structure->headers = rcube_mime::parse_headers($headers);

--- a/tests/MessageRendering/MessageRfc822Test.php
+++ b/tests/MessageRendering/MessageRfc822Test.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\MessageRendering;
+
+/**
+ * Test class to test simple messages.
+ */
+class MessageRfc822Test extends MessageRenderingTestCase
+{
+    public function testRfc822Part()
+    {
+        $domxpath = $this->runAndGetHtmlOutputDomxpath('4052c2097de93825c1be040270d98e47@example.net');
+        $this->assertSame('Fwd: Lines', $this->getScrubbedSubject($domxpath));
+
+        $parts = $domxpath->query('//div[@id="messagebody"]/div');
+        $this->assertCount(3, $parts);
+        $this->assertSame('message-part', $parts[0]->attributes->getNamedItem('class')->textContent);
+        $this->assertSame('Check the forwarded message', $parts[0]->textContent);
+        $this->assertSame('message-part', $parts[2]->attributes->getNamedItem('class')->textContent);
+        $this->assertStringStartsWith('Plain text message body.', $parts[2]->textContent);
+
+        $this->assertSame('message-partheaders', $parts[1]->attributes->getNamedItem('class')->textContent);
+
+        $msgRfc822Subject = $domxpath->query('//div[@class="message-partheaders"]//td[@class="header subject"]');
+        $this->assertCount(1, $msgRfc822Subject);
+        $this->assertSame('Lines', $msgRfc822Subject[0]->textContent);
+
+        $msgRfc822From = $domxpath->query('//div[@class="message-partheaders"]//td[@class="header from"]');
+        $this->assertCount(1, $msgRfc822From);
+        $this->assertSame('Thomas B.', $msgRfc822From[0]->textContent);
+
+        $msgRfc822To = $domxpath->query('//div[@class="message-partheaders"]//td[@class="header to"]');
+        $this->assertCount(1, $msgRfc822To);
+        $this->assertSame('Tom Tester', $msgRfc822To[0]->textContent);
+
+        $msgRfc822Cc = $domxpath->query('//div[@class="message-partheaders"]//td[@class="header cc"]');
+        $this->assertCount(1, $msgRfc822Cc);
+        $this->assertSame('test1@domain.tld, test2@domain.tld, test3@domain.tld, test4@domain.tld, test5@domain.tld, test6@domain.tld, test7@domain.tld, test8@domain.tld, test9@domain.tld, test10@domain.tld, test11@domain.tld, test12@domain.tld', $msgRfc822Cc[0]->textContent);
+
+        $msgRfc822ReplyTo = $domxpath->query('//div[@class="message-partheaders"]//td[@class="header mail-reply-to"]');
+        $this->assertCount(1, $msgRfc822ReplyTo);
+        $this->assertSame('hello@roundcube.net', $msgRfc822ReplyTo[0]->textContent);
+
+        $msgRfc822Date = $domxpath->query('//div[@class="message-partheaders"]//td[@class="header date"]');
+        $this->assertCount(1, $msgRfc822Date);
+        // Using a RegExp here, because the result is different depending on the timezone of the testing environment.
+        $this->assertMatchesRegularExpression('/2014-05-2[234]{1} \d{2}:\d{2}/', $msgRfc822Date[0]->textContent);
+    }
+}

--- a/tests/MessageRendering/data/greenmail/test-message-rendering@localhost/INBOX/fwd_lines.eml
+++ b/tests/MessageRendering/data/greenmail/test-message-rendering@localhost/INBOX/fwd_lines.eml
@@ -1,0 +1,74 @@
+MIME-Version: 1.0
+Date: Wed, 15 Jan 2025 11:44:00 +0100
+From: admin@example.net
+To: admin@example.net
+Subject: Fwd: Lines
+In-Reply-To: <99839b8ec12482419372f1edafa9de75@woodcrest.local>
+References: <99839b8ec12482419372f1edafa9de75@woodcrest.local>
+Message-ID: <4052c2097de93825c1be040270d98e47@example.net>
+X-Sender: admin@example.net
+X-Draft-Info: type=forward; uid=3; folder=B::SU5CT1g=
+Content-Type: multipart/mixed;
+ boundary="=_9b038d50a3b2b5cfe9fdbd53743b1ea9"
+
+--=_9b038d50a3b2b5cfe9fdbd53743b1ea9
+Content-Transfer-Encoding: 7bit
+Content-Type: text/plain; charset=US-ASCII;
+ format=flowed
+
+Check the forwarded message
+--=_9b038d50a3b2b5cfe9fdbd53743b1ea9
+Content-Transfer-Encoding: 8bit
+Content-Type: message/rfc822;
+ name=Lines.eml
+Content-Disposition: attachment;
+ filename=Lines.eml;
+ size=1382
+
+Return-Path: <thomas@roundcube.net>
+X-Original-To: tb@tester.local
+From: "Thomas B." <thomas@roundcube.net>
+To: Tom Tester <tb@tester.local>
+Subject: Lines
+Cc: test1@domain.tld, test2@domain.tld, test3@domain.tld, test4@domain.tld,
+ test5@domain.tld, test6@domain.tld, test7@domain.tld, test8@domain.tld,
+ test9@domain.tld, test10@domain.tld, test11@domain.tld, test12@domain.tld
+MIME-Version: 1.0
+Content-Type: multipart/mixed;
+ boundary="=_8853bfb47b7da1852ac882e69cc724f3"
+Date: Fri, 23 May 2014 19:44:50 +0200
+Reply-To: hello@roundcube.net
+Mail-Reply-To: hello@roundcube.net
+Message-ID: <99839b8ec12482419372f1edafa9de75@woodcrest.local>
+X-Sender: thomas@roundcube.net
+
+--=_8853bfb47b7da1852ac882e69cc724f3
+Content-Transfer-Encoding: 7bit
+Content-Type: text/plain; charset=UTF-8;
+ format=flowed
+
+Plain text message body.
+
+-- 
+Developer of Free Software
+Sent with Roundcube Webmail - roundcube.net
+--=_8853bfb47b7da1852ac882e69cc724f3
+Content-Transfer-Encoding: base64
+Content-Type: text/plain;
+ name=lines.txt
+Content-Disposition: attachment;
+ filename=lines.txt;
+ size=13
+
+Zm9vDQpiYXINCmduYQ==
+--=_8853bfb47b7da1852ac882e69cc724f3
+Content-Transfer-Encoding: base64
+Content-Type: text/plain;
+ name=lines_lf.txt
+Content-Disposition: attachment;
+ filename=lines_lf.txt;
+ size=11
+
+Zm9vCmJhcgpnbmE=
+--=_8853bfb47b7da1852ac882e69cc724f3--
+--=_9b038d50a3b2b5cfe9fdbd53743b1ea9--


### PR DESCRIPTION
The previous code contained a simple error that assigned the body part to the $headers variable (which then couldn't be parsed and got discarded).