### PR TITLE
Fix flaky browser test

### DIFF
--- a/tests/Browser/Mail/ListTest.php
+++ b/tests/Browser/Mail/ListTest.php
@@ -99,6 +99,7 @@ class ListTest extends TestCase
     public function testListSelection()
     {
         $this->browse(static function ($browser) {
+            $browser->refresh();
             if ($browser->isPhone()) {
                 $browser->with(new Toolbarmenu(), static function ($browser) {
                     $browser->clickMenuItem('select', null, false);


### PR DESCRIPTION
Fixes `Browser/Mail/ListTest.php` on tablets by refreshing the page. Not sure why it's necessary, but it works reliably.