### PR TITLE
add keep_formatting_default setting

### DIFF
--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -1505,6 +1505,9 @@ $config['mdn_default'] = 0;
 // Delivery Status Notification checkbox default state
 $config['dsn_default'] = 0;
 
+// Keep formatting checkbox default state
+$config['keep_formatting_default'] = 0;
+
 // Place replies in the folder of the message being replied to
 $config['reply_same_folder'] = false;
 

--- a/program/actions/mail/compose.php
+++ b/program/actions/mail/compose.php
@@ -254,6 +254,10 @@ class rcmail_action_mail_compose extends rcmail_action_mail_index
                     $options['dsn_enabled'] = true;
                 }
 
+                if (!empty($info['keep_formatting']) && $info['keep_formatting'] === 'on') {
+                    $options['keep_formatting_enabled'] = true;
+                }
+
                 if ($compose_mode == rcmail_sendmail::MODE_DRAFT) {
                     // get reply_uid/forward_uid to flag the original message when sending
                     if (!empty($info['type'])) {

--- a/program/actions/settings/index.php
+++ b/program/actions/settings/index.php
@@ -841,6 +841,20 @@ class rcmail_action_settings_index extends rcmail_action
                         ];
                     }
 
+                    if (!isset($no_override['keep_formatting_default'])) {
+                        if (!$current) {
+                            continue 2;
+                        }
+
+                        $field_id = 'rcmfd_keep_formatting_default';
+                        $input = new html_checkbox(['name' => '_keep_formatting_default', 'id' => $field_id, 'value' => 1]);
+
+                        $blocks['editor']['options']['keep_formatting_default'] = [
+                            'title' => html::label($field_id, rcube::Q($rcmail->gettext('alwayskeepformatting'))),
+                            'content' => $input->show($config['keep_formatting_default'] ? 1 : 0),
+                        ];
+                    }
+
                     if (!isset($no_override['spellcheck_before_send']) && $config['enable_spellcheck']) {
                         if (!$current) {
                             continue 2;

--- a/program/actions/settings/prefs_save.php
+++ b/program/actions/settings/prefs_save.php
@@ -93,6 +93,7 @@ class rcmail_action_settings_prefs_save extends rcmail_action
                     'force_7bit' => isset($_POST['_force_7bit']),
                     'mdn_default' => isset($_POST['_mdn_default']),
                     'dsn_default' => isset($_POST['_dsn_default']),
+                    'keep_formatting_default' => isset($_POST['_keep_formatting_default']),
                     'reply_same_folder' => isset($_POST['_reply_same_folder']),
                     'spellcheck_before_send' => isset($_POST['_spellcheck_before_send']),
                     'spellcheck_ignore_syms' => isset($_POST['_spellcheck_ignore_syms']),

--- a/program/include/rcmail_sendmail.php
+++ b/program/include/rcmail_sendmail.php
@@ -58,6 +58,7 @@ class rcmail_sendmail
      *                       message (object) - Message object to get some data from
      *                       error_handler (callback) - Error handler
      *                       dsn_enabled (bool) - Enable DSN
+     *                       keep_formatting_enabled (bool) - Enable keep formatting
      */
     public function __construct($data = [], $options = [])
     {
@@ -145,6 +146,7 @@ class rcmail_sendmail
         $dont_override = (array) $this->rcmail->config->get('dont_override');
         $mdn_enabled = in_array('mdn_default', $dont_override) ? $this->rcmail->config->get('mdn_default') : !empty($_POST['_mdn']);
         $dsn_enabled = in_array('dsn_default', $dont_override) ? $this->rcmail->config->get('dsn_default') : !empty($_POST['_dsn']);
+        $keep_formatting_enabled = in_array('keep_formatting_default', $dont_override) ? $this->rcmail->config->get('keep_formatting_default') : !empty($_POST['_keepformatting']);
         $subject = rcube_utils::get_input_string('_subject', rcube_utils::INPUT_POST, true, $charset);
         $from = rcube_utils::get_input_string('_from', rcube_utils::INPUT_POST, true, $charset);
         $replyto = rcube_utils::get_input_string('_replyto', rcube_utils::INPUT_POST, true, $charset);
@@ -198,6 +200,7 @@ class rcmail_sendmail
         $subject = trim(preg_replace('|\r?\n|', ' ', $subject));
 
         $this->options['dsn_enabled'] = $dsn_enabled;
+        $this->options['keep_formatting_enabled'] = $keep_formatting_enabled;
         $this->options['from'] = $from;
         $this->options['mailto'] = $mailto;
 
@@ -262,6 +265,10 @@ class rcmail_sendmail
 
             if ($dsn_enabled) {
                 $draft_info['dsn'] = 'on';
+            }
+
+            if ($keep_formatting_enabled) {
+                $draft_info['keep_formatting'] = 'on';
             }
 
             if (!empty($draft_info)) {
@@ -1426,8 +1433,14 @@ class rcmail_sendmail
 
         $checkbox = new html_checkbox($attrib);
 
+        if (!empty($_POST['_keepformatting']) || !empty($this->options['keep_formatting_enabled'])) {
+            $keep_farmatting_value = 1;
+        } else {
+            $keep_farmatting_value = $this->rcmail->config->get('keep_formatting_default');
+        }
+
         $out = $form_start ? "{$form_start}\n" : '';
-        $out .= $checkbox->show();
+        $out .= $checkbox->show($keep_farmatting_value);
         $out .= $form_end ? "\n{$form_end}" : '';
 
         return $out;

--- a/program/localization/en_US/labels.inc
+++ b/program/localization/en_US/labels.inc
@@ -613,6 +613,7 @@ $labels['automarkread'] = 'Mark messages as read';
 $labels['afternseconds'] = 'after $n seconds';
 $labels['reqmdn'] = 'Always request a return receipt';
 $labels['reqdsn'] = 'Always request a delivery status notification';
+$labels['alwayskeepformatting'] = 'Always keep original text formatting';
 $labels['replysamefolder'] = 'Place replies in the folder of the message being replied to';
 $labels['defaultabook'] = 'Default address book';
 $labels['autocompletesingle'] = 'Skip alternative email addresses in autocompletion';

--- a/skins/elastic/templates/compose.html
+++ b/skins/elastic/templates/compose.html
@@ -46,12 +46,14 @@
 				</div>
 			</div>
 			<roundcube:endif />
+			<roundcube:if condition="!in_array('keep_formatting_default', (array)config:dont_override)" />
 			<div class="form-group row form-check">
 				<label for="compose-keep-formatting" class="col-form-label col-6"><roundcube:label name="keepformatting" /></label>
 				<div class="col-6 form-check">
 					<roundcube:object name="keepFormattingCheckBox" id="compose-keep-formatting" noform="true" tabindex="2" class="form-check-input" />
 				</div>
 			</div>
+			<roundcube:endif />
 			<div class="form-group row">
 				<label for="compose-priority" class="col-form-label col-6"><roundcube:label name="priority" /></label>
 				<div class="col-6">


### PR DESCRIPTION
handle the keep formatting setting on the compose screen the same as other settings e.g. read receipt and dsn. This includes saving the option's value as part of draft info.

closes #8987 and #9703

Regarding [Alec's comment](https://github.com/roundcube/roundcubemail/issues/8987#issuecomment-1537358273) about the number of options in the Composing Messages section, I used the new Editor Options block to keep the display tidy.