### PR TITLE
Fixes Microsoft 365 OAUTH2 authentication workflow no longer works #9598

### DIFF
--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -384,6 +384,9 @@ $config['oauth_verify_peer'] = true;
 // Mandatory: OAuth scopes to request (space-separated string)
 $config['oauth_scope'] = null;
 
+// Optional: OAuth scopes specific to identity request (space-separated string)
+$config['oauth_scope_identity'] = null;
+
 // Optional: additional query parameters to send with login request (hash array)
 $config['oauth_auth_parameters'] = [];
 
@@ -455,6 +458,7 @@ $config['oauth_password_claim'] = null;
 // $config['oauth_identity_uri'] = "https://graph.microsoft.com/v1.0/me";
 // $config['oauth_identity_fields'] = ['email', 'userPrincipalName'];
 // $config['oauth_scope'] = "https://outlook.office365.com/IMAP.AccessAsUser.All https://outlook.office365.com/SMTP.Send User.Read offline_access";
+// $config['oauth_scope_identity'] = "https://graph.microsoft.com/IMAP.AccessAsUser.All SMTP.Send offline_access User.Read";
 // $config['oauth_auth_parameters'] = ['nonce' => mt_rand()];
 
 // ----------------------------------

--- a/program/include/rcmail_oauth.php
+++ b/program/include/rcmail_oauth.php
@@ -645,11 +645,11 @@ class rcmail_oauth
                 if($this->options['scope_identity']) {
                     $this->mask_auth_data($data);
                     $refresh_response = $this->refresh_access_token($data, $this->options['scope_identity']);
-                    $data = $refresh_response['token'];
-                    $authorization = $refresh_response['authorization'];
+                    $data_ident = $refresh_response['token'];
+                    $authorization_ident = $refresh_response['authorization'];
                 }
 
-                $fetched_identity = $this->fetch_userinfo($authorization);
+                $fetched_identity = $this->fetch_userinfo($authorization_ident);
 
                 $this->log_debug('fetched identity: %s', json_encode($fetched_identity, true));
 
@@ -662,13 +662,6 @@ class rcmail_oauth
                             break;
                         }
                     }
-                }
-
-                // Restore scope for general mail functions
-                if($this->options['scope_identity']) {
-                    $refresh_response = $this->refresh_access_token($data, $this->options['scope']);
-                    $data = $refresh_response['token'];
-                    $authorization = $refresh_response['authorization'];
                 }
             }
 


### PR DESCRIPTION
See:
[Microsoft 365 OAUTH2 authentication workflow no longer works](https://github.com/roundcube/roundcubemail/issues/9598)
#9598 

Modfiy rcmail_oauth.php and config defaults and examples to allow changing of scope for identity API calls. This is required after Microsoft has changed their API's such that the scopes used for regular mailbox interactions are incompatible with those used for identity operations.