### PR TITLE
Build testrunner images for php v8.4 and 8.5-rc, too

### DIFF
--- a/.ci/docker-images/Dockerfile
+++ b/.ci/docker-images/Dockerfile
@@ -2,6 +2,9 @@ ARG PHPVERSION=8.3
 FROM php:${PHPVERSION}-cli
 LABEL org.opencontainers.image.source="https://github.com/roundcube/roundcubemail"
 
+# To use it below we must repeat the ARG declaration
+ARG PHPVERSION
+
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
@@ -33,7 +36,9 @@ RUN sed -i 's/^# en_US.UTF-8 /en_US.UTF-8 /' /etc/locale.gen && locale-gen
 
 # TODO: Do we need the multiarch-args? What for?
 #RUN debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)" \
-RUN docker-php-ext-configure gd --with-jpeg --with-freetype \
+# For PHP >= v8.4 pspell was moved to PECL, so we have to fetch and unpack it first. (We don't use `pecl install` just because it makes the rest of the script simpler.)
+RUN if php -r 'exit(version_compare(getenv("PHPVERSION"), "8.4", ">=") ? 0 : 1);'; then pecl bundle -d /usr/src/php/ext pspell; fi \
+ && docker-php-ext-configure gd --with-jpeg --with-freetype \
  #&& docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch" \
  && docker-php-ext-configure ldap \
  && docker-php-ext-install \

--- a/.ci/docker-images/build.sh
+++ b/.ci/docker-images/build.sh
@@ -11,4 +11,4 @@ case "$1" in
 		;;
 esac
 
-exec docker build --build-arg "PHPVERSION=$phpversion" -f "$(realpath $(dirname $0)/Dockerfile)" -t "ghcr.io/pabzm/roundcubemail-testrunner:php$phpversion" "$(realpath $(dirname $0)/../../..)"
+exec docker build --build-arg "PHPVERSION=$phpversion" -f "$(realpath $(dirname $0)/Dockerfile)" -t "localhost/roundcubemail-testrunner:php$phpversion" "$(realpath $(dirname $0)/../../..)"

--- a/.ci/docker-images/build.sh
+++ b/.ci/docker-images/build.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 case "$1" in
-	8.1|8.3)
-		phpversion="$1"
+	''|-*)
+		echo "Error: first and only argument must be the wanted PHP version."
+		echo "E.g.: $(basename $0) 8.4"
+		exit 1
 		;;
 	*)
-		echo "Error: first and only argument must be the wanted PHP version."
-		echo "Usage: $(basename $0) 8.1|8.3"
-		exit 1
+		phpversion="$1"
 		;;
 esac
 

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       # Set up a matrix so we can add more versions to build with in the future.
       matrix:
-        php: ["8.3"]
+        php: ["8.3", "8.4", "8.5-rc"]
 
     name: build and push with PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
@@ -48,4 +48,3 @@ jobs:
           #platforms: linux/amd64,linux/arm64
           build-args: PHPVERSION=${{ matrix.php }}
           tags: "ghcr.io/roundcube/roundcubemail-testrunner:php${{ matrix.php }}"
-


### PR DESCRIPTION
Extracted from https://github.com/roundcube/roundcubemail/pull/9970 so we can use those new images in that PR, too