### PR TITLE
fix: Sanitize filename on download

### DIFF
--- a/program/lib/Roundcube/rcube_output.php
+++ b/program/lib/Roundcube/rcube_output.php
@@ -259,12 +259,14 @@ abstract class rcube_output
             $fallback_filename = preg_replace('/[^a-zA-Z0-9_.(),;@+ -]/', '_', $filename);
             $disposition .= "; filename=\"{$fallback_filename}\"";
 
-            $filename = rawurlencode($filename);
-            $charset = $this->charset;
-            if (!empty($params['charset']) && rcube_charset::is_valid($params['charset'])) {
-                $charset = $params['charset'];
+            if ($fallback_filename != $filename) {
+                $filename = rawurlencode($filename);
+                $charset = $this->charset;
+                if (!empty($params['charset']) && rcube_charset::is_valid($params['charset'])) {
+                    $charset = $params['charset'];
+                }
+                $disposition .= "; filename*={$charset}''{$filename}";
             }
-            $disposition .= "; filename*={$charset}''{$filename}";
         }
 
         $this->header("Content-Disposition: {$disposition}");

--- a/program/lib/Roundcube/rcube_output.php
+++ b/program/lib/Roundcube/rcube_output.php
@@ -256,17 +256,15 @@ abstract class rcube_output
         // @phpstan-ignore-next-line
         if (is_string($filename) && $filename !== '' && strlen($filename) <= 1024) {
             // For non-ascii characters we'll use RFC2231 syntax
-            if (!preg_match('/[^a-zA-Z0-9_.:,?;@+ -]/', $filename)) {
-                $disposition .= "; filename=\"{$filename}\"";
-            } else {
-                $filename = rawurlencode($filename);
-                $charset = $this->charset;
-                if (!empty($params['charset']) && rcube_charset::is_valid($params['charset'])) {
-                    $charset = $params['charset'];
-                }
+            $fallback_filename = preg_replace('/[^a-zA-Z0-9_.(),;@+ -]/', '_', $filename);
+            $disposition .= "; filename=\"{$fallback_filename}\"";
 
-                $disposition .= "; filename*={$charset}''{$filename}";
+            $filename = rawurlencode($filename);
+            $charset = $this->charset;
+            if (!empty($params['charset']) && rcube_charset::is_valid($params['charset'])) {
+                $charset = $params['charset'];
             }
+            $disposition .= "; filename*={$charset}''{$filename}";
         }
 
         $this->header("Content-Disposition: {$disposition}");

--- a/tests/Framework/OutputTest.php
+++ b/tests/Framework/OutputTest.php
@@ -26,6 +26,16 @@ class OutputTest extends TestCase
         $this->assertContains('Content-Type: application/octet-stream', $output->headers);
         $this->assertContains('Content-Security-Policy: default-src \'none\'; img-src \'self\'', $output->headers);
 
+        // Test handling of filename*
+        $output->reset();
+        $output->download_headers('test ? test');
+
+        $this->assertCount(3, $output->headers);
+        $this->assertContains('Content-Disposition: attachment; filename="test _ test"; filename*=' . RCUBE_CHARSET . "''" . rawurlencode('test ? test'), $output->headers);
+        $this->assertContains('Content-Type: application/octet-stream', $output->headers);
+        $this->assertContains('Content-Security-Policy: default-src \'none\'; img-src \'self\'', $output->headers);
+
+
         // Invalid content type
         $output->reset();
         $params = ['type' => 'invalid'];

--- a/tests/Framework/OutputTest.php
+++ b/tests/Framework/OutputTest.php
@@ -35,7 +35,6 @@ class OutputTest extends TestCase
         $this->assertContains('Content-Type: application/octet-stream', $output->headers);
         $this->assertContains('Content-Security-Policy: default-src \'none\'; img-src \'self\'', $output->headers);
 
-
         // Invalid content type
         $output->reset();
         $params = ['type' => 'invalid'];


### PR DESCRIPTION
Hi @alecpl,

Thanks again for your feedback on the previous PR (#9906).

I've moved the changes on a dedicated branch, implemented your suggestions for the filename handling, and added a test to confirm the fix.

This PR replaces the previous (#9906). This PR is still compliant to the [IETF RFC Standard: 6266, section 4.3](https://datatracker.ietf.org/doc/html/rfc6266#section-4.3).

All CI checks should be passing now.

Ready for your review when you have a moment.

Thanks