### PR TITLE
perf: php session is always written because of __MTIME value

### DIFF
--- a/program/lib/Roundcube/session/php.php
+++ b/program/lib/Roundcube/session/php.php
@@ -81,8 +81,10 @@ class rcube_session_php extends rcube_session
     #[Override]
     public function write_close()
     {
-        $_SESSION['__IP'] = $this->ip;
-        $_SESSION['__MTIME'] = time();
+        if (!isset($_SESSION['__MTIME']) || (time() - $_SESSION['__MTIME']) > ($this->lifetime / 10)) {
+            $_SESSION['__IP'] = $this->ip;
+            $_SESSION['__MTIME'] = time();
+        }
 
         parent::write_close();
     }


### PR DESCRIPTION
On each request the session `__MTIME` variable is updated with the `time()` value so the session is written on each request.
It can be a performance issue when using shared session handler as Redis, as we can see a lot of network traffic to update all this data.
To reduce the network consumption we choose to update `__MTIME` only a time to time, and a little arbitrary we choose to do it each 1/10 session lifetime. As `__MTIME` acted probably as a keep alive for the session, it's steel a good idea to update it regulary, but not too regulary

In our infrastructure, this change reduce the network consumption of Redis by half, so I think it worth the change
