### PR TITLE
fix: ensure proper HTTP status codes for error responses

### DIFF
--- a/program/actions/utils/error.php
+++ b/program/actions/utils/error.php
@@ -107,6 +107,9 @@ class rcmail_action_utils_error extends rcmail_action
 
         $HTTP_ERR_CODE = $ERROR_CODE < 600 ? $ERROR_CODE : 500;
 
+        // Set HTTP response code
+        http_response_code($HTTP_ERR_CODE);
+
         // Ajax request
         if ($rcmail->output && $rcmail->output->type == 'js') {
             $rcmail->output->sendExit('', ["HTTP/1.0 {$HTTP_ERR_CODE} {$error_title}"]);


### PR DESCRIPTION
### Description

This PR ensures that Roundcube consistently returns proper HTTP status codes for error responses, particularly for `404 Not Found` errors.
Previously, some error responses were returning `200 OK` even when resources were not found.

### Issues Fixed or Closed
- Fixes #9737