### PR TITLE
elastic: disable spellcheck on recipient inputs (compose)

### DIFF
--- a/skins/elastic/ui.js
+++ b/skins/elastic/ui.js
@@ -3431,7 +3431,7 @@ function rcube_elastic_ui() {
             };
 
         // Create the input element and "editable" area
-        input = $('<input>').attr({ type: 'text', tabindex: $(obj).attr('tabindex') })
+        input = $('<input>').attr({ type: 'text', spellcheck: false, tabindex: $(obj).attr('tabindex') })
             .on('paste change', parse_func)
             .on('keydown', keydown_func)
             .on('blur', function () {


### PR DESCRIPTION
the default recipient inputs created all have a `spellcheck = false` attribute

https://github.com/roundcube/roundcubemail/blob/f7d8852d175b2e12dc59c10cd289977d37d1ffab/program/include/rcmail_sendmail.php#L940

please add the same attribute to the custom inputs that Elastic uses