### PR TITLE
stub out 2 more contact searching tests

### DIFF
--- a/tests/Actions/Contacts/SearchTest.php
+++ b/tests/Actions/Contacts/SearchTest.php
@@ -61,6 +61,7 @@ class SearchTest extends ActionTestCase
         $this->assertTrue(strpos($result['exec'], 'this.unselect_directory();') !== false);
         $this->assertTrue(strpos($result['exec'], 'this.enable_command("search-create",true);') !== false);
         $this->assertTrue(strpos($result['exec'], 'this.update_group_commands()') !== false);
+        $this->assertTrue(strpos($result['exec'], 'this.list_contacts_clear();') === false);
     }
 
     /**
@@ -91,6 +92,7 @@ class SearchTest extends ActionTestCase
         $this->assertTrue(strpos($result['exec'], 'this.unselect_directory();') !== false);
         $this->assertTrue(strpos($result['exec'], 'this.enable_command("search-create",true);') !== false);
         $this->assertTrue(strpos($result['exec'], 'this.update_group_commands()') !== false);
+        $this->assertTrue(strpos($result['exec'], 'this.list_contacts_clear();') !== false);
     }
 
     /**

--- a/tests/Actions/Contacts/SearchTest.php
+++ b/tests/Actions/Contacts/SearchTest.php
@@ -68,7 +68,28 @@ class SearchTest extends ActionTestCase
      */
     public function test_run_search()
     {
-        // TODO: Search using saved search, or using the form
-        $this->markTestIncomplete();
+        $action = new \rcmail_action_contacts_search();
+        $output = $this->initOutput(\rcmail_action::MODE_AJAX, 'contacts', 'search');
+
+        $this->assertTrue($action->checks());
+
+        self::initDB('contacts');
+
+        $_POST = ['_adv' => '1', '_search_organization' => 'acme'];
+
+        $this->runAndAssert($action, OutputJsonMock::E_EXIT);
+
+        $result = $output->getOutput();
+
+        $this->assertContains('Content-Type: application/json; charset=UTF-8', $output->headers);
+        $this->assertSame('search', $result['action']);
+        $this->assertSame(1, $result['env']['pagecount']);
+        $this->assertMatchesRegularExpression('/^[0-9a-z]{32}$/', $result['env']['search_request']);
+        $this->assertTrue(strpos($result['exec'], 'this.add_contact_row') !== false);
+        $this->assertTrue(strpos($result['exec'], 'this.set_rowcount("Contacts 1 to 1 of 1");') !== false);
+        $this->assertTrue(strpos($result['exec'], 'this.display_message("1 contacts found.","confirmation",0);') !== false);
+        $this->assertTrue(strpos($result['exec'], 'this.unselect_directory();') !== false);
+        $this->assertTrue(strpos($result['exec'], 'this.enable_command("search-create",true);') !== false);
+        $this->assertTrue(strpos($result['exec'], 'this.update_group_commands()') !== false);
     }
 }

--- a/tests/Actions/Contacts/SearchTest.php
+++ b/tests/Actions/Contacts/SearchTest.php
@@ -92,4 +92,41 @@ class SearchTest extends ActionTestCase
         $this->assertTrue(strpos($result['exec'], 'this.enable_command("search-create",true);') !== false);
         $this->assertTrue(strpos($result['exec'], 'this.update_group_commands()') !== false);
     }
+
+    /**
+     * Test saved search
+     */
+    public function test_run_saved_search()
+    {
+        $action = new \rcmail_action_contacts_search();
+        $output = $this->initOutput(\rcmail_action::MODE_AJAX, 'contacts', 'search');
+
+        $this->assertTrue($action->checks());
+
+        self::initDB('searches');
+
+        $db = \rcmail::get_instance()->get_dbh();
+        $query = $db->query('SELECT * FROM `searches` WHERE `name` = \'test\'');
+        $result = $db->fetch_assoc($query);
+        $sid = $result['search_id'];
+
+        self::initDB('contacts');
+
+        $_GET = ['_sid' => $sid];
+
+        $this->runAndAssert($action, OutputJsonMock::E_EXIT);
+
+        $result = $output->getOutput();
+
+        $this->assertContains('Content-Type: application/json; charset=UTF-8', $output->headers);
+        $this->assertSame('search', $result['action']);
+        $this->assertSame(1, $result['env']['pagecount']);
+        $this->assertMatchesRegularExpression('/^[0-9a-z]{32}$/', $result['env']['search_request']);
+        $this->assertTrue(strpos($result['exec'], 'this.add_contact_row') !== false);
+        $this->assertTrue(strpos($result['exec'], 'this.set_rowcount("Contacts 1 to 1 of 1");') !== false);
+        $this->assertTrue(strpos($result['exec'], 'this.display_message("1 contacts found.","confirmation",0);') !== false);
+        $this->assertTrue(strpos($result['exec'], 'this.unselect_directory();') === false);
+        $this->assertTrue(strpos($result['exec'], 'this.enable_command("search-create",true);') === false);
+        $this->assertTrue(strpos($result['exec'], 'this.update_group_commands()') !== false);
+    }
 }

--- a/tests/Actions/Contacts/SearchTest.php
+++ b/tests/Actions/Contacts/SearchTest.php
@@ -71,12 +71,4 @@ class SearchTest extends ActionTestCase
         // TODO: Search using saved search, or using the form
         $this->markTestIncomplete();
     }
-
-    /**
-     * Test contact_search_form() method
-     */
-    public function test_contact_search_form()
-    {
-        $this->markTestIncomplete();
-    }
 }

--- a/tests/src/sql/contacts.sql
+++ b/tests/src/sql/contacts.sql
@@ -9,8 +9,9 @@ INSERT INTO contacts (user_id, changed, del, name, email, firstname, surname, vc
 VERSION:3.0
 N:Doe;John;;;
 FN:John Doe
+ORG:Acme
 EMAIL;TYPE=INTERNET;TYPE=HOME:johndoe@example.org
-END:VCARD', ' john do johndo@example.org');
+END:VCARD', ' john do acme johndo@example.org');
 INSERT INTO contacts (user_id, changed, del, name, email, firstname, surname, vcard, words)
     VALUES (1, '2019-12-31 12:24:10.213475-05', 0, 'Jane Stalone', 'j.stalone@microsoft.com', 'Jane', 'Stalone', 'BEGIN:VCARD
 VERSION:3.0


### PR DESCRIPTION
added a couple of tests to make sure advanced and searched searches are responding as expected.

I removed `test_contact_search_form` as I think its a duplicate of `test_run_search_form`