### PR TITLE
feat: :sparkles: Allow saving of compose_data somewhere other than in the session

### DIFF
--- a/config/config.inc.php.sample
+++ b/config/config.inc.php.sample
@@ -64,3 +64,8 @@ $config['plugins'] = [
 
 // skin name: folder from skins/
 $config['skin'] = 'elastic';
+// Backend to use for compose_data storage. 
+//Can either be 'session' (default), 'redis', 'memcache', 'apc', or 'db'
+$config['compose_data_storage'] = 'session';
+// Lifetime of compose data storage. Possible units: s, m, h, d, w
+$config['compose_data_storage_ttl'] = '24h'; 

--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -1567,3 +1567,8 @@ $config['message_show_email'] = false;
 // 0 - Reply-All always
 // 1 - Reply-List if mailing list is detected
 $config['reply_all_mode'] = 0;
+// Backend to use for compose_data storage. 
+//Can either be 'session' (default), 'redis', 'memcache', 'apc', or 'db'
+$config['compose_data_storage'] = 'session';
+// Lifetime of compose data storage. Possible units: s, m, h, d, w
+$config['compose_data_storage_ttl'] = '24h'; 

--- a/program/actions/mail/attachment_upload.php
+++ b/program/actions/mail/attachment_upload.php
@@ -162,12 +162,7 @@ class rcmail_action_mail_attachment_upload extends rcmail_action_mail_index
     public static function init()
     {
         self::$COMPOSE_ID = rcube_utils::get_input_string('_id', rcube_utils::INPUT_GPC);
-        self::$COMPOSE = null;
-        self::$SESSION_KEY = 'compose_data_' . self::$COMPOSE_ID;
-
-        if (self::$COMPOSE_ID && !empty($_SESSION[self::$SESSION_KEY])) {
-            self::$COMPOSE = &$_SESSION[self::$SESSION_KEY];
-        }
+        self::$COMPOSE     = rcmail_action_mail_compose::get_compose_data(self::$COMPOSE_ID);
 
         if (!self::$COMPOSE) {
             exit('Invalid session var!');

--- a/program/actions/mail/send.php
+++ b/program/actions/mail/send.php
@@ -35,7 +35,7 @@ class rcmail_action_mail_send extends rcmail_action
         $rcmail->output->framed = true;
 
         $COMPOSE_ID = rcube_utils::get_input_string('_id', rcube_utils::INPUT_GPC);
-        $COMPOSE = &$_SESSION['compose_data_' . $COMPOSE_ID];
+        $COMPOSE    = rcmail_action_mail_compose::get_compose_data($COMPOSE_ID);
 
         // Sanity checks
         if (!isset($COMPOSE['id'])) {
@@ -253,6 +253,8 @@ class rcmail_action_mail_send extends rcmail_action
             }
 
             if ($saved) {
+                rcmail_action_mail_compose::set_compose_data($COMPOSE_ID, $COMPOSE);
+                
                 $plugin = $rcmail->plugins->exec_hook('message_draftsaved', [
                     'msgid' => $message_id,
                     'uid' => $saved,
@@ -296,7 +298,7 @@ class rcmail_action_mail_send extends rcmail_action
                 $save_error = true;
             } else {
                 $rcmail->delete_uploaded_files($COMPOSE_ID);
-                $rcmail->session->remove('compose_data_' . $COMPOSE_ID);
+                rcmail_action_mail_compose::remove_compose_data($COMPOSE_ID);
                 $_SESSION['last_compose_session'] = $COMPOSE_ID;
 
                 $rcmail->output->command('remove_compose_data', $COMPOSE_ID);

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -1659,18 +1659,18 @@ function rcube_webmail() {
     };
 
     // return a localized string
-    this.get_label = function (label, domain, variables = null) {
-        if (domain && this.labels[domain + '.' + label]) {
-            label = this.labels[domain + '.' + label];
+    this.get_label = function (name, domain, variables = null) {
+        if (domain && this.labels[domain + '.' + name]) {
+            name = this.labels[domain + '.' + name];
         }
-        else if (this.labels[label]) {
-            label = this.labels[label];
+        else if (this.labels[name]) {
+            name = this.labels[name];
         }
 
         // set variable value in localized string
         if (variables && Object.keys(variables).length) {
             for (const [key, value] of Object.entries(variables)) {
-                label = label.replaceAll(`$${key}`, value);
+                name = name.replaceAll(`$${key}`, value);
             }
         }
 

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -1659,18 +1659,18 @@ function rcube_webmail() {
     };
 
     // return a localized string
-    this.get_label = function (name, domain, variables = null) {
-        if (domain && this.labels[domain + '.' + name]) {
-            name = this.labels[domain + '.' + name];
+    this.get_label = function (label, domain, variables = null) {
+        if (domain && this.labels[domain + '.' + label]) {
+            label = this.labels[domain + '.' + label];
         }
-        else if (this.labels[name]) {
-            name = this.labels[name];
+        else if (this.labels[label]) {
+            label = this.labels[label];
         }
 
         // set variable value in localized string
         if (variables && Object.keys(variables).length) {
             for (const [key, value] of Object.entries(variables)) {
-                name = name.replaceAll(`$${key}`, value);
+                label = label.replaceAll(`$${key}`, value);
             }
         }
 


### PR DESCRIPTION
We are experiencing issues due to saving compose_data in the session when there are a large number of users.
We’ve therefore found a solution by saving compose_data in the cache instead.
We’re submitting this idea to you