### PR TITLE
Don't save layout if in dont_override.

### DIFF
--- a/program/actions/mail/list.php
+++ b/program/actions/mail/list.php
@@ -62,8 +62,9 @@ class rcmail_action_mail_list extends rcmail_action_mail_index
         // register layout change
         if ($layout && preg_match('/^[a-zA-Z_-]+$/', $layout)) {
             $rcmail->output->set_env('layout', $layout);
-            if (!in_array('layout', $dont_override))
+            if (!in_array('layout', $dont_override)) {
                 $save_arr['layout'] = $layout;
+            }
             // force header replace on layout change
             if (!empty($_SESSION['list_attrib']['columns'])) {
                 $cols = $_SESSION['list_attrib']['columns'];

--- a/program/actions/mail/list.php
+++ b/program/actions/mail/list.php
@@ -62,7 +62,8 @@ class rcmail_action_mail_list extends rcmail_action_mail_index
         // register layout change
         if ($layout && preg_match('/^[a-zA-Z_-]+$/', $layout)) {
             $rcmail->output->set_env('layout', $layout);
-            $save_arr['layout'] = $layout;
+            if (!in_array('layout', $dont_override))
+                $save_arr['layout'] = $layout;
             // force header replace on layout change
             if (!empty($_SESSION['list_attrib']['columns'])) {
                 $cols = $_SESSION['list_attrib']['columns'];


### PR DESCRIPTION
This simple change ensures that the layout will not be overwritten to user preferences if `layout` is in `dont_override`.

A plugin can thus manipulate the config by adding a hook to `config_get` in order to make the setting of `layout` temporary.  A prime example of a plugin whom this would come in handy is `elastic4mobile`, which currently overwrites the layout setting, as reported in #8403.  A PR for that plugin is coming shortly.