### PR TITLE
Prepend group-names to display-name

### DIFF
--- a/program/actions/mail/show.php
+++ b/program/actions/mail/show.php
@@ -283,29 +283,6 @@ class rcmail_action_mail_show extends rcmail_action_mail_index
         return html::div($attrib, $msg . '&nbsp;' . html::span('boxbuttons', $buttons));
     }
 
-    /**
-     * Display a warning whenever a suspicious email address has been found in the message.
-     *
-     * @return string HTML content of the warning element
-     */
-    public static function suspicious_content_warning()
-    {
-        if (empty(self::$SUSPICIOUS_EMAIL)) {
-            return '';
-        }
-
-        $rcmail = rcmail::get_instance();
-
-        $attrib = [
-            'id' => 'suspicious-content-message',
-            'class' => 'notice',
-        ];
-
-        $msg = html::span(null, rcube::Q($rcmail->gettext('suspiciousemail')));
-
-        return html::div($attrib, $msg);
-    }
-
     public static function message_buttons()
     {
         $rcmail = rcmail::get_instance();
@@ -352,7 +329,6 @@ class rcmail_action_mail_show extends rcmail_action_mail_index
         $content = [
             self::message_buttons(),
             self::remote_objects_msg(),
-            self::suspicious_content_warning(),
         ];
 
         $plugin = $rcmail->plugins->exec_hook('message_objects',

--- a/program/localization/en_US/messages.inc
+++ b/program/localization/en_US/messages.inc
@@ -233,4 +233,3 @@ $messages['emptyattachment'] = 'This attachment appears to be empty.<br>Please, 
 $messages['oauthloginfailed'] = 'OAuth login failed. Please try again.';
 $messages['oauthinvalidrequest'] = 'Authorization request was invalid or incomplete.';
 $messages['oauthaccessdenied'] = 'Authorization server or the user denied the request.';
-$messages['senderphishingwarning'] = 'This sender name and address look forged, please be careful!';

--- a/program/localization/en_US/messages.inc
+++ b/program/localization/en_US/messages.inc
@@ -233,3 +233,4 @@ $messages['emptyattachment'] = 'This attachment appears to be empty.<br>Please, 
 $messages['oauthloginfailed'] = 'OAuth login failed. Please try again.';
 $messages['oauthinvalidrequest'] = 'Authorization request was invalid or incomplete.';
 $messages['oauthaccessdenied'] = 'Authorization server or the user denied the request.';
+$messages['senderphishingwarning'] = 'This sender name and address look forged, please be careful!';

--- a/skins/elastic/styles/styles.less
+++ b/skins/elastic/styles/styles.less
@@ -434,6 +434,14 @@ body.task-error-login #layout {
     margin: 1rem 1rem 0 1rem;
 }
 
+.sender-phishing-warning:before {
+    .font-icon-class();
+    float: none;
+    display: inline-block;
+    content: @fa-var-exclamation-triangle;
+    color: @color-message-warning;
+}
+
 #composestatusbar {
     opacity: .3;
     right: 2.5rem;

--- a/skins/elastic/styles/styles.less
+++ b/skins/elastic/styles/styles.less
@@ -434,7 +434,7 @@ body.task-error-login #layout {
     margin: 1rem 1rem 0 1rem;
 }
 
