### PR TITLE
Makefile: extend PATH, and target to remove untracked minified .js and .css files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ VERSION=1.7-git
 SEDI=sed -i
 PHP_VERSION=8.1
 
+PATH := $(PATH):$(PWD)/node_modules/.bin
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
     SEDI=sed -i ''

--- a/Makefile
+++ b/Makefile
@@ -89,5 +89,8 @@ clean:
 	rm -rf roundcubemail-$(VERSION)*
 	rm -f /tmp/composer.phar /tmp/phpDocumentor.phar
 
+clean-untracked-minified:
+	git status -s | awk '/^\?\? .*.min.(js|css)/ { print $$2 }' | xargs rm -v
+
 css-elastic: npm-install
 	cd skins/elastic && make css


### PR DESCRIPTION
1. Previously, e.g. during `make`ing a release npm-commands like uglify were not found unless they were installed globally.
2. Is handy during development.
