### PR TITLE
Can use variable in rcmail.gettext, like the php version

### DIFF
--- a/program/js/app.js
+++ b/program/js/app.js
@@ -1656,22 +1656,22 @@ function rcube_webmail() {
     };
 
     // return a localized string
-    this.get_label = function (name, domain, variables = null) {
-        if (domain && this.labels[domain + '.' + name]) {
-            name = this.labels[domain + '.' + name];
+    this.get_label = function (label, domain, variables = null) {
+        if (domain && this.labels[domain + '.' + label]) {
+            label = this.labels[domain + '.' + label];
         }
-        else if (this.labels[name]) {
-            name = this.labels[name];
+        else if (this.labels[label]) {
+            label = this.labels[label];
         }
 
         // set variable value in localized string
         if (variables && Object.keys(variables).length) {
             for (const [key, value] of Object.entries(variables)) {
-                name = name.replaceAll(`$${key}`, value);
+                label = label.replaceAll(`$${key}`, value);
             }
         }
 
-        return name;
+        return label;
     };
 
     // alias for convenience reasons

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -1656,13 +1656,19 @@ function rcube_webmail() {
     };
 
     // return a localized string
-    this.get_label = function (name, domain) {
+    this.get_label = function (name, domain, variables = null) {
         if (domain && this.labels[domain + '.' + name]) {
-            return this.labels[domain + '.' + name];
+            name = this.labels[domain + '.' + name];
+        }
+        else if (this.labels[name]) {
+            name = this.labels[name];
         }
 
-        if (this.labels[name]) {
-            return this.labels[name];
+        // set variable value in localized string
+        if (variables && Object.keys(variables).length) {
+            for (const [key, value] of Object.entries(variables)) {
+                name = name.replaceAll(`$${key}`, value);
+            }
         }
 
         return name;


### PR DESCRIPTION
In PHP, you can use an array as an argument for `rcmail:get_instance()->gettext()` to utilize variables in localization texts. This modification allows the JavaScript version to do the same.