### PR TITLE
additional_message_headers.php: support CALLABLE/callback via config

### DIFF
--- a/config/config.inc.php.sample
+++ b/config/config.inc.php.sample
@@ -62,5 +62,24 @@ $config['plugins'] = [
     'zipdownload',
 ];
 
-// skin name: folder from skins/
+// Specify Roundcube's Default Skin, equal to the folder name beneath skins/
 $config['skin'] = 'elastic';
+
+// Optional config of the additional_message_headers plugin (Issue #9755; Feb 2025)
+// Uncomment to remove the X-Sender header from outgoing messages:
+// $config['additional_message_headers']['X-Sender'] = null;
+//
+// You can also specify a callback function like this, which would be called when
+// the user clicks the "Send" button, allowing you to access to the rcube object.
+// This example adds an X-RC-USR header with a base64-encoded JSON string.
+// Do not use this in production unless you know what you are doing and your
+// users are informed via Terms of Service or other means of compliance.
+// $config['additional_message_headers']['X-RC-USR'] = (function() {
+//                $d = json_encode([
+//                    'u' => rcube::get_instance()->get_user_name(),
+//                    'r' => $_SERVER['REMOTE_ADDR'],
+//                    'a' => empty($_SERVER['HTTP_USER_AGENT']) ? '-' : $_SERVER['HTTP_USER_AGENT'],
+//                    't' => $_SERVER['REQUEST_TIME']
+//                ]);
+//                return base64_encode($d); # should be encrypted!
+//        });

--- a/config/config.inc.php.sample
+++ b/config/config.inc.php.sample
@@ -70,10 +70,10 @@ $config['skin'] = 'elastic';
 // $config['additional_message_headers']['X-Sender'] = null;
 //
 // You can also specify a callback function like this, which would be called when
-// the user clicks the "Send" button, allowing you to access to the rcube object.
+// the user clicks the "Send" button, giving you access to the rcube object.
 // This example adds an X-RC-USR header with a base64-encoded JSON string.
-// Do not use this in production unless you know what you are doing and your
-// users are informed via Terms of Service or other means of compliance.
+// Kindly take care not to expose personally identifiable information.
+// Do not use below example in production without adjustments and testing.
 // $config['additional_message_headers']['X-RC-USR'] = (function() {
 //                $d = json_encode([
 //                    'u' => rcube::get_instance()->get_user_name(),

--- a/plugins/additional_message_headers/additional_message_headers.php
+++ b/plugins/additional_message_headers/additional_message_headers.php
@@ -55,9 +55,9 @@ class additional_message_headers extends rcube_plugin
                 if (is_callable($val)) {
                     $additional_headers[$key] = $val();
                 } else {
-                    $additional_headers = preg_replace($search, $replace, $val);
+                    $additional_headers[$key] = preg_replace($search, $replace, $val);
                     // replace %%<variable> with %<variable>
-                    $additional_headers = preg_replace('/%(%[uld])/', '\1', $val);                    
+                    $additional_headers[$key] = preg_replace('/%(%[uld])/', '\1', $val);                    
                 }
             }
 

--- a/plugins/additional_message_headers/additional_message_headers.php
+++ b/plugins/additional_message_headers/additional_message_headers.php
@@ -57,7 +57,7 @@ class additional_message_headers extends rcube_plugin
                 } else {
                     $additional_headers[$key] = preg_replace($search, $replace, $val);
                     // replace %%<variable> with %<variable>
-                    $additional_headers[$key] = preg_replace('/%(%[uld])/', '\1', $val);                    
+                    $additional_headers[$key] = preg_replace('/%(%[uld])/', '\1', $val);
                 }
             }
 

--- a/plugins/additional_message_headers/additional_message_headers.php
+++ b/plugins/additional_message_headers/additional_message_headers.php
@@ -55,9 +55,9 @@ class additional_message_headers extends rcube_plugin
                 if (is_callable($val)) {
                     $additional_headers[$key] = $val();
                 } else {
-                    $additional_headers = preg_replace($search, $replace, $additional_headers);
+                    $additional_headers = preg_replace($search, $replace, $val);
                     // replace %%<variable> with %<variable>
-                    $additional_headers = preg_replace('/%(%[uld])/', '\1', $additional_headers);                    
+                    $additional_headers = preg_replace('/%(%[uld])/', '\1', $val);                    
                 }
             }
 


### PR DESCRIPTION
Good day all,

The purpose of this patch is to have Roundcube execute a callback function during runtime, as defined in config.inc.php, for more complex tasks going beyond static strings or their replacements.

For example, one could configure something like this:

```
$config['additional_message_headers']['X-Sender'] = null;
$config['additional_message_headers']['X-RC-USR'] = (function() {
                $d = json_encode([
                    'u' => rcube::get_instance()->get_user_name(),
                    'r' => $_SERVER['REMOTE_ADDR'],
                    'a' => empty($_SERVER['HTTP_USER_AGENT']) ? '-' : $_SERVER['HTTP_USER_AGENT'],
                    't' => $_SERVER['REQUEST_TIME']
                ]);
                return base64_encode($d); # should also be encrypted ;)
        });

```
In this example,
a) disables the cleartext X-Sender header; 
b) adds a dynamic header X-RC-USR in base64-JSON-encoded form, which could later be used for compliance purposes. If this header is automatically processed by the mail gateway, further analysis could aid in detecting abuse patterns, while not directly exposing this sensitive information as human-readable text; if properly encrypted (out of this scope), this could eliminate privacy concerns.

One of the ideas behind this is that using Roundcube (or any other webmailer) usually masquerades the original user's IP address by the webmailer's server IP address to the SMTP server; this is not the case when a user talks to the SMTP server directly.

With tight integration into your setup, you will never again have to sift through different logs/correlate IP address information just to find the guy who sent this message which the person behind the user's login denies having sent.

This patch also reduces two arrays ($search, $replace) into one ($map) for maintainability.