### PR TITLE
Improve uploading artefacts on browser test failure

### DIFF
--- a/.github/workflows/browser_tests.yml
+++ b/.github/workflows/browser_tests.yml
@@ -84,5 +84,5 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
-          name: screenshots
+          name: screenshots-php${{ matrix.php }}
           path: tests/Browser/screenshots

--- a/.github/workflows/browser_tests.yml
+++ b/.github/workflows/browser_tests.yml
@@ -86,3 +86,11 @@ jobs:
         with:
           name: screenshots-php${{ matrix.php }}
           path: tests/Browser/screenshots
+
+      - name: Upload browser console as artifacts
+        # Upload console messages if the test suite failed.
+        if: failure()
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: console-php${{ matrix.php }}
+          path: tests/Browser/console


### PR DESCRIPTION
This fixes uploading a second set of screenshots, if the workflow runs for both PHP versions fail.

And it introduces uploading the browser console as artefacts for each failing workflow run. 