### PR TITLE
Render text/markdown mimeparts as HTML

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
         "bacon/bacon-qr-code": "^3.0.0",
         "guzzlehttp/guzzle": "^7.9.2",
         "guzzlehttp/promises": "^2.0",
+        "league/commonmark": "^2.7",
         "masterminds/html5": "~2.9.0",
         "pear/auth_sasl": "~1.2.0",
         "pear/crypt_gpg": "~1.6.3",

--- a/program/actions/mail/compose.php
+++ b/program/actions/mail/compose.php
@@ -735,6 +735,8 @@ class rcmail_action_mail_compose extends rcmail_action_mail_index
                 $body = self::prepare_html_body($body);
             } elseif ($part->ctype_secondary == 'enriched') {
                 $body = rcube_enriched::to_html($body);
+            } elseif ($part->ctype_secondary === 'markdown' || $part->ctype_secondary === 'x-markdown') {
+                $body = rcube_markdown::to_html($body);
             } else {
                 // try to remove the signature
                 if ($strip_signature) {
@@ -747,6 +749,9 @@ class rcmail_action_mail_compose extends rcmail_action_mail_index
         } else {
             if ($part->ctype_secondary == 'enriched') {
                 $body = rcube_enriched::to_html($body);
+                $part->ctype_secondary = 'html';
+            } elseif ($part->ctype_secondary === 'markdown' || $part->ctype_secondary === 'x-markdown') {
+                $body = rcube_markdown::to_html($body);
                 $part->ctype_secondary = 'html';
             }
 

--- a/program/actions/mail/index.php
+++ b/program/actions/mail/index.php
@@ -1060,6 +1060,12 @@ class rcmail_action_mail_index extends rcmail_action
             $body = rcube_enriched::to_html($data['body']);
             $body = self::wash_html($body, $data, $part->replaces);
             $part->ctype_secondary = 'html';
+        }
+        // markdown
+        elseif ($data['type'] === 'markdown' || $data['type'] === 'x-markdown') {
+            $body = rcube_markdown::to_html($data['body']);
+            $body = self::wash_html($body, $data, $part->replaces);
+            $part->ctype_secondary = 'html';
         } else {
             // assert plaintext
             $body = $data['body'];

--- a/program/lib/Roundcube/rcube_config.php
+++ b/program/lib/Roundcube/rcube_config.php
@@ -384,7 +384,7 @@ class rcube_config
             }
         } elseif ($name == 'client_mimetypes') {
             if (!$result && !$def) {
-                $result = 'text/plain,text/html'
+                $result = 'text/plain,text/html,text/markdown,text/x-markdown'
                     . ',image/jpeg,image/gif,image/png,image/bmp,image/tiff,image/webp'
                     . ',application/x-javascript,application/pdf,application/x-shockwave-flash';
             }

--- a/program/lib/Roundcube/rcube_markdown.php
+++ b/program/lib/Roundcube/rcube_markdown.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ +-----------------------------------------------------------------------+
+ | This file is part of the Roundcube Webmail client                     |
+ |                                                                       |
+ | Copyright (C) The Roundcube Dev Team                                  |
+ |                                                                       |
+ | Licensed under the GNU General Public License version 3 or            |
+ | any later version with exceptions for skins & plugins.                |
+ | See the README file for a full license statement.                     |
+ |                                                                       |
+ | PURPOSE:                                                              |
+ |   Helper class to convert Markdown text to HTML format                |
+ |                                                                       |
+ +-----------------------------------------------------------------------+
+ */
+
+use League\CommonMark\Environment\Environment;
+use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
+use League\CommonMark\MarkdownConverter;
+
+/**
+ * Class for Markdown to HTML conversion
+ */
+class rcube_markdown
+{
+    public static function to_html(string $markdown): string
+    {
+        return self::converter()->convert($markdown);
+    }
+
+    protected static function converter()
+    {
+        // Some settings for security.
+        $config = [
+            'html_input' => 'strip',
+            'allow_unsafe_links' => false,
+        ];
+        $environment = new Environment($config);
+        $environment->addExtension(new CommonMarkCoreExtension());
+        // GFM bundles some commonly used syntax extensions as well as protects against some raw HTML elements that can
+        // breaks things easily.
+        $environment->addExtension(new GithubFlavoredMarkdownExtension());
+
+        $converter = new MarkdownConverter($environment);
+        $converter = new MarkdownConverter($environment);
+        return $converter;
+    }
+}

--- a/program/lib/Roundcube/rcube_message.php
+++ b/program/lib/Roundcube/rcube_message.php
@@ -359,7 +359,7 @@ class rcube_message
      * a real part not an attachment (or its part)
      *
      * @param bool                    $check_convertible Enables checking for text/enriched or markdown parts, too
-     * @param rcube_message_part|null &$ref     Reference to the part if found
+     * @param rcube_message_part|null &$ref              Reference to the part if found
      *
      * @return bool True if a HTML is available, False if not
      */
@@ -477,7 +477,7 @@ class rcube_message
     /**
      * Return the first HTML part of this message
      *
-     * @param rcube_message_part &$part    Reference to the part if found
+     * @param rcube_message_part &$part             Reference to the part if found
      * @param bool               $check_convertible Enables checking for text/enriched or markdown parts, too
      *
      * @return string|null HTML message part content

--- a/program/lib/Roundcube/rcube_message.php
+++ b/program/lib/Roundcube/rcube_message.php
@@ -358,16 +358,16 @@ class rcube_message
      * Determine if the message contains a HTML part. This must to be
      * a real part not an attachment (or its part)
      *
-     * @param bool                    $enriched Enables checking for text/enriched parts too
+     * @param bool                    $check_convertible Enables checking for text/enriched or markdown parts, too
      * @param rcube_message_part|null &$ref     Reference to the part if found
      *
      * @return bool True if a HTML is available, False if not
      */
-    public function has_html_part($enriched = false, &$ref = null)
+    public function has_html_part($check_convertible = false, &$ref = null)
     {
         // check all message parts
         foreach ($this->mime_parts as $part) {
-            if ($part->mimetype == 'text/html' || ($enriched && $part->mimetype == 'text/enriched')) {
+            if ($part->mimetype == 'text/html' || ($check_convertible && ($part->mimetype == 'text/enriched' || $part->mimetype === 'text/markdown' || $part->mimetype === 'text/x-markdown'))) {
                 // Skip if part is an attachment, don't use is_attachment() here
                 if ($part->filename) {
                     continue;
@@ -478,17 +478,19 @@ class rcube_message
      * Return the first HTML part of this message
      *
      * @param rcube_message_part &$part    Reference to the part if found
-     * @param bool               $enriched Enables checking for text/enriched parts too
+     * @param bool               $check_convertible Enables checking for text/enriched or markdown parts, too
      *
      * @return string|null HTML message part content
      */
-    public function first_html_part(&$part = null, $enriched = false)
+    public function first_html_part(&$part = null, $check_convertible = false)
     {
-        if ($this->has_html_part($enriched, $part)) {
+        if ($this->has_html_part($check_convertible, $part)) {
             $body = $this->get_part_body($part->mime_id, true);
 
             if ($part->mimetype == 'text/enriched') {
                 $body = rcube_enriched::to_html($body);
+            } elseif ($part->mimetype == 'text/markdown' || $part->mimetype == 'text/x-markdown') {
+                $body = rcube_markdown::to_html($body);
             }
 
             return $body;
@@ -759,7 +761,7 @@ class rcube_message
         // print body if message doesn't have multiple parts
         if ($message_ctype_primary == 'text' && !$recursive) {
             // parts with unsupported type add to attachments list
-            if (!in_array($message_ctype_secondary, ['plain', 'html', 'enriched'])) {
+            if (!in_array($message_ctype_secondary, ['plain', 'html', 'enriched', 'markdown', 'x-markdown'])) {
                 $this->add_attachment($structure);
                 return;
             }
@@ -807,6 +809,8 @@ class rcube_message
                     $this->got_html_part = true;
                 } elseif ($sub_mimetype == 'text/enriched' && !isset($enriched_part)) {
                     $enriched_part = $p;
+                } elseif (($sub_mimetype === 'text/markdown' || $sub_mimetype === 'text/x-markdown') && !isset($markdown_part)) {
+                    $markdown_part = $p;
                 } else {
                     // add unsupported/unrecognized parts to attachments list
                     $this->add_attachment($sub_part);
@@ -831,6 +835,8 @@ class rcube_message
                 $print_part = $structure->parts[$html_part];
             } elseif (isset($enriched_part)) {
                 $print_part = $structure->parts[$enriched_part];
+            } elseif (isset($markdown_part)) {
+                $print_part = $structure->parts[$markdown_part];
             } elseif (isset($plain_part)) {
                 $print_part = $structure->parts[$plain_part];
             }
@@ -919,7 +925,7 @@ class rcube_message
                     $this->parse_structure($mail_part, true);
                 }
                 // part text/[plain|html] or delivery status
-                elseif ((($part_mimetype == 'text/plain' || $part_mimetype == 'text/html') && $mail_part->disposition != 'attachment')
+                elseif ((in_array($part_mimetype, ['text/plain', 'text/html', 'text/markdown', 'text/x-markdown']) && $mail_part->disposition != 'attachment')
                     || in_array($part_mimetype, ['message/delivery-status', 'text/rfc822-headers', 'message/disposition-notification'])
                 ) {
                     // Allow plugins to handle also this part

--- a/tests/Framework/MarkdownTest.php
+++ b/tests/Framework/MarkdownTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Roundcube\Tests\Framework;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class to test rcube_markdown class
+ */
+class MarkdownTest extends TestCase
+{
+    public function test_to_html()
+    {
+        // A test string that includes syntax from GitHub Flavoured Markdown.
+        $source = <<<'END'
+            # A headline
+
+            Hello there!
+
+            ---------
+
+            * one
+            * two
+            * three
+
+            ~not~
+            END;
+
+        $expected = <<<'END'
+            <h1>A headline</h1>
+            <p>Hello there!</p>
+            <hr />
+            <ul>
+            <li>one</li>
+            <li>two</li>
+            <li>three</li>
+            </ul>
+            <p><del>not</del></p>
+
+            END;
+
+        $markdown = \rcube_markdown::to_html($source);
+        $this->assertSame($expected, $markdown);
+    }
+}

--- a/tests/MessageRendering/MarkdownTest.php
+++ b/tests/MessageRendering/MarkdownTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\MessageRendering;
+
+/**
+ * Test class to test simple messages.
+ */
+class MarkdownTest extends MessageRenderingTestCase
+{
+    public function testMarkdownContent()
+    {
+        $domxpath = $this->runAndGetHtmlOutputDomxpath('e40d23f5d4b928f1536699b0723fa4a84ef3467d76ecbcdc361e8c394c6675a3@example.net');
+
+        $this->assertSame('Markdown', $this->getScrubbedSubject($domxpath));
+
+        $msgParts = $domxpath->query('//div[@class="message-part"]');
+        $this->assertCount(1, $msgParts, 'Message text parts');
+
+        $paragraphs = $domxpath->query('//div[@class="message-part"]//p');
+        $this->assertCount(2, $paragraphs);
+
+        $html = $paragraphs[0]->ownerDocument->saveHTML($paragraphs[0]);
+        $this->assertSame('<p><strong>Hello!</strong></p>', $html);
+
+        $html = $paragraphs[1]->ownerDocument->saveHTML($paragraphs[1]);
+        $this->assertSame("<p>I'm <em>really</em> happy that you're <em>reading</em> this!</p>", $html);
+
+        $attchNames = $domxpath->query('//span[@class="attachment-name"]');
+        $this->assertCount(0, $attchNames, 'Attachments');
+    }
+
+    public function testPlaintextAndMarkdownContent()
+    {
+        $domxpath = $this->runAndGetHtmlOutputDomxpath('60fb477df7365015fea1b6adc4e85d3dec0571f3260d609768f3427e6bfc8f61@example.net');
+
+        $this->assertSame('Plaintext and markdown', $this->getScrubbedSubject($domxpath));
+
+        $msgParts = $domxpath->query('//div[@class="message-part"]');
+        $this->assertCount(2, $msgParts, 'Message text parts');
+
+        $this->assertSame('Please read the attached markdown file.', $msgParts[0]->textContent);
+
+        $paragraphs = $domxpath->query('//div[@class="message-part"]//p');
+        $this->assertCount(2, $paragraphs);
+
+        $html = $paragraphs[0]->ownerDocument->saveHTML($paragraphs[0]);
+        $this->assertSame('<p><strong>Hello!</strong></p>', $html);
+
+        $html = $paragraphs[1]->ownerDocument->saveHTML($paragraphs[1]);
+        $this->assertSame("<p>I'm <em>really</em> happy that you're <em>reading</em> this!</p>", $html);
+
+        $attchNames = $domxpath->query('//span[@class="attachment-name"]');
+        $this->assertCount(1, $attchNames, 'Attachments');
+        $this->assertSame('test.md', $attchNames[0]->textContent);
+    }
+
+    public function testPlaintextWithMarkdownAttachment()
+    {
+        $domxpath = $this->runAndGetHtmlOutputDomxpath('76fc626530d3253af13591c298d887acb801b440cdf3458da1882d667b8220aa@example.net');
+
+        $this->assertSame('Plaintext with markdown attachment', $this->getScrubbedSubject($domxpath));
+
+        $msgParts = $domxpath->query('//div[@class="message-part"]');
+        $this->assertCount(1, $msgParts, 'Message text parts');
+
+        $this->assertSame('Please read the attached markdown file.', $msgParts[0]->textContent);
+
+        $attchNames = $domxpath->query('//span[@class="attachment-name"]');
+        $this->assertCount(1, $attchNames, 'Attachments');
+        $this->assertSame('test.md', $attchNames[0]->textContent);
+    }
+}

--- a/tests/MessageRendering/data/greenmail/test-message-rendering@localhost/INBOX/markdown.eml
+++ b/tests/MessageRendering/data/greenmail/test-message-rendering@localhost/INBOX/markdown.eml
@@ -1,0 +1,23 @@
+From: Someone <dev@example.net>
+To: Tom Tester <tom@example.net>
+Subject: Markdown
+MIME-Version: 1.0
+Date: Fri, 12 June 2025 23:42:00 +0200
+Message-ID: <e40d23f5d4b928f1536699b0723fa4a84ef3467d76ecbcdc361e8c394c6675a3@example.net>
+X-Comment: We can't test with a message that contains "text/markdown" as primary Content-Type,
+ because our testing IMAP server greenmail then sends the body base64-encoded, even though that's
+ not specified in the message, which breaks the tests. In manual tests with Dovecot the rendering
+ of this message is identical to one with "text/markdown" as primary Content-Type.
+Content-Type: multipart/mixed; boundary=laisj0r9uqwaosijflaskdjflakj
+
+--laisj0r9uqwaosijflaskdjflakj
+Content-Type: text/markdown
+Content-Transfer-Encoding: 7bit
+
+**Hello!**
+
+I'm _really_ happy that you're *reading* this!
+
+<img src='alskdjf' onerror='alert("vulnerable!")' />
+
+--laisj0r9uqwaosijflaskdjflakj--

--- a/tests/MessageRendering/data/greenmail/test-message-rendering@localhost/INBOX/plaintext_and_markdown.eml
+++ b/tests/MessageRendering/data/greenmail/test-message-rendering@localhost/INBOX/plaintext_and_markdown.eml
@@ -1,0 +1,26 @@
+Return-Path: <dev@example.net>
+From: Someone <dev@example.net>
+To: Tom Tester <tom@example.net>
+Subject: Plaintext and markdown
+MIME-Version: 1.0
+Content-Type: multipart/mixed;
+ boundary="361d749fcdac5d2e8bba45e731bfcb3e8f6be320448ed5519ffe639ff12ad697"
+Date: Fri, 12 June 2025 23:42:00 +0200
+Message-ID: <60fb477df7365015fea1b6adc4e85d3dec0571f3260d609768f3427e6bfc8f61@example.net>
+
+--361d749fcdac5d2e8bba45e731bfcb3e8f6be320448ed5519ffe639ff12ad697
+Content-Type: text/plain; charset=US-ASCII;
+
+Please read the attached markdown file.
+
+--361d749fcdac5d2e8bba45e731bfcb3e8f6be320448ed5519ffe639ff12ad697
+Content-Type: text/markdown
+Content-Disposition: inline; filename="test.md"
+
+**Hello!**
+
+I'm _really_ happy that you're *reading* this!
+
+<img src='alskdjf' onerror='alert("vulnerable!")' />
+
+--361d749fcdac5d2e8bba45e731bfcb3e8f6be320448ed5519ffe639ff12ad697--

--- a/tests/MessageRendering/data/greenmail/test-message-rendering@localhost/INBOX/plaintext_with_markdown_attachment.eml
+++ b/tests/MessageRendering/data/greenmail/test-message-rendering@localhost/INBOX/plaintext_with_markdown_attachment.eml
@@ -1,0 +1,26 @@
+Return-Path: <dev@example.net>
+From: Someone <dev@example.net>
+To: Tom Tester <tom@example.net>
+Subject: Plaintext with markdown attachment
+MIME-Version: 1.0
+Content-Type: multipart/mixed;
+ boundary="f275d1a45738d82706320777badbf339026bbe5fb27efb8c62458ad65ae13cef"
+Date: Fri, 12 June 2025 23:42:00 +0200
+Message-ID: <76fc626530d3253af13591c298d887acb801b440cdf3458da1882d667b8220aa@example.net>
+
+--f275d1a45738d82706320777badbf339026bbe5fb27efb8c62458ad65ae13cef
+Content-Type: text/plain; charset=US-ASCII;
+
+Please read the attached markdown file.
+
+--f275d1a45738d82706320777badbf339026bbe5fb27efb8c62458ad65ae13cef
+Content-Type: text/markdown
+Content-Disposition: attachment; filename="test.md"
+
+**Hello!**
+
+I'm _really_ happy that you're *reading* this!
+
+<img src='alskdjf' onerror='alert("vulnerable!")' />
+
+--f275d1a45738d82706320777badbf339026bbe5fb27efb8c62458ad65ae13cef--


### PR DESCRIPTION
This implements rendering mime-types with content-type 'text/markdown' and 'text/x-markdown' into HTML in the preview and show views (if not "dispositioned" as "attachment"), but not in the get view for attached files (the one opening attachments in an external window.)

I chose the [commonmark](https://github.com/thephpleague/commonmark) library because it appears to be more flexible than others, and has relevant extensions and readable code. Additionally the same authors publish an [html-to-markdown](https://github.com/thephpleague/html-to-markdown) library, which might come in handy if we want to tackle composing in markdown (#6276) one day, and then the encoding/decoding libraries should agree on technical details, which is more likely if they are written by the same people.

Closes #8873

### Screenshots

An email with only a markdown mime-part:

<img width="452" alt="Screenshot 2025-06-18 at 11 11 16" src="https://github.com/user-attachments/assets/8eda1a23-3a1b-4a2e-9e64-bd4a6833ff6c" />

--------

An email with a plaintext part and a markdown part "dispositioned" as "inline":

<img width="409" alt="Screenshot 2025-06-18 at 11 11 07" src="https://github.com/user-attachments/assets/700d926c-50c7-4fd8-bdb3-6ed053c93233" />

--------

An email with a plaintext part and a markdown part "dispositioned" as attachment:

<img width="531" alt="Screenshot 2025-06-18 at 12 52 15" src="https://github.com/user-attachments/assets/420175f8-dcb5-43e9-9659-23bd53a981e4" />
