### PR TITLE
use asset_url() instead of get_skin_file() for deleteicon on contact edit form

### DIFF
--- a/program/actions/contacts/index.php
+++ b/program/actions/contacts/index.php
@@ -816,7 +816,7 @@ class rcmail_action_contacts_index extends rcmail_action
 
         if (!empty($attrib['deleteicon'])) {
             $del_button = html::img([
-                'src' => $rcmail->output->get_skin_file($attrib['deleteicon']),
+                'src' => $rcmail->output->asset_url($attrib['deleteicon'], true),
                 'alt' => $rcmail->gettext('delete'),
             ]);
         } else {


### PR DESCRIPTION
fixes display of delete icon on contact edit form in Classic skin in git-master/1.7

similar to https://github.com/roundcube/roundcubemail/blob/8f7cc42fd65e0f92bda3c05b7419fe6081680b8b/program/actions/mail/compose.php#L1377-L1380