### PR TITLE
Fix handling of BODY styles in HTML messages (#9911)

### DIFF
--- a/program/actions/mail/compose.php
+++ b/program/actions/mail/compose.php
@@ -989,12 +989,9 @@ class rcmail_action_mail_compose extends rcmail_action_mail_index
     {
         static $part_no;
 
-        // Set attributes of the part container
-        $container_id = self::$COMPOSE['mode'] . 'body' . (++$part_no);
-
         $wash_params += [
             'safe' => self::$MESSAGE->is_safe,
-            'css_prefix' => 'v' . $part_no,
+            'css_prefix' => 'v' . (++$part_no),
             'add_comments' => false,
         ];
 
@@ -1003,8 +1000,6 @@ class rcmail_action_mail_compose extends rcmail_action_mail_index
             $body = preg_replace('/<p>\xC2\xA0<\/p>/', '<p><br /></p>', $body);
             // remove <body> tags (not their content)
             $wash_params['ignore_elements'] = ['body'];
-        } else {
-            $wash_params['container_id'] = $container_id;
         }
 
         // Make the HTML content safe and clean

--- a/program/actions/mail/compose.php
+++ b/program/actions/mail/compose.php
@@ -990,12 +990,12 @@ class rcmail_action_mail_compose extends rcmail_action_mail_index
         static $part_no;
 
         $wash_params += [
-            'safe' => self::$MESSAGE->is_safe,
+            'safe' => self::$MESSAGE && self::$MESSAGE->is_safe,
             'css_prefix' => 'v' . (++$part_no),
             'add_comments' => false,
         ];
 
-        if (self::$COMPOSE['mode'] == rcmail_sendmail::MODE_DRAFT) {
+        if (self::$COMPOSE && self::$COMPOSE['mode'] == rcmail_sendmail::MODE_DRAFT) {
             // convert TinyMCE's empty-line sequence (#1490463)
             $body = preg_replace('/<p>\xC2\xA0<\/p>/', '<p><br /></p>', $body);
             // remove <body> tags (not their content)

--- a/program/actions/mail/index.php
+++ b/program/actions/mail/index.php
@@ -949,7 +949,6 @@ class rcmail_action_mail_index extends rcmail_action
             'css_prefix' => $p['css_prefix'],
             // internal configuration
             'container_id' => $p['container_id'],
-            'body_class' => $p['body_class'] ?? '',
         ];
 
         if (empty($p['inline_html'])) {
@@ -974,14 +973,6 @@ class rcmail_action_mail_index extends rcmail_action
 
         if (!empty($p['inline_html'])) {
             $washer->add_callback('body', 'rcmail_action_mail_index::washtml_callback');
-
-            if ($wash_opts['body_class']) {
-                self::$wash_html_body_attrs['class'] = $wash_opts['body_class'];
-            }
-
-            if ($wash_opts['container_id']) {
-                self::$wash_html_body_attrs['id'] = $wash_opts['container_id'];
-            }
         }
 
         if (empty($p['skip_washer_form_callback'])) {
@@ -1149,9 +1140,7 @@ class rcmail_action_mail_index extends rcmail_action
                 if (strlen($out)) {
                     $css_prefix = $washtml->get_config('css_prefix');
                     $is_safe = $washtml->get_config('allow_remote');
-                    $body_class = $washtml->get_config('body_class') ?: '';
                     $cont_id = $washtml->get_config('container_id') ?: '';
-                    $cont_id = trim($cont_id . ($body_class ? " div.{$body_class}" : ''));
 
                     $out = rcube_utils::mod_css_styles($out, $cont_id, $is_safe, $css_prefix);
 

--- a/program/actions/mail/show.php
+++ b/program/actions/mail/show.php
@@ -882,7 +882,7 @@ class rcmail_action_mail_show extends rcmail_action_mail_index
         $container_attrib = ['class' => $container_class, 'id' => $container_id];
 
         $body_args = [
-            'safe' => self::$MESSAGE->is_safe || !empty($_GET['_safe']),
+            'safe' => (self::$MESSAGE && self::$MESSAGE->is_safe) || !empty($_GET['_safe']),
             'plain' => !$rcmail->config->get('prefer_html'),
             'css_prefix' => 'v' . $part_no,
             'container_id' => $container_id,

--- a/program/actions/mail/show.php
+++ b/program/actions/mail/show.php
@@ -692,7 +692,7 @@ class rcmail_action_mail_show extends rcmail_action_mail_index
                     }
 
                     // Process the part content for display
-                    $out .= self::prepare_part_body($body, $part, $body_args = []);
+                    $out .= self::prepare_part_body($body, $part);
                 }
             }
         } else {
@@ -867,7 +867,7 @@ class rcmail_action_mail_show extends rcmail_action_mail_index
     /**
      * Prepare message part content for display
      */
-    protected static function prepare_part_body($body, $part, &$body_args = [])
+    protected static function prepare_part_body($body, $part)
     {
         static $part_no;
 

--- a/program/actions/utils/modcss.php
+++ b/program/actions/utils/modcss.php
@@ -37,7 +37,8 @@ class rcmail_action_utils_modcss extends rcmail_action
             $rcmail->output->sendExitError(403, 'Unauthorized request');
         }
 
-        $realurl = $_SESSION['modcssurls'][$url];
+        $data = $_SESSION['modcssurls'][$url];
+        $realurl = $data['url'] ?? '';
 
         // don't allow any other connections than http(s)
         if (!preg_match('~^https?://~i', $realurl, $matches)) {
@@ -59,16 +60,13 @@ class rcmail_action_utils_modcss extends rcmail_action
             rcube::raise_error($e, true, false);
         }
 
-        $cid = rcube_utils::get_input_string('_c', rcube_utils::INPUT_GET);
-        $prefix = rcube_utils::get_input_string('_p', rcube_utils::INPUT_GET);
+        if ($source !== false && $ctype && preg_match('~^text/(css|plain)~i', $ctype)) {
+            $container_id = $data['container_id'] ?? '';
+            $css_prefix = $data['css_prefix'] ?? '';
+            $body_class = $data['body_class'] ?? '';
 
-        $container_id = preg_replace('/[^a-z0-9]/i', '', $cid);
-        $css_prefix = preg_replace('/[^a-z0-9]/i', '', $prefix);
-        $ctype_regexp = '~^text/(css|plain)~i';
-
-        if ($source !== false && $ctype && preg_match($ctype_regexp, $ctype)) {
             $rcmail->output->sendExit(
-                rcube_utils::mod_css_styles($source, $container_id, false, $css_prefix),
+                rcube_utils::mod_css_styles($source, $container_id, false, $css_prefix, $body_class),
                 ['Content-Type: text/css']
             );
         }

--- a/skins/elastic/styles/styles.less
+++ b/skins/elastic/styles/styles.less
@@ -334,7 +334,7 @@ body.task-error-login #layout {
         margin-bottom: .5rem;
     }
 
-    > div {
+    & > .rcmBody {
         // Remove margins that can be set by the mail message styles
         margin: 0 auto !important;
         // Fix floating table issue (#9804)

--- a/skins/elastic/styles/styles.less
+++ b/skins/elastic/styles/styles.less
@@ -334,7 +334,7 @@ body.task-error-login #layout {
         margin-bottom: .5rem;
     }
 
-    div.rcmBody {
+    > div {
         // Remove margins that can be set by the mail message styles
         margin: 0 auto !important;
         // Fix floating table issue (#9804)

--- a/tests/ActionTestCase.php
+++ b/tests/ActionTestCase.php
@@ -2,6 +2,7 @@
 
 namespace Roundcube\Tests;
 
+use Masterminds\HTML5;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -266,6 +267,15 @@ class ActionTestCase extends TestCase
                 \rcube::raise_error($error, false, true);
             }
         }
+    }
+
+    /**
+     * Parse HTML output into DOMXPath object
+     */
+    protected static function parseHtml($html)
+    {
+        $html5 = new HTML5(['disable_html_ns' => true]);
+        return new \DOMXPath($html5->loadHTML($html));
     }
 
     /**

--- a/tests/Actions/Mail/ComposeTest.php
+++ b/tests/Actions/Mail/ComposeTest.php
@@ -20,6 +20,44 @@ class ComposeTest extends ActionTestCase
     }
 
     /**
+     * Test prepare_html_body() method
+     */
+    public function test_prepare_html_body()
+    {
+        $action = new \rcmail_action_mail_compose();
+
+        $html = <<<'EOF'
+            <html lang="en">
+                <head>
+                    <style>
+                        @media (min-width: 600px) {
+                            .body_class_name { color: red; }
+                        }
+                    </style>
+                </head>
+                <body class="body_class_name" id="bod">
+                    <p>Broken CSS selector</p>
+                </body>
+            </html>
+            EOF;
+
+        $body = $action->prepare_html_body($html);
+        $xpath = self::parseHtml($body);
+
+        $this->assertCount(1, $xpath->query('//style'));
+        $this->assertSame('text/css', $xpath->query('//style')->item(0)->getAttribute('type'));
+        $this->assertSame(
+            '@media (min-width: 600px) { .v1body_class_name { color: red; } }',
+            trim(preg_replace('/(\s{2,}|\n)/', ' ', $xpath->query('//style')->item(0)->textContent))
+        );
+
+        $this->assertCount(1, $xpath->query('//div'));
+        $this->assertSame('v1bod', $xpath->query('//div')->item(0)->getAttribute('id'));
+        $this->assertSame('v1body_class_name', $xpath->query('//div')->item(0)->getAttribute('class'));
+        $this->assertCount(1, $xpath->query('//div/p'));
+    }
+
+    /**
      * Test quote_text() method
      */
     public function test_quote_text()

--- a/tests/Actions/Mail/ComposeTest.php
+++ b/tests/Actions/Mail/ComposeTest.php
@@ -27,7 +27,7 @@ class ComposeTest extends ActionTestCase
         $action = new \rcmail_action_mail_compose();
 
         $html = <<<'EOF'
-            <html lang="en">
+            <html>
                 <head>
                     <style>
                         @media (min-width: 600px) {
@@ -53,7 +53,7 @@ class ComposeTest extends ActionTestCase
 
         $this->assertCount(1, $xpath->query('//div'));
         $this->assertSame('v1bod', $xpath->query('//div')->item(0)->getAttribute('id'));
-        $this->assertSame('v1body_class_name', $xpath->query('//div')->item(0)->getAttribute('class'));
+        $this->assertSame('rcmBody v1body_class_name', $xpath->query('//div')->item(0)->getAttribute('class'));
         $this->assertCount(1, $xpath->query('//div/p'));
     }
 

--- a/tests/Actions/Mail/IndexTest.php
+++ b/tests/Actions/Mail/IndexTest.php
@@ -328,8 +328,6 @@ class IndexTest extends ActionTestCase
      */
     public function test_html()
     {
-        $this->initOutput(\rcmail_action::MODE_HTTP, 'mail', '');
-
         $part = $this->get_html_part('src/htmlbody.txt');
         $part->replaces = ['ex1.jpg' => 'part_1.2.jpg', 'ex2.jpg' => 'part_1.2.jpg'];
 
@@ -364,8 +362,6 @@ class IndexTest extends ActionTestCase
      */
     public function test_html_xss()
     {
-        $this->initOutput(\rcmail_action::MODE_HTTP, 'mail', '');
-
         $part = $this->get_html_part('src/htmlxss.txt');
         $params = ['container_id' => 'foo', 'safe' => true];
         $html = \rcmail_action_mail_index::print_body($part->body, $part, $params);
@@ -383,8 +379,6 @@ class IndexTest extends ActionTestCase
      */
     public function test_html_xss2()
     {
-        $this->initOutput(\rcmail_action::MODE_HTTP, 'mail', '');
-
         $part = $this->get_html_part('src/BID-26800.txt');
         $params = ['container_id' => 'dabody', 'safe' => true];
         $washed = \rcmail_action_mail_index::print_body($part->body, $part, $params);
@@ -398,8 +392,6 @@ class IndexTest extends ActionTestCase
      */
     public function test_html_xss3()
     {
-        $this->initOutput(\rcmail_action::MODE_HTTP, 'mail', '');
-
         // #1488850
         $html = '<p><a href="data:text/html,&lt;script&gt;alert(document.cookie)&lt;/script&gt;">Firefox</a>'
             . '<a href="vbscript:alert(document.cookie)">Internet Explorer</a></p>';
@@ -448,16 +440,16 @@ class IndexTest extends ActionTestCase
      */
     public function test_wash_html_body_style()
     {
-        $html = '<body background="http://test.com/image" bgcolor="#fff" style="font-size: 11px" text="#000"><p>test</p></body>';
+        $html = '<body id="aaa" background="http://test.com/image" bgcolor="#fff" style="font-size: 11px" text="#000"><p>test</p></body>';
         $params = ['container_id' => 'foo', 'add_comments' => false, 'safe' => false];
         $washed = \rcmail_action_mail_index::wash_html($html, $params, []);
 
-        $this->assertSame('<div id="foo" style="font-size: 11px; background-image: url(static.php/program/resources/blocked.gif); background-color: #fff; color: #000"><p>test</p></div>', $washed);
+        $this->assertSame('<div id="aaa" style="font-size: 11px; background-image: url(static.php/program/resources/blocked.gif); background-color: #fff; color: #000"><p>test</p></div>', $washed);
 
         $params['safe'] = true;
         $washed = \rcmail_action_mail_index::wash_html($html, $params, []);
 
-        $this->assertSame('<div id="foo" style="font-size: 11px; background-image: url(http://test.com/image); background-color: #fff; color: #000"><p>test</p></div>', $washed);
+        $this->assertSame('<div id="aaa" style="font-size: 11px; background-image: url(http://test.com/image); background-color: #fff; color: #000"><p>test</p></div>', $washed);
     }
 
     /**
@@ -468,8 +460,6 @@ class IndexTest extends ActionTestCase
     #[Group('mbstring')]
     public function test_washtml_utf8()
     {
-        $this->initOutput(\rcmail_action::MODE_HTTP, 'mail', '');
-
         $part = $this->get_html_part('src/invalidchars.html');
         $washed = \rcmail_action_mail_index::print_body($part->body, $part);
 
@@ -481,8 +471,6 @@ class IndexTest extends ActionTestCase
      */
     public function test_meta_insertion()
     {
-        $this->initOutput(\rcmail_action::MODE_HTTP, 'mail', '');
-
         $meta = '<meta charset="' . RCUBE_CHARSET . '" />';
         $args = [
             'inline_html' => false,
@@ -521,8 +509,6 @@ class IndexTest extends ActionTestCase
      */
     public function test_plaintext()
     {
-        $this->initOutput(\rcmail_action::MODE_HTTP, 'mail', '');
-
         $part = new \rcube_message_part();
         $part->ctype_primary = 'text';
         $part->ctype_secondary = 'plain';
@@ -551,8 +537,6 @@ class IndexTest extends ActionTestCase
      */
     public function test_mailto()
     {
-        $this->initOutput(\rcmail_action::MODE_HTTP, 'mail', '');
-
         $part = $this->get_html_part('src/mailto.txt');
         $params = ['container_id' => 'foo', 'safe' => false];
 
@@ -570,8 +554,6 @@ class IndexTest extends ActionTestCase
      */
     public function test_html_comments()
     {
-        $this->initOutput(\rcmail_action::MODE_HTTP, 'mail', '');
-
         $part = $this->get_html_part('src/htmlcom.txt');
         $washed = \rcmail_action_mail_index::print_body($part->body, $part, ['safe' => true]);
 
@@ -586,8 +568,6 @@ class IndexTest extends ActionTestCase
      */
     public function test_html_links()
     {
-        $this->initOutput(\rcmail_action::MODE_HTTP, 'mail', '');
-
         // disable relative links
         $html = '<a href="/">test</a>';
         $body = \rcmail_action_mail_index::print_body($html, $this->get_html_part(), ['safe' => false, 'plain' => false]);
@@ -609,8 +589,6 @@ class IndexTest extends ActionTestCase
      */
     public function test_html_link_xss()
     {
-        $this->initOutput(\rcmail_action::MODE_HTTP, 'mail', '');
-
         $html = '<a style="x:><img src=x onerror=alert(1)//">test</a>';
         $body = \rcmail_action_mail_index::print_body($html, $this->get_html_part(), ['safe' => false, 'plain' => false]);
 

--- a/tests/Actions/Mail/IndexTest.php
+++ b/tests/Actions/Mail/IndexTest.php
@@ -409,7 +409,7 @@ class IndexTest extends ActionTestCase
         $part = $this->get_html_part();
         $part->body = '<body title="bgcolor=foo" name="bar style=animation-name:progress-bar-stripes onanimationstart=alert(origin) foo=bar">Foo</body>';
 
-        $params = ['safe' => true, 'add_comments' => false];
+        $params = ['safe' => true, 'add_comments' => false, 'body_class' => ''];
         $washed = \rcmail_action_mail_index::print_body($part->body, $part, $params);
 
         $this->assertSame(str_replace('body', 'div', $part->body), $washed);
@@ -440,16 +440,16 @@ class IndexTest extends ActionTestCase
      */
     public function test_wash_html_body_style()
     {
-        $html = '<body id="aaa" background="http://test.com/image" bgcolor="#fff" style="font-size: 11px" text="#000"><p>test</p></body>';
-        $params = ['container_id' => 'foo', 'add_comments' => false, 'safe' => false];
+        $html = '<body background="http://test.com/image" bgcolor="#fff" style="font-size: 11px" text="#000"><p>test</p></body>';
+        $params = ['container_id' => 'foo', 'add_comments' => false, 'safe' => false, 'body_class' => ''];
         $washed = \rcmail_action_mail_index::wash_html($html, $params, []);
 
-        $this->assertSame('<div id="aaa" style="font-size: 11px; background-image: url(static.php/program/resources/blocked.gif); background-color: #fff; color: #000"><p>test</p></div>', $washed);
+        $this->assertSame('<div style="font-size: 11px; background-image: url(static.php/program/resources/blocked.gif); background-color: #fff; color: #000"><p>test</p></div>', $washed);
 
         $params['safe'] = true;
         $washed = \rcmail_action_mail_index::wash_html($html, $params, []);
 
-        $this->assertSame('<div id="aaa" style="font-size: 11px; background-image: url(http://test.com/image); background-color: #fff; color: #000"><p>test</p></div>', $washed);
+        $this->assertSame('<div style="font-size: 11px; background-image: url(http://test.com/image); background-color: #fff; color: #000"><p>test</p></div>', $washed);
     }
 
     /**

--- a/tests/Actions/Mail/ShowTest.php
+++ b/tests/Actions/Mail/ShowTest.php
@@ -4,6 +4,8 @@ namespace Roundcube\Tests\Actions\Mail;
 
 use Roundcube\Tests\ActionTestCase;
 
+use function Roundcube\Tests\invokeMethod;
+
 /**
  * Test class to test rcmail_action_mail_show
  */
@@ -17,5 +19,80 @@ class ShowTest extends ActionTestCase
         $object = new \rcmail_action_mail_show();
 
         $this->assertInstanceOf(\rcmail_action::class, $object);
+    }
+
+    /**
+     * Test prepare_part_body() method
+     */
+    public function test_prepare_part_body()
+    {
+        // HTML sample (from #9911) focusing on body attributes and styles
+        $html = <<<'EOF'
+            <html lang="en">
+                <head>
+                    <style>
+                        @media (min-width: 600px) {
+                            .body_class_name { color: red; }
+                        }
+                    </style>
+                </head>
+                <body class="body_class_name" id="bod">
+                    <p>Test</p>
+                </body>
+            </html>
+            EOF;
+
+        $action = new \rcmail_action_mail_show();
+
+        $body = invokeMethod($action, 'prepare_part_body', [$html, $this->get_html_part()]);
+        $xpath = self::parseHtml($body);
+
+        $this->assertCount(1, $xpath->query('/html/div'));
+        $this->assertSame('message-htmlpart1', $xpath->query('/html/div')->item(0)->getAttribute('id'));
+        $this->assertSame('message-htmlpart', $xpath->query('/html/div')->item(0)->getAttribute('class'));
+
+        $this->assertCount(1, $xpath->query('/html/div/style'));
+        $this->assertSame('text/css', $xpath->query('/html/div/style')->item(0)->getAttribute('type'));
+        $this->assertSame(
+            '@media (min-width: 600px) { #message-htmlpart1 .v1body_class_name { color: red; } }',
+            trim(preg_replace('/(\s{2,}|\n)/', ' ', $xpath->query('/html/div/style')->item(0)->textContent))
+        );
+
+        $this->assertCount(1, $xpath->query('/html/div/div'));
+        $this->assertSame('v1bod', $xpath->query('/html/div/div')->item(0)->getAttribute('id'));
+        $this->assertSame('v1body_class_name', $xpath->query('/html/div/div')->item(0)->getAttribute('class'));
+        $this->assertSame('Test', $xpath->query('/html/div/div/p')->item(0)->textContent);
+
+        // Invoking the method again (for the next part) use a different ID/prefix
+        $body = invokeMethod($action, 'prepare_part_body', [$html, $this->get_html_part()]);
+        $xpath = self::parseHtml($body);
+
+        $this->assertCount(1, $xpath->query('/html/div'));
+        $this->assertSame('message-htmlpart2', $xpath->query('/html/div')->item(0)->getAttribute('id'));
+        $this->assertSame('message-htmlpart', $xpath->query('/html/div')->item(0)->getAttribute('class'));
+
+        $this->assertCount(1, $xpath->query('/html/div/style'));
+        $this->assertSame(
+            '@media (min-width: 600px) { #message-htmlpart2 .v2body_class_name { color: red; } }',
+            trim(preg_replace('/(\s{2,}|\n)/', ' ', $xpath->query('/html/div/style')->item(0)->textContent))
+        );
+
+        $this->assertCount(1, $xpath->query('/html/div/div'));
+        $this->assertSame('v2bod', $xpath->query('/html/div/div')->item(0)->getAttribute('id'));
+        $this->assertSame('v2body_class_name', $xpath->query('/html/div/div')->item(0)->getAttribute('class'));
+    }
+
+    /**
+     * Helper method to create a HTML message part object
+     */
+    protected function get_html_part($body = null)
+    {
+        $part = new \rcube_message_part();
+        $part->ctype_primary = 'text';
+        $part->ctype_secondary = 'html';
+        $part->body = $body ? file_get_contents(TESTS_DIR . $body) : null;
+        $part->replaces = [];
+
+        return $part;
     }
 }

--- a/tests/Actions/Utils/ModcssTest.php
+++ b/tests/Actions/Utils/ModcssTest.php
@@ -49,7 +49,7 @@ class ModcssTest extends ActionTestCase
         $this->assertNull($output->getOutput());
 
         // Valid url pointing to non-existing resource
-        $_SESSION['modcssurls'][$key] = $url;
+        $_SESSION['modcssurls'][$key] = ['url' => $url];
 
         HttpClientMock::setResponses([
             [404],
@@ -64,9 +64,11 @@ class ModcssTest extends ActionTestCase
 
         // Valid url pointing to an existing resource
         $url = 'https://raw.githubusercontent.com/roundcube/roundcubemail/master/program/resources/tinymce/content.css';
-        $_SESSION['modcssurls'][$key] = $url;
-        $_GET['_p'] = 'prefix';
-        $_GET['_c'] = 'cid';
+        $_SESSION['modcssurls'][$key] = [
+            'url' => $url,
+            'css_prefix' => 'prefix',
+            'container_id' => 'cid',
+        ];
 
         $this->runAndAssert($action, OutputHtmlMock::E_EXIT);
 

--- a/tests/Framework/UtilsTest.php
+++ b/tests/Framework/UtilsTest.php
@@ -240,7 +240,7 @@ class UtilsTest extends TestCase
         $this->assertSame('/* evil! */', $mod);
 
         $mod = \rcube_utils::mod_css_styles("body.main2cols { background-image: url('../images/leftcol.png'); }", 'rcmbody');
-        $this->assertSame('#rcmbody.main2cols {}', $mod);
+        $this->assertSame('#rcmbody .main2cols {}', $mod);
 
         $mod = \rcube_utils::mod_css_styles('p { left:expression(document.body.offsetWidth-20); }', 'rcmbody');
         $this->assertSame('#rcmbody p {}', $mod);

--- a/tests/MessageRendering/InlineImageTest.php
+++ b/tests/MessageRendering/InlineImageTest.php
@@ -24,7 +24,7 @@ class InlineImageTest extends MessageRenderingTestCase
         $this->assertStringContainsString('?_task=mail&_action=get&_mbox=INBOX&_uid=', $src);
         $this->assertStringContainsString('&_part=2&_embed=1&_mimeclass=image', $src);
 
-        $this->assertSame('v1signature', $divElements[2]->attributes->getNamedItem('class')->textContent);
+        $this->assertStringMatchesFormat('v%isignature', $divElements[2]->attributes->getNamedItem('class')->textContent);
         // This matches a non-breakable space.
         $this->assertMatchesRegularExpression('|^\x{00a0}$|u', $divElements[2]->textContent);
 


### PR DESCRIPTION
Fixes #9911 

This removes use of `rcmBody` class, and makes sure ID/class is set only on the container element, while properly handling styles and BODY class and id attributes. So, a potentially breaking change that touches mail preview and composing. And I need to test some more.