### PR TITLE
Allow to manually reorder "normal" folders

### DIFF
--- a/program/actions/settings/folder_edit.php
+++ b/program/actions/settings/folder_edit.php
@@ -156,6 +156,13 @@ class rcmail_action_settings_folder_edit extends rcmail_action_settings_folders
                 'label' => $rcmail->gettext('parentfolder'),
                 'value' => $select->show($selected),
             ];
+
+            $up = new html_button(['id' => 'move-folder-up', 'class' => 'move-folder-up'])->show($rcmail->gettext('reorder_folder_up'));
+            $down = new html_button(['id' => 'move-folder-down', 'class' => 'move-folder-down'])->show($rcmail->gettext('reorder_folder_down'));
+            $form['props']['fieldsets']['location']['content']['order'] = [
+                'label' => $rcmail->gettext('reorder_folder'),
+                'value' => html::div([], [$up, $down]),
+            ];
         }
 
         // Settings

--- a/program/actions/settings/folder_edit.php
+++ b/program/actions/settings/folder_edit.php
@@ -157,11 +157,14 @@ class rcmail_action_settings_folder_edit extends rcmail_action_settings_folders
                 'value' => $select->show($selected),
             ];
 
-            $up = new html_button(['id' => 'move-folder-up', 'class' => 'move-folder-up'])->show($rcmail->gettext('reorder_folder_up'));
-            $down = new html_button(['id' => 'move-folder-down', 'class' => 'move-folder-down'])->show($rcmail->gettext('reorder_folder_down'));
+            $upBtn = new html_button(['id' => 'move-folder-up', 'class' => 'move-folder-up']);
+            $downBtn = new html_button(['id' => 'move-folder-down', 'class' => 'move-folder-down']);
             $form['props']['fieldsets']['location']['content']['order'] = [
                 'label' => $rcmail->gettext('reorder_folder'),
-                'value' => html::div([], [$up, $down]),
+                'value' => html::div([], [
+                    $upBtn->show($rcmail->gettext('reorder_folder_up')),
+                    $downBtn->show($rcmail->gettext('reorder_folder_down')),
+                ]),
             ];
         }
 

--- a/program/actions/settings/folder_reorder.php
+++ b/program/actions/settings/folder_reorder.php
@@ -9,7 +9,7 @@ class rcmail_action_settings_folder_reorder extends rcmail_action_settings_folde
      *
      * @param array $args Arguments from the previous step(s)
      */
-    #[Override]
+    #[\Override]
     public function run($args = [])
     {
         $rcmail = rcmail::get_instance();

--- a/program/actions/settings/folder_reorder.php
+++ b/program/actions/settings/folder_reorder.php
@@ -1,0 +1,22 @@
+<?php
+
+class rcmail_action_settings_folder_reorder extends rcmail_action_settings_folders
+{
+    protected static $mode = self::MODE_AJAX;
+
+    /**
+     * Request handler.
+     *
+     * @param array $args Arguments from the previous step(s)
+     */
+    #[Override]
+    public function run($args = [])
+    {
+        $rcmail = rcmail::get_instance();
+        $list = array_flip(rcube_utils::get_input_value('folderorder', rcube_utils::INPUT_POST, true));
+        $rcmail->user->save_prefs(['folder_order' => $list]);
+
+        $rcmail->output->show_message('successfullysaved', 'confirmation');
+        $rcmail->output->send();
+    }
+}

--- a/program/actions/settings/folders.php
+++ b/program/actions/settings/folders.php
@@ -34,6 +34,7 @@ class rcmail_action_settings_folders extends rcmail_action_settings_index
         $storage = $rcmail->get_storage();
 
         $rcmail->output->set_pagetitle($rcmail->gettext('folders'));
+        $rcmail->output->set_env('folder_ordered_manually', !empty($rcmail->user->get_prefs()['folder_order']));
         $rcmail->output->set_env('prefix_ns', $storage->get_namespace('prefix'));
         $rcmail->output->set_env('quota', (bool) $storage->get_capability('QUOTA'));
         $rcmail->output->include_script('treelist.js');
@@ -262,6 +263,10 @@ class rcmail_action_settings_folders extends rcmail_action_settings_index
             'id' => $idx,
             'class' => trim($data['class'] . ' mailbox'),
         ];
