### PR TITLE
Add javascript to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,7 @@ root = true
 end_of_line = lf
 insert_final_newline = true
 
-[*.{json, php, sh}]
+[*.{json, php, sh, js}]
 charset = utf-8
 indent_style = space
 indent_size = 4


### PR DESCRIPTION
We're using 4 spaces for JavaScript, too.