### PR TITLE
Reduce duplicate Github CI workflow runs

### DIFF
--- a/.github/workflows/browser_tests.yml
+++ b/.github/workflows/browser_tests.yml
@@ -2,6 +2,9 @@ name: E2E
 
 on:
   push:
+    branches:
+      - main
+      - release-*
   pull_request:
 
 permissions:
@@ -76,4 +79,3 @@ jobs:
         with:
           name: screenshots
           path: tests/Browser/screenshots
-          

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
+      - release-*
   pull_request:
 
 permissions:

--- a/.github/workflows/message_rendering.yml
+++ b/.github/workflows/message_rendering.yml
@@ -2,6 +2,9 @@ name: Message Rendering
 
 on:
   push:
+    branches:
+      - main
+      - release-*
   pull_request:
 
 permissions:
@@ -34,4 +37,3 @@ jobs:
         with:
           name: Logs
           path: logs/errors.log
-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,9 @@ name: Unit
 
 on:
   push:
+    branches:
+      - main
+      - release-*
   pull_request:
 
 permissions:


### PR DESCRIPTION
The tasks are now run on push-events to the branches "master", and "release-*", as well as on pull-request-events (i.e. all pushes to branches that have a pull request).

This appears to be the easiest way to reduce duplicate workflow runs.