+        // Only allow reordering of non-protected folders.
+        if ($data['protected']) {
+            $attribs['class'] .= ' protected';
+        }
 
         if (!isset($data['level'])) {
             $data['level'] = 0;

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -7818,7 +7818,6 @@ function rcube_webmail() {
 
     // TODO: In the receive callback, can we wait for the confirmation dialog without introducing async/await and Promises?
     // TODO: save only if the list is different than at start
-    // TODO: Fix the styling (padding)
     this.make_folder_lists_sortable = () => {
         const mainFolderList = this.gui_objects.subscriptionlist;
         $folderLists = $('ul', mainFolderList.parentElement);

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -7931,7 +7931,7 @@ function rcube_webmail() {
         } else {
             upIcon.attr('disabled', null).removeClass('disabled');
             upIcon.on('click', () => {
-                ref.move_folder_up(ref.env.folder)
+                ref.move_folder_up(ref.env.folder);
                 ref.handle_folder_sorting_icons();
             });
         }
@@ -7942,7 +7942,7 @@ function rcube_webmail() {
         } else {
             downIcon.attr('disabled', null).removeClass('disabled');
             downIcon.on('click', () => {
-                ref.move_folder_down(ref.env.folder)
+                ref.move_folder_down(ref.env.folder);
                 ref.handle_folder_sorting_icons();
             });
         }
@@ -7952,7 +7952,7 @@ function rcube_webmail() {
         if (ref.is_framed()) {
             return window.parent.rcmail.move_folder_up(name);
         }
-        const elem = ref.get_folder_li(name, null, true)
+        const elem = ref.get_folder_li(name, null, true);
         if (!elem || elem.classList.contains('protected')) {
             return;
         }
@@ -7967,7 +7967,7 @@ function rcube_webmail() {
         if (ref.is_framed()) {
             return window.parent.rcmail.move_folder_down(name);
         }
-        const elem = ref.get_folder_li(name, null, true)
+        const elem = ref.get_folder_li(name, null, true);
         if (!elem || elem.classList.contains('protected')) {
             return;
         }

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -629,6 +629,7 @@ function rcube_webmail() {
                     this.enable_command('save', 'folder-size', true);
                     parent.rcmail.env.exists = this.env.messagecount;
                     parent.rcmail.enable_command('purge', this.env.messagecount);
+                    ref.handle_folder_sorting_icons();
                 } else if (this.env.action == 'responses') {
                     this.enable_command('add', true);
                 }
@@ -7910,6 +7911,66 @@ function rcube_webmail() {
 
     this.folder_id2name = function (id) {
         return id ? ref.html_identifier_decode(id.replace(/^rcmli/, '')) : null;
+    };
+
+    this.handle_folder_sorting_icons = function () {
+        const folder_li = window.parent.rcmail.get_folder_li(ref.env.folder, null, true);
+        const upIcon = $('#move-folder-up');
+        const downIcon = $('#move-folder-down');
+        const prevElem = folder_li.previousElementSibling;
+        const nextElem = folder_li.nextElementSibling;
+
+        upIcon.off('click');
+        if (prevElem === null || prevElem.classList.contains('protected')) {
+            upIcon.attr('disabled', 'disabled').addClass('disabled');
+        } else {
+            upIcon.attr('disabled', null).removeClass('disabled');
+            upIcon.on('click', () => {
+                ref.move_folder_up(ref.env.folder)
+                ref.handle_folder_sorting_icons();
+            });
+        }
+
+        downIcon.off('click');
+        if (nextElem === null || nextElem.classList.contains('protected')) {
+            downIcon.attr('disabled', 'disabled').addClass('disabled');
+        } else {
+            downIcon.attr('disabled', null).removeClass('disabled');
+            downIcon.on('click', () => {
+                ref.move_folder_down(ref.env.folder)
+                ref.handle_folder_sorting_icons();
+            });
+        }
+    };
+
+    this.move_folder_up = function (name) {
+        if (ref.is_framed()) {
+            return window.parent.rcmail.move_folder_up(name);
+        }
+        const elem = ref.get_folder_li(name, null, true)
+        if (!elem || elem.classList.contains('protected')) {
+            return;
+        }
+        const prevSibling = elem.previousElementSibling;
+        if (prevSibling && !prevSibling.classList.contains('protected')) {
+            prevSibling.before(elem);
+        }
+        ref.save_reordered_folder_list();
+    };
+
+    this.move_folder_down = function (name) {
+        if (ref.is_framed()) {
+            return window.parent.rcmail.move_folder_down(name);
+        }
+        const elem = ref.get_folder_li(name, null, true)
+        if (!elem || elem.classList.contains('protected')) {
+            return;
+        }
+        const nextSibling = elem.nextElementSibling;
+        if (nextSibling) {
+            nextSibling.after(elem);
+        }
+        ref.save_reordered_folder_list();
     };
 
     this.subscription_select = function (id) {

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -8969,7 +8969,7 @@ function rcube_webmail() {
             prefix = 'rcmli';
         }
 
-        if (this.gui_objects.folderlist) {
+        if (this.gui_objects.folderlist || this.gui_objects.subscriptionlist) {
             name = this.html_identifier(name, encode);
             return document.getElementById(prefix + name);
         }

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -7913,6 +7913,13 @@ function rcube_webmail() {
         return id ? ref.html_identifier_decode(id.replace(/^rcmli/, '')) : null;
     };
 
+    this.folder_name2id = function (name) {
+        if (!name) {
+            return null;
+        }
+        return 'rcmli' + ref.html_identifier_encode(name);
+    };
+
     this.handle_folder_sorting_icons = function () {
         const folder_li = window.parent.rcmail.get_folder_li(ref.env.folder, null, true);
         const upIcon = $('#move-folder-up');
@@ -8068,7 +8075,7 @@ function rcube_webmail() {
         }
 
         // set ID, reset css class
-        row.attr({ id: 'rcmli' + this.html_identifier_encode(id), class: class_name });
+        row.attr({ id: this.folder_name2id(id), class: class_name });
 
         if (!refrow || !refrow.length) {
             // remove old data, subfolders and toggle
@@ -8264,7 +8271,7 @@ function rcube_webmail() {
                 folder = ref.env.subscriptionrows[fname],
                 newid = id + fname.slice(prefix_len_id);
 
-            this.id = 'rcmli' + ref.html_identifier_encode(newid);
+            this.id = this.folder_name2id(newid);
             $('input[name="_subscribed[]"]', this).first().val(newid);
             folder[0] = name + folder[0].slice(prefix_len_name);
 

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -8848,6 +8848,8 @@ function rcube_webmail() {
             });
         }
 
+        options.close = close_func;
+
         return this.show_popup_dialog(content, title, buttons, options);
     };
 

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -8203,6 +8203,8 @@ function rcube_webmail() {
             // We need to store this information now, because it's not available anymore after removing the row from
             // the DOM.
             next_sibling = row.nextElementSibling;
+        } else {
+            next_sibling = null;
         }
 
         // get row off the list

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -7906,12 +7906,29 @@ function rcube_webmail() {
                 newname = to === '' || to === '*' ? basename : to + this.env.delimiter + basename;
 
             if (newname != from) {
-                this.confirm_dialog(this.get_label('movefolderconfirm'), 'move', function () {
-                    ref.http_post('rename-folder', { _folder_oldname: from, _folder_newname: newname },
-                        ref.set_busy(true, 'foldermoving'));
-                }, { button_class: 'save move' });
+                return new Promise((resolve, _reject) => {
+                    this.confirm_dialog(
+                        this.get_label('movefolderconfirm'),
+                        'move',
+                        function () {
+                            ref.http_post('rename-folder',
+                                {
+                                    _folder_oldname: from,
+                                    _folder_newname: newname,
+                                },
+                                ref.set_busy(true, 'foldermoving')
+                            );
+                            resolve(true);
+                        },
+                        {
+                            button_class: 'save move',
+                            cancel_func: (e, ref) => resolve(false),
+                        }
+                    );
+                });
             }
         }
+        return Promise.resolve(true);
     };
 
     // tell server to create and subscribe a new mailbox

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -7817,7 +7817,6 @@ function rcube_webmail() {
     };
 
     // TODO: In the receive callback, can we wait for the confirmation dialog without introducing async/await and Promises?
-    // TODO: save only if the list is different than at start
     this.make_folder_lists_sortable = () => {
         const mainFolderList = this.gui_objects.subscriptionlist;
         $folderLists = $('ul', mainFolderList.parentElement);

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -772,6 +772,10 @@ function rcube_webmail() {
 
         // catch document (and iframe) mouse clicks
         var body_mouseup = function (e) {
+            // Stop dragging in sortable list if the mouseup event happens over an iframe.
+            if (ref.gui_objects.subscriptionlist && e.target.ownerDocument !== ref.gui_objects.subscriptionlist.ownerDocument) {
+                $(ref.gui_objects.subscriptionlist).trigger('mouseup');
+            }
             return ref.doc_mouse_up(e);
         };
         $(document.body)

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -8269,7 +8269,7 @@ function rcube_webmail() {
                 folder = ref.env.subscriptionrows[fname],
                 newid = id + fname.slice(prefix_len_id);
 
-            this.id = this.folder_name2id(newid);
+            this.id = ref.folder_name2id(newid);
             $('input[name="_subscribed[]"]', this).first().val(newid);
             folder[0] = name + folder[0].slice(prefix_len_name);
 

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -7884,6 +7884,8 @@ function rcube_webmail() {
                     ui.item.parent().sortable('cancel');
                     return false;
                 }
+            },
+            update: (event, ui) => {
                 // Save the order if the item was moved only within its list. In case it was moved into a (different)
                 // sub-list, the order-saving function gets called from the server's response after the relevant folder
                 // rows have been re-rendered, and we can save one HTTP request. We don't skip the other function call

--- a/program/js/treelist.js
+++ b/program/js/treelist.js
@@ -47,6 +47,7 @@ function rcube_treelist_widget(node, p) {
         keyboard: true,
         tabexit: true,
         parent_focus: false,
+        sortable: false,
         check_droptarget: function (node) {
             return !node.virtual;
         },
@@ -157,6 +158,14 @@ function rcube_treelist_widget(node, p) {
         .on('mousedown', 'a', function (e) {
             var link = $(e.target), node = indexbyid[dom2id(link.closest('li'))];
             if (node && node.virtual && !link.attr('href')) {
+                e.preventDefault();
+                e.stopPropagation();
+                return false;
+            }
+            // Prevent protected folders from being dragged/sorted.
+            // We can't use the options of $.sortable() for that (then sub-folders of protected folders couldn't be
+            // dragged, either), thus we implement it here.
+            if ($(e.target).parent().is('li.mailbox.protected')) {
                 e.preventDefault();
                 e.stopPropagation();
                 return false;
@@ -804,6 +813,16 @@ function rcube_treelist_widget(node, p) {
                 }
 
                 li.attr('aria-expanded', node.collapsed ? 'false' : 'true');
+            } else if (p.sortable) {
+                li.children('div.treetoggle').remove();
+                // Add an empty sublist if none exists yet, so items can be pulled into it when sorting.
+                if (li.children('ul').length === 0) {
+                    const ul = $('<ul>').appendTo(li)
+                        .attr('role', 'group');
+                    if (node.childlistclass) {
+                        ul.attr('class', node.childlistclass);
+                    }
+                }
             }
             if (li.hasClass('selected')) {
                 li.attr('aria-selected', 'true');

--- a/program/js/treelist.js
+++ b/program/js/treelist.js
@@ -162,14 +162,14 @@ function rcube_treelist_widget(node, p) {
                 e.stopPropagation();
                 return false;
             }
+        })
+        .on('mousedown', 'li.mailbox.protected, li.mailbox.protected a', function (e) {
             // Prevent protected folders from being dragged/sorted.
             // We can't use the options of $.sortable() for that (then sub-folders of protected folders couldn't be
             // dragged, either), thus we implement it here.
-            if ($(e.target).parent().is('li.mailbox.protected')) {
-                e.preventDefault();
-                e.stopPropagation();
-                return false;
-            }
+            e.preventDefault();
+            e.stopPropagation();
+            return false;
         });
 
     // activate search function

--- a/program/lib/Roundcube/rcube_imap.php
+++ b/program/lib/Roundcube/rcube_imap.php
@@ -4401,8 +4401,26 @@ class rcube_imap extends rcube_storage
         // sort folders
         // asort($folders, SORT_LOCALE_STRING) is not properly sorting case sensitive names
         uasort($folders, [$this, 'sort_folder_comparator']);
-
         $folders = array_keys($folders);
+
+        $prefs = rcube::get_instance()->user->get_prefs();
+        if (isset($prefs['folder_order'])) {
+            $folder_order = $prefs['folder_order'];
+            $new_list = [];
+            foreach ($folders as $folder_name) {
+                if (!is_string($folder_name)) {
+                    continue;
+                }
+                $folder_id = rcube_utils::html_identifier($folder_name, true);
+                // If the folder doesn't have a position, e.g. because it wasn't yet part of a list that has been
+                // reordered, just append it to the end (but keep the original sorting order within the "un-ordered"
+                // folders).
+                $index = $folder_order[$folder_id] ?? 100000 + count($new_list);
+                $new_list[$index] = $folder_name;
+            }
+            ksort($new_list);
+            $folders = array_values($new_list);
+        }
 
         if ($skip_special || empty($folders)) {
             return $folders;

--- a/program/localization/en_US/labels.inc
+++ b/program/localization/en_US/labels.inc
@@ -796,3 +796,7 @@ $labels['helplistkeyboardnavmessages'] = "Arrows right/left: expand/collapse mes
 Enter: Open the selected/focused message.
 Delete: Move selected messages to Trash.";
 $labels['helplistkeyboardnavcontacts'] = "Enter: Open the selected/focused contact.";
+
+$labels['reorder_folder'] = 'Reorder folder in list';
+$labels['reorder_folder_up'] = 'up';
+$labels['reorder_folder_down'] = 'down';

--- a/skins/elastic/styles/dark.less
+++ b/skins/elastic/styles/dark.less
@@ -257,8 +257,20 @@ html.dark-mode {
 
     .listing li ul,
     .listing tbody td,
-    .listing li {
+    .listing li,
+    .listing li ul li:first-child {
         border-color: @color-dark-list-border;
+    }
+
+    #subscription-table {
+        .placeholder {
+            /* color-dark-list-border is a little too dark here, so we use the input border color */
+            border-color: @color-dark-input-border;
+        }
+
+        .hover {
+            background-color: @color-dark-list-droptarget-background;
+        }
     }
 
     .listing li.selected,

--- a/skins/elastic/styles/dark.less
+++ b/skins/elastic/styles/dark.less
@@ -271,9 +271,15 @@ html.dark-mode {
         .hover {
             background-color: @color-dark-list-droptarget-background;
         }
+        .ui-sortable-helper {
+            background-color: rgba(@color-dark-background, 50%);
+
+            &.selected > a {
+                background-color: rgba(@color-dark-list-selected-background, 0.7);
+            }
+        }
     }
 
-    .listing li.selected,
     .listing li.selected > a,
     .listing li.selected > div > a, // this is used e.g. by kolab_addressbook
     .listing tr.selected td {
@@ -281,12 +287,8 @@ html.dark-mode {
         background-color: @color-dark-list-selected-background;
     }
 
-    .listing li.selected ul {
-        background-color: @color-dark-background;
-
-        div.treetoggle {
-            color: @color-dark-font;
-        }
+    .listing li.selected ul div.treetoggle {
+        color: @color-dark-font;
     }
 
     .listing {

--- a/skins/elastic/styles/widgets/forms.less
+++ b/skins/elastic/styles/widgets/forms.less
@@ -312,6 +312,20 @@ input.smart-upload {
             }
         }
     }
+
+    .move-folder-up:before {
+        &:extend(.font-icon-class);
+        content: @fa-var-arrow-up;
+    }
+
+    .move-folder-down {
+        margin-left: 1rem;
+        &:before {
+            &:extend(.font-icon-class);
+            content: @fa-var-arrow-down;
+        }
+    }
+
 }
 
 @media screen and (max-width: @screen-width-bs-phone) {

--- a/skins/elastic/styles/widgets/lists.less
+++ b/skins/elastic/styles/widgets/lists.less
@@ -1105,3 +1105,15 @@ html.touch {
         padding-right: 2.5rem;
     }
 }
+
+.sortable-handle {
+    display: inline-block;
+
+    &::before {
+        font-family: 'Icons';
+        font-style: normal;
+        .font-icon-solid(@fa-var-arrows-alt-v);
+        padding-right: 0.2rem;
+    }
+
+}

--- a/skins/elastic/styles/widgets/lists.less
+++ b/skins/elastic/styles/widgets/lists.less
@@ -151,10 +151,13 @@ ul.listing {
     }
 
     li {
-        .overflow-ellipsis();
         white-space: nowrap;
         position: relative;
         list-style: none;
+
+        a {
+            .overflow-ellipsis();
+        }
 
         ul {
             min-height: 1.5rem;

--- a/skins/elastic/styles/widgets/lists.less
+++ b/skins/elastic/styles/widgets/lists.less
@@ -1123,12 +1123,12 @@ html.touch {
     }
 
     .placeholder {
-        border: dashed thin #ccc;
+        border: dashed thin @color-input-border;
         min-height: 1.5rem;
     }
 
     .hover {
-        background-color: lightyellow;
+        background-color: @color-list-droptarget-background;
 
         .placeholder {
             margin-left: 3em;

--- a/skins/elastic/styles/widgets/lists.less
+++ b/skins/elastic/styles/widgets/lists.less
@@ -1108,6 +1108,8 @@ html.touch {
 }
 
 #subscription-table {
+    padding-bottom: 2em;
+
     li.mailbox a {
         padding-right: 2.5rem;
     }
@@ -1117,7 +1119,7 @@ html.touch {
       display: block;
       min-height: 1rem;
       margin: 0;
-      padding: 0 0 0 1rem;
+      padding: 0 0 0.5em 1rem;
     }
 
     .placeholder {

--- a/skins/elastic/styles/widgets/lists.less
+++ b/skins/elastic/styles/widgets/lists.less
@@ -618,6 +618,40 @@ ul.treelist {
     &.menu a:before {
         margin-left: .5em;
     }
+
+    // Styles for the sortable list of folders in the settings.
+    &.ui-sortable {
+        // Using an ID here to overwrite the styles from other rules, which also use this ID as selector.
+        &#subscription-table ul {
+            // Make the sub-list overlay its parent element so an item that is visually hovering over the parent element is actually hovering over the sub-list and thus gets sorted into it.
+            margin-top: -2rem;
+            padding-top: 2rem;
+            padding-bottom: 0;
+        }
+
+        // Give the list items a little bit more space at top to counter the increased space required by the sub-lists at the bottom.
+        li {
+            padding-top: 0.5rem;
+        }
+
+        li div.treetoggle {
+            top: 0.5rem;
+        }
+
+        .custom-control-label {
+            top: 0.5rem;
+        }
+
+        li ul li:first-child {
+            margin-top: 0.5rem;
+        }
+
+        // To counter the counter, give the first sub-list layer a small padding at the bottom to even out the increased margins/paddings at the top of the elements.
+        &#subscription-table > li > ul {
+            padding-bottom: 0.5rem;
+        }
+
+    }
 }
 
 

--- a/skins/elastic/styles/widgets/lists.less
+++ b/skins/elastic/styles/widgets/lists.less
@@ -157,11 +157,15 @@ ul.listing {
         list-style: none;
 
         ul {
-            border-top: 1px solid @color-list-border;
+            min-height: 1.5rem;
             padding-left: 1.5em;
 
             li:last-child {
                 border-bottom: none;
+            }
+
+            li:first-child {
+                border-top: 1px solid @color-list-border;
             }
         }
 
@@ -1104,16 +1108,25 @@ html.touch {
     li.mailbox a {
         padding-right: 2.5rem;
     }
-}
 
-.sortable-handle {
-    display: inline-block;
-
-    &::before {
-        font-family: 'Icons';
-        font-style: normal;
-        .font-icon-solid(@fa-var-arrows-alt-v);
-        padding-right: 0.2rem;
+    ul {
+      list-style-type: none;
+      display: block;
+      min-height: 1rem;
+      margin: 0;
+      padding: 0 0 0 1rem;
     }
 
+    .placeholder {
+        border: dashed thin #ccc;
+        min-height: 1.5rem;
+    }
+
+    .hover {
+        background-color: lightyellow;
+
+        .placeholder {
+            margin-left: 3em;
+        }
+    }
 }

--- a/skins/elastic/styles/widgets/lists.less
+++ b/skins/elastic/styles/widgets/lists.less
@@ -543,7 +543,7 @@ ul.treelist {
             display: none;
         }
 
-        li > a {
+        & > li > a {
             padding-left: .5em;
         }
     }

--- a/skins/elastic/styles/widgets/lists.less
+++ b/skins/elastic/styles/widgets/lists.less
@@ -648,26 +648,13 @@ ul.treelist {
             padding-bottom: 0;
         }
 
-        // Give the list items a little bit more space at top to counter the increased space required by the sub-lists at the bottom.
-        li {
-            padding-top: 0.5rem;
+        .placeholder {
+            border: dashed thin @color-input-border;
+            min-height: 2.5rem;
         }
 
-        li div.treetoggle {
-            top: 0.5rem;
-        }
-
-        .custom-control-label {
-            top: 0.5rem;
-        }
-
-        li ul li:first-child {
-            margin-top: 0.5rem;
-        }
-
-        // To counter the counter, give the first sub-list layer a small padding at the bottom to even out the increased margins/paddings at the top of the elements.
-        &#subscription-table > li > ul {
-            padding-bottom: 0.5rem;
+        .hover {
+            background-color: @color-list-droptarget-background;
         }
 
     }
@@ -1157,34 +1144,5 @@ html.touch {
     td.name:before {
         &:extend(.font-icon-class);
         content: @fa-var-file-alt;
-    }
-}
-
-#subscription-table {
-    padding-bottom: 2em;
-
-    li.mailbox a {
-        padding-right: 2.5rem;
-    }
-
-    ul {
-      list-style-type: none;
-      display: block;
-      min-height: 1rem;
-      margin: 0;
-      padding: 0 0 0.5em 1rem;
-    }
-
-    .placeholder {
-        border: dashed thin @color-input-border;
-        min-height: 1.5rem;
-    }
-
-    .hover {
-        background-color: @color-list-droptarget-background;
-
-        .placeholder {
-            margin-left: 3em;
-        }
     }
 }

--- a/skins/elastic/styles/widgets/lists.less
+++ b/skins/elastic/styles/widgets/lists.less
@@ -476,6 +476,10 @@ ul.treelist {
             padding-left: @listing-treetoggle-width;
         }
 
+        &.hover .placeholder {
+            margin-left: (2 * @listing-treetoggle-width);
+        }
+
         &.selected {
             // reset .listing selection style
             color: inherit;
@@ -495,22 +499,37 @@ ul.treelist {
                 padding-left: 0;
                 a { padding-left: (2 * @listing-treetoggle-width); }
                 div.treetoggle { left: @listing-treetoggle-width; }
+                &.hover .placeholder {
+                    margin-left: (3 * @listing-treetoggle-width);
+                }
 
                 li {
                     a { padding-left: (3 * @listing-treetoggle-width); }
                     div.treetoggle { left: (2 * @listing-treetoggle-width); }
+                    &.hover .placeholder {
+                        margin-left: (4 * @listing-treetoggle-width);
+                    }
 
                     li {
                         a { padding-left: (4 * @listing-treetoggle-width); }
                         div.treetoggle { left: (3 * @listing-treetoggle-width); }
+                        &.hover .placeholder {
+                            margin-left: (5 * @listing-treetoggle-width);
+                        }
 
                         li {
                             a { padding-left: (5 * @listing-treetoggle-width); }
                             div.treetoggle { left: (4 * @listing-treetoggle-width); }
+                            &.hover .placeholder {
+                                margin-left: (6 * @listing-treetoggle-width);
+                            }
 
                             li {
                                 a { padding-left: (6 * @listing-treetoggle-width); }
                                 div.treetoggle { left: (5 * @listing-treetoggle-width); }
+                                &.hover .placeholder {
+                                    margin-left: (7 * @listing-treetoggle-width);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Protected folders like INBOX, Sent, etc. are staying at the top of the list.

Fixes #5003

TODO:
- [x] Fix broken state after folder renaming
- [x] Fix the styling (equalize white space around list elements through padding, avoid ID as selector)
- [x] Figure out if the item was moved between protected folders, which is not allowed.
- [x] ~~Save only if the folder list is different than at start~~ (Not worth the effort)
- [ ] In the receive callback, can we wait for the confirmation dialog without introducing async/await and Promises?


Screenshots:

<img width="405" height="534" alt="Screenshot 2025-07-25 at 16 24 28" src="https://github.com/user-attachments/assets/791592df-dbb0-443e-98f3-2563eb78f0c6" />

---------

<img width="401" height="505" alt="Screenshot 2025-07-25 at 16 24 37" src="https://github.com/user-attachments/assets/07bbd353-35ac-41e6-a3aa-ba29224b12f5" />


---------

<img width="693" height="577" alt="Screenshot 2025-07-25 at 16 24 49" src="https://github.com/user-attachments/assets/5cc2db5a-05ae-4268-9088-cd760c9c65cf" />


---------


<img width="408" height="544" alt="Screenshot 2025-07-25 at 16 24 57" src="https://github.com/user-attachments/assets/ffdad971-dbcd-4e63-ba48-7bf5d91e07d0" />
