### PR TITLE
Allow to resize the compose textarea

### DIFF
--- a/skins/elastic/styles/widgets/editor.less
+++ b/skins/elastic/styles/widgets/editor.less
@@ -475,7 +475,6 @@ div.tox {
         font-size: 13px;
         width: 100% !important;
         padding-top: 40px;
-        resize: none;
     }
 
     & > iframe { // e.g. mailvelope frame


### PR DESCRIPTION
Sometimes one needs a little bit more space to write an email, then being able to manually draw the edit field bigger is very helpful. 

This had been blocked in https://github.com/roundcube/roundcubemail/commit/1c5f83d41cccefa3e54ae2c752a534fe51136a64, which references https://github.com/roundcube/roundcubemail/issues/7230. But the problem described in that issue doesn't reappear without this CSS statement (tested in Firefox, Chrome and Vivaldi on Mac OS), so I assume we can safely remove it.