### PR TITLE
Add APCu-Cache

### DIFF
--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -240,7 +240,7 @@ $config['imap_disabled_caps'] = [];
 // This is used to relate IMAP session with Roundcube user sessions
 $config['imap_log_session'] = false;
 
-// Type of IMAP indexes cache. Supported values: 'db', 'apc', 'redis' and 'memcache' or 'memcached'.
+// Type of IMAP indexes cache. Supported values: 'db', 'apc', 'apcu', 'redis' and 'memcache' or 'memcached'.
 $config['imap_cache'] = null;
 
 // Enables messages cache. Only 'db' cache is supported.
@@ -460,7 +460,7 @@ $config['oauth_password_claim'] = null;
 // LDAP
 // ----------------------------------
 
-// Type of LDAP cache. Supported values: 'db', 'apc' and 'memcache' or 'memcached'.
+// Type of LDAP cache. Supported values: 'db', 'apc', 'apcu' and 'memcache' or 'memcached'.
 $config['ldap_cache'] = 'db';
 
 // Lifetime of LDAP cache. Possible units: s, m, h, d, w

--- a/plugins/database_attachments/config.inc.php.dist
+++ b/plugins/database_attachments/config.inc.php.dist
@@ -4,7 +4,7 @@ $config = [];
 
 // By default this plugin stores attachments in filesystem
 // and copies them into sql database.
-// You can change it to use 'memcache', 'memcached', 'redis' or 'apc'.
+// You can change it to use 'memcache', 'memcached', 'redis', 'apc' or 'apcu'.
 // -----------------------------------------------------------
 // WARNING: Remember to set max_allowed_packet in database or
 //          config to match with expected max attachment size.

--- a/program/lib/Roundcube/cache/apcu.php
+++ b/program/lib/Roundcube/cache/apcu.php
@@ -38,7 +38,7 @@ class rcube_cache_apcu extends rcube_cache
         $rcube = rcube::get_instance();
 
         $this->type = 'apcu';
-        $this->enabled = function_exists('apcu_exists'); // APC 3.1.4 required
+        $this->enabled = function_exists('apcu_exists'); // APCu required (pecl install apcu)
         $this->debug = $rcube->config->get('apcu_debug');
     }
 

