### PR TITLE
add asset url to additional logo paths

### DIFF
--- a/program/include/rcmail_output_html.php
+++ b/program/include/rcmail_output_html.php
@@ -1507,9 +1507,9 @@ class rcmail_output_html extends rcmail_output
 
                     foreach ($logo_types as $type) {
                         if (($template_logo = $this->get_template_logo($type)) !== null) {
-                            $additional_logos[$type] = $this->abs_url($template_logo);
+                            $additional_logos[$type] = $this->asset_url($template_logo, true);
                         } elseif (!empty($attrib['data-src-' . $type])) {
-                            $additional_logos[$type] = $this->abs_url($attrib['data-src-' . $type]);
+                            $additional_logos[$type] = $this->asset_url($attrib['data-src-' . $type], true);
                         }
                     }
 


### PR DESCRIPTION
currently `abs_url` is applied to additional url paths but not `assest_url`. The `true` param means `abs_url` is still applied within `assest_url`. 64df318a733448585db963f6696da133451a6b70 highlighted this but did not cause it.