### PR TITLE
Support early MIME types for S/MIME encrypted messages

### DIFF
--- a/program/js/app.js
+++ b/program/js/app.js
@@ -2530,7 +2530,7 @@ function rcube_webmail() {
                     html = '<span class="' + flags.attachmentClass + '" title="' + label + '"></span>';
                 } else if (flags.ctype == 'multipart/report') {
                     html = '<span class="report"></span>';
-                } else if (flags.ctype == 'multipart/encrypted' || flags.ctype == 'application/pkcs7-mime') {
+                } else if (flags.ctype == 'multipart/encrypted' || flags.ctype == 'application/pkcs7-mime' || flags.ctype == 'application/x-pkcs7-mime') {
                     html = '<span class="encrypted"></span>';
                 } else if (flags.hasattachment || (!flags.hasnoattachment && /application\/|multipart\/(m|signed)/.test(flags.ctype))) {
                     html = '<span class="attachment" title="' + label + '"></span>';

--- a/program/lib/Roundcube/rcube_message.php
+++ b/program/lib/Roundcube/rcube_message.php
@@ -892,7 +892,7 @@ class rcube_message
             }
         }
         // this is an S/MIME encrypted message -> create a plaintext body with the according message
-        elseif ($mimetype == 'application/pkcs7-mime') {
+        elseif ($mimetype == 'application/pkcs7-mime' || $mimetype == 'application/x-pkcs7-mime') {
             $p = new rcube_message_part();
             $p->type = 'content';
             $p->ctype_primary = 'text';


### PR DESCRIPTION
I like to propose a small enhancement to make Roundcube recognize S/MIME encrypted messages by the early Content-Type `application/x-pkcs7-mime` (RFC 2311, Appendix C.1). 

By this change those messages get the lock symbol in the message list and the banner text `encryptedmessage` is displayed when the message is selected.

There might be some clients around still using it, for example if they use openssl for encryption like the example below:
```
openssl smime -encrypt -in mytext.txt -out mail.msg -from bob@example.com -to alice@example.com -subject "This message is encrypted" -aes-256-cbc alice_pup_key.pem
```