### PR TITLE
bug fix: autocomplete fails if contactlist_fields contains vcard fields

### DIFF
--- a/program/lib/Roundcube/rcube_contacts.php
+++ b/program/lib/Roundcube/rcube_contacts.php
@@ -347,7 +347,16 @@ class rcube_contacts extends rcube_addressbook
             foreach ($words as $word) {
                 $groups = [];
                 foreach ((array) $fields as $idx => $col) {
-                    $groups[] = $this->fulltext_sql_where($word, $mode, $col);
+                    // table column
+                    if (in_array($col, $this->table_cols)) {
+                        $groups[] = $this->fulltext_sql_where($word, $mode, $col);
+                    }
+                    // vCard field
+                    else {
+                        if (in_array($col, $this->fulltext_cols)) {
+                            $groups[] = $this->fulltext_sql_where($word, $mode, 'words');
+                        }
+                    }
                 }
                 $where[] = '(' . implode(' OR ', $groups) . ')';
             }


### PR DESCRIPTION
In `config/defaults.inc.php` it says:
```php
// List of fields used on contacts list and for autocompletion searches
// Warning: These are field names not LDAP attributes (see 'fieldmap' setting)!
$config['contactlist_fields'] = ['name', 'firstname', 'surname', 'email'];
```
But if you are using an SQL address book and you add any field which is not of the SQL fields, e.g. `organization` then autocomplete on the compose screen will fail with an error like:
```
DB Error: [1054] Unknown column 'organization' in 'WHERE' (SQL Query: SELECT * FROM `contacts` AS c WHERE c.`del` <> 1 AND c.`user_id` = '4' AND ((`name` LIKE '%n%') OR (`firstname` LIKE '%n%') OR (`surname` LIKE '%n%') OR (`email` LIKE '%n%') OR (`organization` LIKE '%n%')) AND `email` <> '' ORDER BY CONCAT(c.`surname`, c.`firstname`, c.`name`, c.`email`) ASC LIMIT 15) in /var/www/roundcubemail/roundcube_dev/program/lib/Roundcube/rcube_db.php on line 555
```
