### PR TITLE
only apply fix_path for href attrib in <link>s

### DIFF
--- a/program/include/rcmail_output_html.php
+++ b/program/include/rcmail_output_html.php
@@ -992,7 +992,11 @@ class rcmail_output_html extends rcmail_output
      */
     protected function fix_paths($output)
     {
-        $regexp = '!(src|href|background|data-src-[a-z]+)=(["\']?)([a-z0-9/_.?=-]+)(["\'\s>])!i';
+        $regexp = [
+            '%(?P<name>src|background|data-src-[a-z]+)=(?P<opener>["\']?)(?P<file>[a-z0-9/_.?=-]+)(?P<closer>["\'\s>])%i',
+            // use dedicated pattern for href attribute to avoid <a>'s (#9941)
+            '%(?P<prefix><(?!a\s)[^>]*)(?P<name>href)=(?P<opener>["\']?)(?P<file>[a-z0-9/_.?=-]+)(?P<closer>["\'\s>])%i',
+        ];
 
         return preg_replace_callback($regexp, [$this, 'file_callback'], $output);
     }
@@ -1004,7 +1008,7 @@ class rcmail_output_html extends rcmail_output
      */
     protected function file_callback($matches)
     {
-        $file = $matches[3];
+        $file = $matches['file'];
         $file = preg_replace('!^/this/!', '/', $file);
 
         // correct absolute paths
@@ -1020,7 +1024,7 @@ class rcmail_output_html extends rcmail_output
 
         $file = $this->resource_location($file);
 
-        return $matches[1] . '=' . $matches[2] . $file . $matches[4];
+        return ($matches['prefix'] ?? '') . $matches['name'] . '=' . $matches['opener'] . $file . $matches['closer'];
     }
 
     /**

--- a/program/include/rcmail_output_html.php
+++ b/program/include/rcmail_output_html.php
@@ -994,8 +994,8 @@ class rcmail_output_html extends rcmail_output
     {
         $regexp = [
             '%(?P<name>src|background|data-src-[a-z]+)=(?P<opener>["\']?)(?P<file>[a-z0-9/_.?=-]+)(?P<closer>["\'\s>])%i',
-            // use dedicated pattern for href attribute to avoid <a>'s (#9941)
-            '%(?P<prefix><(?!a\s)[^>]*)(?P<name>href)=(?P<opener>["\']?)(?P<file>[a-z0-9/_.?=-]+)(?P<closer>["\'\s>])%i',
+            // fix href attributes in <link>'s only (#9941)
+            '%(?P<prefix><link[^>]*)(?P<name>href)=(?P<opener>["\']?)(?P<file>[a-z0-9/_.?=-]+)(?P<closer>["\'\s>])%i',
         ];
 
         return preg_replace_callback($regexp, [$this, 'file_callback'], $output);

--- a/tests/Rcmail/OutputHtmlTest.php
+++ b/tests/Rcmail/OutputHtmlTest.php
@@ -457,5 +457,14 @@ class OutputHtmlTest extends TestCase
             . '<a class="mail" id="rcmbtn100" role="button" href="/?_task=mail" onclick="return rcmail.command(\'switch-task\',\'mail\',this,event)"><span class="inner">Mail</span></a></body>';
         $result = $fix_paths->invokeArgs($output, [$input]);
         $this->assertSame($expected, $result);
+
+        $input = '<body><a href="https://ezample.com/test.php">link 1</a>'
+            . '<a href="/example/">link 2</a>'
+            . '<a href="/example/test.html">link 3</a></body>';
+        $expected = '<body><a href="https://ezample.com/test.php">link 1</a>'
+            . '<a href="/example/">link 2</a>'
+            . '<a href="/example/test.html">link 3</a></body>';
+        $result = $fix_paths->invokeArgs($output, [$input]);
+        $this->assertSame($expected, $result);
     }
 }

--- a/tests/Rcmail/OutputHtmlTest.php
+++ b/tests/Rcmail/OutputHtmlTest.php
@@ -437,9 +437,6 @@ class OutputHtmlTest extends TestCase
         $set_skin = $reflection->getProperty('skin_name');
         $fix_paths = $reflection->getMethod('fix_paths');
 
-        $set_skin->setAccessible(true);
-        $fix_paths->setAccessible(true);
-
         $set_skin->setValue($output, 'elastic');
 
         $input = '<body><link rel="shortcut icon" href="/images/test.ico">'

--- a/tests/Rcmail/OutputHtmlTest.php
+++ b/tests/Rcmail/OutputHtmlTest.php
@@ -425,4 +425,37 @@ class OutputHtmlTest extends TestCase
         $this->assertTrue(str_starts_with($result, '<select name="_charset">'));
         $this->assertTrue(str_contains($result, '<option value="UTF-8" selected="selected">UTF-8 (Unicode)</option>'));
     }
+
+    /**
+     * Test fix_paths()
+     */
+    public function test_fix_paths()
+    {
+        $rcmail = \rcube::get_instance();
+        $output = new \rcmail_output_html();
+        $reflection = new \ReflectionClass('rcmail_output_html');
+        $set_skin = $reflection->getProperty('skin_name');
+        $fix_paths = $reflection->getMethod('fix_paths');
+
+        $set_skin->setAccessible(true);
+        $fix_paths->setAccessible(true);
+
+        $set_skin->setValue($output, 'elastic');
+
+        $input = '<body><link rel="shortcut icon" href="/images/test.ico">'
+            . '<link rel="stylesheet" href="/styles/test.css">'
+            . '<script src="program/js/test.js"></script></body>';
+        $expected = '<body><link rel="shortcut icon" href="static.php/skins/elastic/images/test.ico">'
+            . '<link rel="stylesheet" href="static.php/skins/elastic/styles/test.css">'
+            . '<script src="static.php/program/js/test.js"></script></body>';
+        $result = $fix_paths->invokeArgs($output, [$input]);
+        $this->assertSame($expected, $result);
+
+        $input = '<body><img src="/images/test.svg" data-src-alt="/images/test.svg" id="logo" alt="Logo">'
+            . '<a class="mail" id="rcmbtn100" role="button" href="/?_task=mail" onclick="return rcmail.command(\'switch-task\',\'mail\',this,event)"><span class="inner">Mail</span></a></body>';
+        $expected = '<body><img src="static.php/skins/elastic/images/test.svg" data-src-alt="static.php/skins/elastic/images/test.svg" id="logo" alt="Logo">'
+            . '<a class="mail" id="rcmbtn100" role="button" href="/?_task=mail" onclick="return rcmail.command(\'switch-task\',\'mail\',this,event)"><span class="inner">Mail</span></a></body>';
+        $result = $fix_paths->invokeArgs($output, [$input]);
+        $this->assertSame($expected, $result);
+    }
 }


### PR DESCRIPTION
for #9941

I could not think of a use case for the `href` of an `<a>` to go via `static.php` so I split up the existing regex to allow special handling of the `href` attribute and take account of the tag its being used it.

It could be that this is a bit too complicated and really we only need to fix the path when we are in a `<link>` tag. W3Schools says `href` is only valid in `<a>`, `<area>`, `<base>` and `<link>` tags. So the new pattern could be changed to specifically match `<link ` rather than ignore `<a `.