### PR TITLE
Add priority to local message object

### DIFF
--- a/program/js/app.js
+++ b/program/js/app.js
@@ -2392,6 +2392,7 @@ function rcube_webmail() {
             flagged_children: flags.flagged_children || 0,
             parent_uid: flags.parent_uid || 0,
             selected: this.select_all_mode || this.message_list.in_selection(uid),
+            prio: flags.prio ? flags.prio : 0,
             ml: flags.ml ? 1 : 0,
             ctype: flags.ctype,
             mbox: flags.mbox,

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -2392,7 +2392,7 @@ function rcube_webmail() {
             flagged_children: flags.flagged_children || 0,
             parent_uid: flags.parent_uid || 0,
             selected: this.select_all_mode || this.message_list.in_selection(uid),
-            prio: flags.prio ? flags.prio : 0,
+            prio: flags.prio || 0,
             ml: flags.ml ? 1 : 0,
             ctype: flags.ctype,
             mbox: flags.mbox,


### PR DESCRIPTION
The "priority" flag was forgotten in the local message object.
One line is enough to fix it (see code).

It will allow me to add a priority icon in the message list of my Elastic2022 skin. (like outlook)
Adding this missing flag is the cleanest way to do it.

Thanks !
