### PR TITLE
Exclude inline base64 images from static.php

### DIFF
--- a/program/include/rcmail_output_html.php
+++ b/program/include/rcmail_output_html.php
@@ -1084,7 +1084,7 @@ class rcmail_output_html extends rcmail_output
                 $prefix = str_repeat('../', count($path) + 1);
             }
 
-            if (!str_starts_with($location, $prefix . 'static.php') && strpos($location, 'data:image') === false) {
+            if (!str_starts_with($location, $prefix . 'static.php') && !str_starts_with($location, 'data:')) {
                 $location = $prefix . 'static.php/' . $location;
             }
         }

--- a/program/include/rcmail_output_html.php
+++ b/program/include/rcmail_output_html.php
@@ -1084,7 +1084,7 @@ class rcmail_output_html extends rcmail_output
                 $prefix = str_repeat('../', count($path) + 1);
             }
 
-            if (!str_starts_with($location, $prefix . 'static.php') && strpos($location, "data:image") === false) {
+            if (!str_starts_with($location, $prefix . 'static.php') && strpos($location, 'data:image') === false) {
                 $location = $prefix . 'static.php/' . $location;
             }
         }

--- a/program/include/rcmail_output_html.php
+++ b/program/include/rcmail_output_html.php
@@ -1084,7 +1084,7 @@ class rcmail_output_html extends rcmail_output
                 $prefix = str_repeat('../', count($path) + 1);
             }
 
-            if (!str_starts_with($location, $prefix . 'static.php')) {
+            if (!str_starts_with($location, $prefix . 'static.php') && strpos($location, "data:image") === false) {
                 $location = $prefix . 'static.php/' . $location;
             }
         }


### PR DESCRIPTION
Setting a custom skin logo in a plugin with ..config->set('skin_logo', $logo) doesn't seem to work with static.php when the $logo array contains a base64 inline image.
The simplest way I could find to solve this issue is to exclude adding static.php as a suffix to locations containing "data:image".