### PR TITLE
Wash the `name` attribute also on more elements

### DIFF
--- a/program/lib/Roundcube/rcube_washtml.php
+++ b/program/lib/Roundcube/rcube_washtml.php
@@ -326,7 +326,7 @@ class rcube_washtml
                         $out = $value;
                     }
                 } elseif ($this->_css_prefix !== null
-                    && (in_array($key, ['id', 'class', 'for']) || ($key == 'name' && in_array($node->nodeName, ['a', 'img', 'input', 'form'])))
+                    && (in_array($key, ['id', 'class', 'for']) || ($key == 'name' && in_array($node->nodeName, ['a', 'img', 'input', 'form', 'select', 'textarea'])))
                 ) {
                     $out = preg_replace('/(\S+)/', $this->_css_prefix . '\1', $value);
                 } elseif ($key == 'xmlns' && !strpos($value, '://')) {

--- a/program/lib/Roundcube/rcube_washtml.php
+++ b/program/lib/Roundcube/rcube_washtml.php
@@ -326,7 +326,7 @@ class rcube_washtml
                         $out = $value;
                     }
                 } elseif ($this->_css_prefix !== null
-                    && (in_array($key, ['id', 'class', 'for']) || ($key == 'name' && $node->nodeName == 'a'))
+                    && (in_array($key, ['id', 'class', 'for']) || ($key == 'name' && in_array($node->nodeName, ['a', 'img', 'input', 'form'])))
                 ) {
                     $out = preg_replace('/(\S+)/', $this->_css_prefix . '\1', $value);
                 } elseif ($key == 'xmlns' && !strpos($value, '://')) {

--- a/tests/Framework/WashtmlTest.php
+++ b/tests/Framework/WashtmlTest.php
@@ -705,12 +705,23 @@ class WashtmlTest extends TestCase
         $this->assertStringContainsString('href="#testmy-id"', $washed);
         $this->assertStringContainsString('class="testmy-class1 testmy-class2"', $washed);
 
-        // Make sure the anchor name is prefixed too
+        // Make sure the name attribute is prefixed on different elements, too
         $html = '<p><a href="#a">test link</a></p><a name="a">test anchor</a>';
         $washed = $washer->wash($html);
-
         $this->assertStringContainsString('href="#testa"', $washed);
         $this->assertStringContainsString('name="testa"', $washed);
+
+        $html = '<img src="something" name="animage" />';
+        $washed = $washer->wash($html);
+        $this->assertStringContainsString('name="testanimage"', $washed);
+
+        $html = '<form action="something"><input name="myform" type="submit" /></form>';
+        $washed = $washer->wash($html);
+        $this->assertStringContainsString('name="testmyform"', $washed);
+
+        $html = '<meta content="something" name="description"><input name="myform" type="submit" /></form>';
+        $washed = $washer->wash($html);
+        $this->assertStringContainsString('name="testmyform"', $washed);
     }
 
     /**

--- a/tests/Framework/WashtmlTest.php
+++ b/tests/Framework/WashtmlTest.php
@@ -721,7 +721,16 @@ class WashtmlTest extends TestCase
 
         $html = '<meta content="something" name="description"><input name="myform" type="submit" /></form>';
         $washed = $washer->wash($html);
-        $this->assertStringContainsString('name="testmyform"', $washed);
+        $this->assertStringNotContainsString('name="description"', $washed);
+        $this->assertStringContainsString('input name="testmyform"', $washed);
+
+        $html = '<textarea name="something" />';
+        $washed = $washer->wash($html);
+        $this->assertStringContainsString('name="testsomething"', $washed);
+
+        $html = '<select name="something" />';
+        $washed = $washer->wash($html);
+        $this->assertStringContainsString('name="testsomething"', $washed);
     }
 
     /**

--- a/tests/MessageRendering/BasicMessagesTest.php
+++ b/tests/MessageRendering/BasicMessagesTest.php
@@ -66,4 +66,22 @@ class BasicMessagesTest extends MessageRenderingTestCase
         $this->assertSame('żółć.png', $attchNames[4]->textContent);
         $this->assertSame('very very very very long very very very very long ćććććć very very very long name.txt', $attchNames[5]->textContent);
     }
+
+    /**
+     * Test that name attributes are properly prefixed.
+     */
+    public function testNameAttribute()
+    {
+        $domxpath = $this->runAndGetHtmlOutputDomxpath('20176e2b981a7231e77134de8bc3b02d3652aaac1f5b8dece087c550f4816a60@example.net');
+
+        $this->assertSame('Name attribute', $this->getScrubbedSubject($domxpath));
+
+        $this->assertSame('unchanged', $domxpath->query('//div[@class="rcmBody"]//div')[0]->attributes['name']->textContent);
+        $this->assertSame('v1imgtest', $domxpath->query('//div[@class="rcmBody"]//img')[0]->attributes['name']->textContent);
+        $this->assertSame('v1test', $domxpath->query('//div[@class="rcmBody"]//a')[0]->attributes['name']->textContent);
+        $this->assertSame('v1inputtest', $domxpath->query('//div[@class="rcmBody"]//input')[0]->attributes['name']->textContent);
+        // Make sure the `form` element was replaced. If this fails at some point in time, some code was changed and we
+        // have to adapt this test case to also check the `name`-attribute on the `form`-element.
+        $this->assertCount(0, $domxpath->query('//div[@class="rcmBody"]//form'));
+    }
 }

--- a/tests/MessageRendering/data/greenmail/test-message-rendering@localhost/INBOX/name-attribute.eml
+++ b/tests/MessageRendering/data/greenmail/test-message-rendering@localhost/INBOX/name-attribute.eml
@@ -1,0 +1,11 @@
+From: <someone@example.net>
+To: <someoneelse@bbb.cc>
+Date: Wed, 1 Aug 2024 12:00:00 +0000
+Subject: Name attribute
+Message-Id: <20176e2b981a7231e77134de8bc3b02d3652aaac1f5b8dece087c550f4816a60@example.net>
+Content-Type: text/html; charset="UTF-8"
+Content-Transfer-Encoding: quoted-printable
+
+<div name=3D"unchanged"><a href=3D"/something" name=3D"test">lala</a><img s=
+rc=3D"/something" name=3D"imgtest" /></div><form action=3D"/bla"><input typ=
+e=3D"submit" name=3D"inputtest" /></form>


### PR DESCRIPTION
It can pollute the document's namespace unless handled.

The elements the code now handles the `name`-attribute on is based on my research, if you know of further relevant elements, please let me know.