### PR TITLE
add scope param for contact search

### DIFF
--- a/program/actions/contacts/search.php
+++ b/program/actions/contacts/search.php
@@ -45,10 +45,13 @@ class rcmail_action_contacts_search extends rcmail_action_contacts_index
         $adv = isset($_POST['_adv']);
         $sid = rcube_utils::get_input_string('_sid', rcube_utils::INPUT_GET);
         $search = null;
+        $scope = null;
 
         // get search criteria from saved search
         if ($sid && ($search = $rcmail->user->get_search($sid))) {
             $fields = $search['data']['fields'];
+            // scope param added in 1.7, existence check for backwards compatibility
+            $scope = isset($search['data']['scope']) ? $search['data']['scope'] : null;
             $search = $search['data']['search'];
         }
         // get fields/values from advanced search form
@@ -56,9 +59,13 @@ class rcmail_action_contacts_search extends rcmail_action_contacts_index
             $fields = [];
             foreach (array_keys($_POST) as $key) {
                 $s = trim(rcube_utils::get_input_string($key, rcube_utils::INPUT_POST, true));
-                if (strlen($s) && preg_match('/^_search_([a-zA-Z0-9_-]+)$/', $key, $m)) {
-                    $search[] = $s;
-                    $fields[] = $m[1];
+                if (strlen($s)) {
+                    if (preg_match('/^_search_([a-zA-Z0-9_-]+)$/', $key, $m)) {
+                        $search[] = $s;
+                        $fields[] = $m[1];
+                    } elseif ($key == '_scope') {
+                        $scope = $s;
+                    }
                 }
             }
 
@@ -71,6 +78,7 @@ class rcmail_action_contacts_search extends rcmail_action_contacts_index
         else {
             $search = trim(rcube_utils::get_input_string('_q', rcube_utils::INPUT_GET, true));
             $fields = rcube_utils::get_input_string('_headers', rcube_utils::INPUT_GET);
+            $scope = strlen($_GET['_scope']) ? rcube_utils::get_input_string('_scope', rcube_utils::INPUT_GET) : null;
 
             if (empty($fields)) {
                 $fields = array_keys(self::$SEARCH_MODS_DEFAULT);
@@ -104,6 +112,10 @@ class rcmail_action_contacts_search extends rcmail_action_contacts_index
         $records = [];
 
         foreach ($sources as $s) {
+            if (isset($scope) && $scope !== $s['id']) {
+                continue;
+            }
+
             $source = $rcmail->get_address_book($s['id']);
 
             // check if search fields are supported....
@@ -167,7 +179,7 @@ class rcmail_action_contacts_search extends rcmail_action_contacts_index
 
         // save search settings in session
         $_SESSION['contact_search'][$search_request] = $search_set;
-        $_SESSION['contact_search_params'] = ['id' => $search_request, 'data' => [$fields, $search]];
+        $_SESSION['contact_search_params'] = ['id' => $search_request, 'data' => [$fields, $search], 'scope' => $scope];
         $_SESSION['page'] = 1;
 
         if ($adv) {
@@ -249,6 +261,20 @@ class rcmail_action_contacts_search extends rcmail_action_contacts_index
             }
         }
 
+        // add search scope field
+        $coltypes['_scope'] = [
+            'id' => 'scope',
+            'type' => 'select',
+            'category'=> 'main',
+            'label' => $rcmail->gettext('searchscope'),
+            'options' => [
+                'base' => $rcmail->gettext('currentaddressbook'),
+                'all' => $rcmail->gettext('alladdressbooks')
+            ],
+            'value' => 'all',
+            'skip-empty' => true
+        ];
+
         // build form fields list
         foreach ($coltypes as $col => $colprop) {
             if (!isset($colprop['type'])) {
@@ -266,11 +292,12 @@ class rcmail_action_contacts_search extends rcmail_action_contacts_index
                     $colprop['size'] = $i_size;
                 }
 
-                $colprop['id'] = '_search_' . $col;
+                $fname = !empty($colprop['id']) ? $colprop['id'] : 'search_' . $col;
+                $colprop['id'] = !empty($colprop['id']) ? '_' . $colprop['id'] : '_search_' . $col;
 
                 $content = html::div('row',
                     html::label(['class' => 'contactfieldlabel label', 'for' => $colprop['id']], rcube::Q($label))
-                    . html::div('contactfieldcontent', rcube_output::get_edit_field('search_' . $col, '', $colprop, $ftype))
+                    . html::div('contactfieldcontent', rcube_output::get_edit_field($fname, $colprop['value'] ?? '', $colprop, $ftype))
                 );
 
                 $form[$category]['content'][] = $content;

--- a/program/actions/contacts/search.php
+++ b/program/actions/contacts/search.php
@@ -51,7 +51,7 @@ class rcmail_action_contacts_search extends rcmail_action_contacts_index
         if ($sid && ($search = $rcmail->user->get_search($sid))) {
             $fields = $search['data']['fields'];
             // scope param added in 1.7, existence check for backwards compatibility
-            $scope = isset($search['data']['scope']) ? $search['data']['scope'] : null;
+            $scope = $search['data']['scope'] ?? null;
             $search = $search['data']['search'];
         }
         // get fields/values from advanced search form
@@ -265,14 +265,14 @@ class rcmail_action_contacts_search extends rcmail_action_contacts_index
         $coltypes['_scope'] = [
             'id' => 'scope',
             'type' => 'select',
-            'category'=> 'main',
+            'category' => 'main',
             'label' => $rcmail->gettext('searchscope'),
             'options' => [
                 'base' => $rcmail->gettext('currentaddressbook'),
-                'all' => $rcmail->gettext('alladdressbooks')
+                'all' => $rcmail->gettext('alladdressbooks'),
             ],
             'value' => 'all',
-            'skip-empty' => true
+            'skip-empty' => true,
         ];
 
         // build form fields list

--- a/program/actions/contacts/search.php
+++ b/program/actions/contacts/search.php
@@ -78,7 +78,7 @@ class rcmail_action_contacts_search extends rcmail_action_contacts_index
         else {
             $search = trim(rcube_utils::get_input_string('_q', rcube_utils::INPUT_GET, true));
             $fields = rcube_utils::get_input_string('_headers', rcube_utils::INPUT_GET);
-            $scope = strlen($_GET['_scope']) ? rcube_utils::get_input_string('_scope', rcube_utils::INPUT_GET) : null;
+            $scope = isset($_GET['_scope']) && strlen($_GET['_scope']) ? rcube_utils::get_input_string('_scope', rcube_utils::INPUT_GET) : null;
 
             if (empty($fields)) {
                 $fields = array_keys(self::$SEARCH_MODS_DEFAULT);

--- a/program/actions/contacts/search_create.php
+++ b/program/actions/contacts/search_create.php
@@ -47,6 +47,7 @@ class rcmail_action_contacts_search_create extends rcmail_action
                 'data' => [
                     'fields' => $params['data'][0],
                     'search' => $params['data'][1],
+                    'scope' => $params['scope'],
                 ],
             ];
 

--- a/program/actions/mail/search_contacts.php
+++ b/program/actions/mail/search_contacts.php
@@ -117,7 +117,7 @@ class rcmail_action_mail_search_contacts extends rcmail_action_mail_list_contact
 
             // save search settings in session
             $_SESSION['contact_search'][$search_request] = $search_set;
-            $_SESSION['contact_search_params'] = ['id' => $search_request, 'data' => [$afields, $search]];
+            $_SESSION['contact_search_params'] = ['id' => $search_request, 'data' => [$afields, $search], 'scope' => null];
 
             $rcmail->output->show_message('contactsearchsuccessful', 'confirmation', ['nr' => $result->count]);
 

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -5832,6 +5832,8 @@ function rcube_webmail() {
                 this.clear_message_list();
             } else if (this.contact_list) {
                 this.list_contacts_clear();
+                // use env.last_source as env.source is overwritten by search action
+                url._scope = this.env.search_scope == 'base' ? this.env.last_source : null;
             }
 
             if (this.env.source) {
@@ -7489,6 +7491,9 @@ function rcube_webmail() {
                     if (this.name.match(/^_search/) && this.value != '') {
                         form[this.name] = this.value;
                         valid = true;
+                    } else if (this.name == '_scope' && this.value == 'base') {
+                        // use env.last_source as env.source is overwritten by search action
+                        form[this.name] = ref.env.last_source;
                     }
                 });
 

--- a/program/localization/en_US/labels.inc
+++ b/program/localization/en_US/labels.inc
@@ -263,6 +263,8 @@ $labels['searchinterval-1Y'] = 'older than a year';
 $labels['searchinterval1W'] = 'younger than a week';
 $labels['searchinterval1M'] = 'younger than a month';
 $labels['searchinterval1Y'] = 'younger than a year';
+$labels['currentaddressbook'] = 'Current address book';
+$labels['alladdressbooks'] = 'All address books';
 
 $labels['openinextwin'] = 'Open in new window';
 $labels['emlsave'] = 'Download (.eml)';

--- a/skins/elastic/templates/addressbook.html
+++ b/skins/elastic/templates/addressbook.html
@@ -42,6 +42,15 @@
 				<li><label><input type="checkbox" name="s_mods[]" value="email" /><roundcube:label name="email" /></label></li>
 				<li><label><input type="checkbox" name="s_mods[]" value="*" /><roundcube:label name="allfields" /></label></li>
 			</ul>
+			<div class="input-group">
+				<div class="input-group-prepend">
+					<label for="s_scope" class="input-group-text"><roundcube:label name="searchscope" /></label>
+				</div>
+				<select name="s_scope" id="s_scope" class="custom-select">
+					<option value="base"><roundcube:label name="currentaddressbook" /></option>
+					<option value="all"><roundcube:label name="alladdressbooks" /></option>
+				</select>
+			</div>
 		</div>
 		<div class="formbuttons">
 			<button type="button" class="btn btn-primary icon search" onclick="return rcmail.command('search')"><roundcube:label name="search" /></button>

--- a/skins/elastic/ui.js
+++ b/skins/elastic/ui.js
@@ -2843,7 +2843,7 @@ function rcube_elastic_ui() {
             interval_select = $('#s_interval', obj),
             mbox = rcmail.env.mailbox,
             mods = rcmail.env.search_mods,
-            scope = rcmail.env.search_scope || 'base';
+            scope = rcmail.env.search_scope || (rcmail.task == 'addressbook' ? 'all' : 'base');
 
         if (!$(obj).data('initialized')) {
             $(obj).data('initialized', true);

--- a/tests/Actions/Contacts/DeleteTest.php
+++ b/tests/Actions/Contacts/DeleteTest.php
@@ -41,7 +41,7 @@ class DeleteTest extends ActionTestCase
         $this->assertSame('delete', $result['action']);
         $this->assertSame(1, $result['env']['pagecount']);
         $this->assertTrue(str_contains($result['exec'], 'this.display_message("Contact(s) deleted successfully.","confirmation",0);'));
-        $this->assertTrue(str_contains($result['exec'], 'this.set_rowcount("Contacts 1 to 5 of 5")'));
+        $this->assertTrue(str_contains($result['exec'], 'this.set_rowcount("Contacts 1 to 6 of 6")'));
 
         $query = $db->query('SELECT * FROM `contacts` WHERE `contact_id` = ?', $cid);
         $result = $db->fetch_assoc($query);

--- a/tests/Actions/Contacts/ExportTest.php
+++ b/tests/Actions/Contacts/ExportTest.php
@@ -44,8 +44,8 @@ class ExportTest extends ActionTestCase
 
         $this->assertContains('Content-Type: text/vcard; charset=UTF-8', $output->headers);
         $this->assertContains('Content-Disposition: attachment; filename="contacts.vcf"', $output->headers);
-        $this->assertSame(6, substr_count($vcf, 'BEGIN:VCARD'));
-        $this->assertSame(6, substr_count($vcf, 'END:VCARD'));
+        $this->assertSame(7, substr_count($vcf, 'BEGIN:VCARD'));
+        $this->assertSame(7, substr_count($vcf, 'END:VCARD'));
         $this->assertSame(1, substr_count($vcf, 'FN:Jane Stalone'));
     }
 

--- a/tests/Actions/Contacts/ListTest.php
+++ b/tests/Actions/Contacts/ListTest.php
@@ -33,9 +33,9 @@ class ListTest extends ActionTestCase
 
         $commands = explode("\n", trim($result['exec']));
 
-        $this->assertCount(8, $commands);
+        $this->assertCount(9, $commands);
         $this->assertSame('this.set_group_prop(null);', $commands[0]);
-        $this->assertSame('this.set_rowcount("Contacts 1 to 6 of 6");', $commands[1]);
+        $this->assertSame('this.set_rowcount("Contacts 1 to 7 of 7");', $commands[1]);
         $this->assertStringMatchesFormat(
             'this.add_contact_row("%i",{"name":"George Bush"},"person",'
             . '{"name":"George Bush","email":"g.bush@gov.com","ID":"%i"});',

--- a/tests/Actions/Contacts/MoveTest.php
+++ b/tests/Actions/Contacts/MoveTest.php
@@ -36,9 +36,9 @@ class MoveTest extends ActionTestCase
 
         $this->assertContains('Content-Type: application/json; charset=UTF-8', $output->headers);
         $this->assertSame('move', $result['action']);
-        $this->assertSame(0, $result['env']['pagecount']);
+        $this->assertSame(1, $result['env']['pagecount']);
         $this->assertTrue(str_contains($result['exec'], 'this.display_message("Successfully moved 1 contacts.","confirmation",0);'));
-        $this->assertTrue(str_contains($result['exec'], 'this.set_rowcount("No contacts found.");'));
+        $this->assertTrue(str_contains($result['exec'], 'this.set_rowcount("Contacts 1 to 1 of 1");'));
 
         $query = $db->query('SELECT * FROM `contacts` WHERE `email` = ?', 'test@collected.eu');
         $result = $db->fetch_assoc($query);

--- a/tests/Actions/Contacts/SearchTest.php
+++ b/tests/Actions/Contacts/SearchTest.php
@@ -67,7 +67,7 @@ class SearchTest extends ActionTestCase
     /**
      * Test search scope
      */
-    public function test_search_scope()
+    public function test_run_quick_search_scope()
     {
         $action = new \rcmail_action_contacts_search();
         $output = $this->initOutput(\rcmail_action::MODE_AJAX, 'contacts', 'search');
@@ -134,6 +134,44 @@ class SearchTest extends ActionTestCase
         $this->assertTrue(str_contains($result['exec'], 'this.enable_command("search-create",true);'));
         $this->assertTrue(str_contains($result['exec'], 'this.update_group_commands()'));
         $this->assertTrue(str_contains($result['exec'], 'this.list_contacts_clear();'));
+    }
+
+    public function test_run_search_scope()
+    {
+        $action = new \rcmail_action_contacts_search();
+        $output = $this->initOutput(\rcmail_action::MODE_AJAX, 'contacts', 'search');
+
+        $this->assertTrue($action->checks());
+
+        self::initDB('contacts');
+
+        $_POST = ['_adv' => '1', '_search_email' => 'target'];
+
+        $this->runAndAssert($action, OutputJsonMock::E_EXIT);
+
+        $result = $output->getOutput();
+
+        $this->assertTrue(strpos($result['exec'], 'this.display_message("2 contacts found.","confirmation",0);') !== false);
+        $this->assertTrue(strpos($result['exec'], 'target@personal.com') !== false);
+        $this->assertTrue(strpos($result['exec'], 'target@collected.com') !== false);
+
+        $_POST = ['_adv' => '1', '_search_email' => 'target', '_scope' => '0'];
+
+        $this->runAndAssert($action, OutputJsonMock::E_EXIT);
+
+        $result = $output->getOutput();
+
+        $this->assertTrue(strpos($result['exec'], 'this.display_message("1 contacts found.","confirmation",0);') !== false);
+        $this->assertTrue(strpos($result['exec'], 'target@personal.com') !== false);
+
+        $_POST = ['_adv' => '1', '_search_email' => 'target', '_scope' => (string) \rcube_addressbook::TYPE_RECIPIENT];
+
+        $this->runAndAssert($action, OutputJsonMock::E_EXIT);
+
+        $result = $output->getOutput();
+
+        $this->assertTrue(strpos($result['exec'], 'this.display_message("1 contacts found.","confirmation",0);') !== false);
+        $this->assertTrue(strpos($result['exec'], 'target@collected.com') !== false);
     }
 
     /**

--- a/tests/Actions/Contacts/SearchTest.php
+++ b/tests/Actions/Contacts/SearchTest.php
@@ -65,6 +65,47 @@ class SearchTest extends ActionTestCase
     }
 
     /**
+     * Test search scope
+     */
+    public function test_search_scope()
+    {
+        $action = new \rcmail_action_contacts_search();
+        $output = $this->initOutput(\rcmail_action::MODE_AJAX, 'contacts', 'search');
+
+        $this->assertTrue($action->checks());
+
+        self::initDB('contacts');
+
+        $_GET = ['_q' => 'target'];
+
+        $this->runAndAssert($action, OutputJsonMock::E_EXIT);
+
+        $result = $output->getOutput();
+
+        $this->assertTrue(strpos($result['exec'], 'this.display_message("2 contacts found.","confirmation",0);') !== false);
+        $this->assertTrue(strpos($result['exec'], 'target@personal.com') !== false);
+        $this->assertTrue(strpos($result['exec'], 'target@collected.com') !== false);
+
+        $_GET = ['_q' => 'target', '_scope' => '0'];
+
+        $this->runAndAssert($action, OutputJsonMock::E_EXIT);
+
+        $result = $output->getOutput();
+
+        $this->assertTrue(strpos($result['exec'], 'this.display_message("1 contacts found.","confirmation",0);') !== false);
+        $this->assertTrue(strpos($result['exec'], 'target@personal.com') !== false);
+
+        $_GET = ['_q' => 'target', '_scope' => \rcube_addressbook::TYPE_RECIPIENT];
+
+        $this->runAndAssert($action, OutputJsonMock::E_EXIT);
+
+        $result = $output->getOutput();
+
+        $this->assertTrue(strpos($result['exec'], 'this.display_message("1 contacts found.","confirmation",0);') !== false);
+        $this->assertTrue(strpos($result['exec'], 'target@collected.com') !== false);
+    }
+
+    /**
      * Test search request
      */
     public function test_run_search()

--- a/tests/Actions/Contacts/SearchTest.php
+++ b/tests/Actions/Contacts/SearchTest.php
@@ -82,9 +82,9 @@ class SearchTest extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertTrue(strpos($result['exec'], 'this.display_message("2 contacts found.","confirmation",0);') !== false);
-        $this->assertTrue(strpos($result['exec'], 'target@personal.com') !== false);
-        $this->assertTrue(strpos($result['exec'], 'target@collected.com') !== false);
+        $this->assertTrue(str_contains($result['exec'], 'this.display_message("2 contacts found.","confirmation",0);'));
+        $this->assertTrue(str_contains($result['exec'], 'target@personal.com'));
+        $this->assertTrue(str_contains($result['exec'], 'target@collected.com'));
 
         $_GET = ['_q' => 'target', '_scope' => '0'];
 
@@ -92,8 +92,8 @@ class SearchTest extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertTrue(strpos($result['exec'], 'this.display_message("1 contacts found.","confirmation",0);') !== false);
-        $this->assertTrue(strpos($result['exec'], 'target@personal.com') !== false);
+        $this->assertTrue(str_contains($result['exec'], 'this.display_message("1 contacts found.","confirmation",0);'));
+        $this->assertTrue(str_contains($result['exec'], 'target@personal.com'));
 
         $_GET = ['_q' => 'target', '_scope' => \rcube_addressbook::TYPE_RECIPIENT];
 
@@ -101,8 +101,8 @@ class SearchTest extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertTrue(strpos($result['exec'], 'this.display_message("1 contacts found.","confirmation",0);') !== false);
-        $this->assertTrue(strpos($result['exec'], 'target@collected.com') !== false);
+        $this->assertTrue(str_contains($result['exec'], 'this.display_message("1 contacts found.","confirmation",0);'));
+        $this->assertTrue(str_contains($result['exec'], 'target@collected.com'));
     }
 
     /**
@@ -151,9 +151,9 @@ class SearchTest extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertTrue(strpos($result['exec'], 'this.display_message("2 contacts found.","confirmation",0);') !== false);
-        $this->assertTrue(strpos($result['exec'], 'target@personal.com') !== false);
-        $this->assertTrue(strpos($result['exec'], 'target@collected.com') !== false);
+        $this->assertTrue(str_contains($result['exec'], 'this.display_message("2 contacts found.","confirmation",0);'));
+        $this->assertTrue(str_contains($result['exec'], 'target@personal.com'));
+        $this->assertTrue(str_contains($result['exec'], 'target@collected.com'));
 
         $_POST = ['_adv' => '1', '_search_email' => 'target', '_scope' => '0'];
 
@@ -161,8 +161,8 @@ class SearchTest extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertTrue(strpos($result['exec'], 'this.display_message("1 contacts found.","confirmation",0);') !== false);
-        $this->assertTrue(strpos($result['exec'], 'target@personal.com') !== false);
+        $this->assertTrue(str_contains($result['exec'], 'this.display_message("1 contacts found.","confirmation",0);'));
+        $this->assertTrue(str_contains($result['exec'], 'target@personal.com'));
 
         $_POST = ['_adv' => '1', '_search_email' => 'target', '_scope' => (string) \rcube_addressbook::TYPE_RECIPIENT];
 
@@ -170,8 +170,8 @@ class SearchTest extends ActionTestCase
 
         $result = $output->getOutput();
 
-        $this->assertTrue(strpos($result['exec'], 'this.display_message("1 contacts found.","confirmation",0);') !== false);
-        $this->assertTrue(strpos($result['exec'], 'target@collected.com') !== false);
+        $this->assertTrue(str_contains($result['exec'], 'this.display_message("1 contacts found.","confirmation",0);'));
+        $this->assertTrue(str_contains($result['exec'], 'target@collected.com'));
     }
 
     /**

--- a/tests/Actions/Contacts/Search_CreateTest.php
+++ b/tests/Actions/Contacts/Search_CreateTest.php
@@ -49,6 +49,7 @@ class Search_CreateTest extends ActionTestCase
         $_SESSION['contact_search_params'] = [
             'id' => 'fakeid',
             'data' => ['*', 'bush'],
+            'scope' => null,
         ];
 
         $this->runAndAssert($action, OutputJsonMock::E_EXIT);

--- a/tests/src/sql/contacts.sql
+++ b/tests/src/sql/contacts.sql
@@ -3,6 +3,7 @@ DELETE FROM contactgroups;
 DELETE FROM contactgroupmembers;
 DELETE FROM collected_addresses;
 INSERT INTO collected_addresses (user_id, name, email, type) VALUES (1, 'test', 'test@collected.eu', 1);
+INSERT INTO collected_addresses (user_id, name, email, type) VALUES (1, 'target collected', 'target@collected.com', 1);
 INSERT INTO contactgroups (user_id, name) VALUES (1, 'test-group');
 INSERT INTO contacts (user_id, changed, del, name, email, firstname, surname, vcard, words)
     VALUES (1, '2019-12-31 12:23:33.523071-05', 0, 'John Doe', 'johndoe@example.org', 'John', 'Doe', 'BEGIN:VCARD
@@ -47,3 +48,10 @@ N:Snow;Jon;;;
 FN:Jon ż Snow
 EMAIL;TYPE=INTERNET;TYPE=HOME:j.snow@game.com
 END:VCARD', ' jon snow j.snow@game.com');
+INSERT INTO contacts (user_id, changed, del, name, email, firstname, surname, vcard, words)
+    VALUES (1, '2019-12-31 12:24:10.213475-05', 0, 'Target Personal', 'target@personal.com', 'Target', 'Personal', 'BEGIN:VCARD
+VERSION:3.0
+N:Personal;Target;;;
+FN:Target Personal
+EMAIL;TYPE=INTERNET;TYPE=HOME:target@personal.com
+END:VCARD', ' target personal target@personal.com');


### PR DESCRIPTION
adding a `_scope` param to contact search to define the scope of the search, all address books (default) or current only.

closes #9863