### PR TITLE
Run phpstan also on public_html

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,4 @@ jobs:
         run: composer install --prefer-dist --no-interaction --no-progress
 
       - name: Run Static Analysis
-        run: |
-          rm -r public_html # remove once https://github.com/phpstan/phpstan/issues/10321 is fixed
-          vendor/bin/phpstan analyse -v
+        run: vendor/bin/phpstan analyse -v


### PR DESCRIPTION
Now that public_html isn't just a symlink anymore but contains actual code, that code should be checked, too.