### PR TITLE
Fix washing html from rcube_attachment_handler

### DIFF
--- a/program/include/rcmail_attachment_handler.php
+++ b/program/include/rcmail_attachment_handler.php
@@ -309,7 +309,13 @@ class rcmail_attachment_handler
         // show images?
         $is_safe = $this->is_safe();
 
-        return rcmail_action_mail_index::wash_html($body, ['safe' => $is_safe, 'inline_html' => false]);
+        if (isset($this->part->replaces)) {
+            $wash_replacements = $this->part->replaces;
+        } else {
+            $wash_replacements = [];
+        }
+
+        return rcmail_action_mail_index::wash_html($body, ['safe' => $is_safe, 'inline_html' => false], $wash_replacements);
     }
 
     /**


### PR DESCRIPTION
This probably wasn't implemented previously because HTML-parts usually didn't run through get.php.

Picked from #9519 