-.sender-phishing-warning:before {
+.suspicious-address-warning:before {
     .font-icon-class();
     float: none;
     display: inline-block;

--- a/tests/Framework/MimeTest.php
+++ b/tests/Framework/MimeTest.php
@@ -106,24 +106,58 @@ class MimeTest extends TestCase
             3 => 'group:test1@email.com,test2@email.com',
             4 => 'group: <test1@email.com>,<test2@email.com>',
             5 => '"test:group": "TEST1" <test1@email.com>,"TEST2" <test2@email.com>; test3@email.com',
+            6 => '<test3@email.com>, testgroup: "TEST1" <test1@email.com>, "TEST2" <test2@email.com>;',
+            7 => '<test3@email.com>, testgroup: "TEST1" <test1@email.com>, "TEST2" <test2@email.com>',
+            8 => 'test3@email.com, testgroup: "TEST1" <test1@email.com>, "TEST2" <test2@email.com>',
+            9 => 'Test <attacker@example.org>:<admin@example.net>',
+            10 => '"Test Foo:" <attacker@example.org>:<admin@example.net>',
+            11 => '<attacker@example.org>:<admin@example.net>',
+            12 => 'attacker@example.org:<admin@example.net>',
         ];
 
         $results = [
             0 => [],
-            1 => [1 => ['name' => '', 'mailto' => 'test1@email.com', 'string' => 'test1@email.com']],
-            2 => [1 => ['name' => '', 'mailto' => 'test1@email.com', 'string' => 'test1@email.com']],
+            1 => [1 => ['name' => 'group', 'mailto' => 'test1@email.com', 'string' => 'group <test1@email.com>']],
+            2 => [1 => ['name' => 'group', 'mailto' => 'test1@email.com', 'string' => 'group <test1@email.com>']],
             3 => [
-                1 => ['name' => '', 'mailto' => 'test1@email.com', 'string' => 'test1@email.com'],
+                1 => ['name' => 'group', 'mailto' => 'test1@email.com', 'string' => 'group <test1@email.com>'],
                 2 => ['name' => '', 'mailto' => 'test2@email.com', 'string' => 'test2@email.com'],
             ],
             4 => [
-                1 => ['name' => '', 'mailto' => 'test1@email.com', 'string' => 'test1@email.com'],
+                1 => ['name' => 'group', 'mailto' => 'test1@email.com', 'string' => 'group <test1@email.com>'],
                 2 => ['name' => '', 'mailto' => 'test2@email.com', 'string' => 'test2@email.com'],
             ],
             5 => [
-                1 => ['name' => 'TEST1', 'mailto' => 'test1@email.com', 'string' => 'TEST1 <test1@email.com>'],
+                1 => ['name' => 'test:group TEST1', 'mailto' => 'test1@email.com', 'string' => '"test:group TEST1" <test1@email.com>'],
                 2 => ['name' => 'TEST2', 'mailto' => 'test2@email.com', 'string' => 'TEST2 <test2@email.com>'],
                 3 => ['name' => '', 'mailto' => 'test3@email.com', 'string' => 'test3@email.com'],
+            ],
+            6 => [
+                1 => ['name' => '', 'mailto' => 'test3@email.com', 'string' => 'test3@email.com'],
+                2 => ['name' => 'testgroup TEST1', 'mailto' => 'test1@email.com', 'string' => 'testgroup TEST1 <test1@email.com>'],
+                3 => ['name' => 'TEST2', 'mailto' => 'test2@email.com', 'string' => 'TEST2 <test2@email.com>'],
+            ],
+            7 => [
+                1 => ['name' => '', 'mailto' => 'test3@email.com', 'string' => 'test3@email.com'],
+                2 => ['name' => 'testgroup TEST1', 'mailto' => 'test1@email.com', 'string' => 'testgroup TEST1 <test1@email.com>'],
+                3 => ['name' => 'TEST2', 'mailto' => 'test2@email.com', 'string' => 'TEST2 <test2@email.com>'],
+            ],
+            8 => [
+                1 => ['name' => '', 'mailto' => 'test3@email.com', 'string' => 'test3@email.com'],
+                2 => ['name' => 'testgroup TEST1', 'mailto' => 'test1@email.com', 'string' => 'testgroup TEST1 <test1@email.com>'],
+                3 => ['name' => 'TEST2', 'mailto' => 'test2@email.com', 'string' => 'TEST2 <test2@email.com>'],
+            ],
+            9 => [
+                1 => ['name' => 'Test <attacker@example.org>', 'mailto' => 'admin@example.net', 'string' => '"Test <attacker@example.org>" <admin@example.net>'],
+            ],
+            10 => [
+                1 => ['name' => '"Test Foo:" <attacker@example.org>', 'mailto' => 'admin@example.net', 'string' => '"\"Test Foo:\" <attacker@example.org>" <admin@example.net>'],
+            ],
+            11 => [
+                1 => ['name' => '<attacker@example.org>', 'mailto' => 'admin@example.net', 'string' => '"<attacker@example.org>" <admin@example.net>'],
+            ],
+            12 => [
+                1 => ['name' => 'attacker@example.org', 'mailto' => 'admin@example.net', 'string' => '"attacker@example.org" <admin@example.net>'],
             ],
         ];
 

--- a/tests/MessageRendering/EmailAdressSpoofingAttacksTest.php
+++ b/tests/MessageRendering/EmailAdressSpoofingAttacksTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\MessageRendering;
+
+/**
+ * Test class to test simple messages.
+ */
+class EmailAdressSpoofingAttacksTest extends MessageRenderingTestCase
+{
+    /**
+     * Test that two text mime-parts with disposition "attachment" are shown as
+     * attachments.
+     */
+    public function testEmailAdressSpoofingAttacks()
+    {
+        $domxpath = $this->runAndGetHtmlOutputDomxpath('1176148a1ed73947311a08a3fc11264e64d8f775eae596e5fa660cfd1684a5e6@example.net');
+        $this->assertSame('Email address spoofing attacks', $this->getScrubbedSubject($domxpath));
+
+        $suspiciousAddressWarnings = $domxpath->query('//span[@class="suspicious-address-warning"]');
+        // It should be present three times: two times for the phishing attack in the From header (once in the header
+        // summary element, once in the header details element), one time for the homograph attack in the To header.
+        $this->assertCount(3, $suspiciousAddressWarnings, 'Sender phishing warning');
+        $expectedMsg = 'This message contains suspicious email addresses that may be fraudulent.';
+        $this->assertSame($expectedMsg, $suspiciousAddressWarnings[0]->attributes->getNamedItem('title')->textContent);
+        $this->assertSame($expectedMsg, $suspiciousAddressWarnings[1]->attributes->getNamedItem('title')->textContent);
+        $this->assertSame($expectedMsg, $suspiciousAddressWarnings[2]->attributes->getNamedItem('title')->textContent);
+    }
+}

--- a/tests/MessageRendering/data/greenmail/test-message-rendering@localhost/INBOX/email-address-spoofing-attacks.eml
+++ b/tests/MessageRendering/data/greenmail/test-message-rendering@localhost/INBOX/email-address-spoofing-attacks.eml
@@ -1,0 +1,9 @@
+From: "Someone" <valid@example.net>:<attacker@example.org>
+To: test@Рaypal.com
+Subject: Email address spoofing attacks
+MIME-Version: 1.0
+Date: Fri, 12 June 2025 23:42:00 +0200
+Message-ID: <1176148a1ed73947311a08a3fc11264e64d8f775eae596e5fa660cfd1684a5e6@example.net>
+Content-Type: text/plain
+
+The content doesn't really matter.


### PR DESCRIPTION
This is not optimal handling, but the most appropriate one as long as we don't actually support groups in addresss-lists. This way users can at least see the group's display-name. And we don't strip text that might be relevant to spot abusive emails.

Previously group-names were just removed, which makes it harder to spot such abusive emails.