--- a/program/lib/Roundcube/cache/apcu.php
+++ b/program/lib/Roundcube/cache/apcu.php
@@ -20,7 +20,7 @@
 */
 
 /**
- * Interface implementation class for accessing APC cache
+ * Interface implementation class for accessing APCu cache
  */
 class rcube_cache_apcu extends rcube_cache
 {

--- a/program/lib/Roundcube/cache/apcu.php
+++ b/program/lib/Roundcube/cache/apcu.php
@@ -12,7 +12,7 @@
  | See the README file for a full license statement.                     |
  |                                                                       |
  | PURPOSE:                                                              |
- |   Caching engine - APC                                                |
+ |   Caching engine - APCu                                                |
  +-----------------------------------------------------------------------+
  | Author: Thomas Bruederli <roundcube@gmail.com>                        |
  | Author: Aleksander Machniak <alec@alec.pl>                            |

--- a/program/lib/Roundcube/cache/apcu.php
+++ b/program/lib/Roundcube/cache/apcu.php
@@ -84,7 +84,7 @@ class rcube_cache_apcu extends rcube_cache
     }
 
     /**
-     * Adds entry into memcache/apc/redis DB.
+     * Adds entry into memcache/apc/apcu/redis DB.
      *
      * @param string $key  Cache internal key name
      * @param mixed  $data Serialized cache data
@@ -112,7 +112,7 @@ class rcube_cache_apcu extends rcube_cache
     }
 
     /**
-     * Deletes entry from memcache/apc/redis DB.
+     * Deletes entry from memcache/apc/apcu/redis DB.
      *
      * @param string $key Cache internal key name
      *

--- a/program/lib/Roundcube/cache/apcu.php
+++ b/program/lib/Roundcube/cache/apcu.php
@@ -1,0 +1,136 @@
+<?php
+
+/*
+ +-----------------------------------------------------------------------+
+ | This file is part of the Roundcube Webmail client                     |
+ |                                                                       |
+ | Copyright (C) The Roundcube Dev Team                                  |
+ | Copyright (C) Kolab Systems AG                                        |
+ |                                                                       |
+ | Licensed under the GNU General Public License version 3 or            |
+ | any later version with exceptions for skins & plugins.                |
+ | See the README file for a full license statement.                     |
+ |                                                                       |
+ | PURPOSE:                                                              |
+ |   Caching engine - APC                                                |
+ +-----------------------------------------------------------------------+
+ | Author: Thomas Bruederli <roundcube@gmail.com>                        |
+ | Author: Aleksander Machniak <alec@alec.pl>                            |
+ +-----------------------------------------------------------------------+
+*/
+
+/**
+ * Interface implementation class for accessing APC cache
+ */
+class rcube_cache_apcu extends rcube_cache
+{
+    /**
+     * Indicates if APCu module is enabled and in a required version
+     *
+     * @var bool
+     */
+    protected $enabled;
+
+    public function __construct($userid, $prefix = '', $ttl = 0, $packed = true, $indexed = false)
+    {
+        parent::__construct($userid, $prefix, $ttl, $packed, $indexed);
+
+        $rcube = rcube::get_instance();
+
+        $this->type = 'apcu';
+        $this->enabled = function_exists('apcu_exists'); // APC 3.1.4 required
+        $this->debug = $rcube->config->get('apcu_debug');
+    }
+
+    /**
+     * Remove cache records older than ttl
+     */
+    #[Override]
+    public function expunge()
+    {
+        // No need for GC, entries are expunged automatically
+    }
+
+    /**
+     * Remove expired records of all caches
+     */
+    #[Override]
+    public static function gc()
+    {
+        // No need for GC, entries are expunged automatically
+    }
+
+    /**
+     * Reads cache entry.
+     *
+     * @param string $key Cache internal key name
+     *
+     * @return mixed Cached value
+     */
+    #[Override]
+    protected function get_item($key)
+    {
+        if (!$this->enabled) {
+            return false;
+        }
+
+        $data = apcu_fetch($key);
+
+        if ($this->debug) {
+            $this->debug('get', $key, $data);
+        }
+
+        return $data;
+    }
+
+    /**
+     * Adds entry into memcache/apc/redis DB.
+     *
+     * @param string $key  Cache internal key name
+     * @param mixed  $data Serialized cache data
+     *
+     * @return bool True on success, False on failure
+     */
+    #[Override]
+    protected function add_item($key, $data)
+    {
+        if (!$this->enabled) {
+            return false;
+        }
+
+        if (apcu_exists($key)) {
+            apcu_delete($key);
+        }
+
+        $result = apcu_store($key, $data, $this->ttl);
+
+        if ($this->debug) {
+            $this->debug('set', $key, $data, $result);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Deletes entry from memcache/apc/redis DB.
+     *
+     * @param string $key Cache internal key name
+     *
+     * @return bool True on success, False on failure
+     */
+    #[Override]
+    protected function delete_item($key)
+    {
+        if (!$this->enabled) {
+            return false;
+        }
+
+        $result = apcu_delete($key);
+
+        if ($this->debug) {
+            $this->debug('delete', $key, null, $result);
+        }
+
+        return $result;
+    }
+}

--- a/program/lib/Roundcube/rcube.php
+++ b/program/lib/Roundcube/rcube.php
@@ -215,7 +215,7 @@ class rcube
      * Initialize and get user cache object
      *
      * @param string     $name    Cache identifier
-     * @param string     $type    Cache type ('db', 'apc', 'memcache', 'redis')
+     * @param string     $type    Cache type ('db', 'apc', 'apcu', 'memcache', 'redis')
      * @param string|int $ttl     Expiration time for cache items
      * @param bool       $packed  Enables/disables data serialization
      * @param bool       $indexed Use indexed cache

--- a/program/lib/Roundcube/rcube_cache.php
+++ b/program/lib/Roundcube/rcube_cache.php
@@ -46,7 +46,7 @@ class rcube_cache
     /**
      * Object factory
      *
-     * @param string     $type    Engine type ('db', 'memcache', 'apc', 'redis')
+     * @param string     $type    Engine type ('db', 'memcache', 'apc', 'apcu', 'redis')
      * @param int        $userid  User identifier
      * @param string     $prefix  Key name prefix
      * @param int|string $ttl     Expiration time of memcache/apc items


### PR DESCRIPTION
Since `APC` is (very) outdated in favor of `APCu` and as of PHP `>= 8.0` you can no longer `pecl install apcu_bc` `roundcube` should also support `APCu` in addition to `APC`.

One could also argue that the `APC`-Caching-Class should be removed in future releases of `roundcube` but I think this discussion is out of scope for this PR.