### PR TITLE
Fix installing aspell in all test workflow runs

### DIFF
--- a/.github/workflows/browser_tests.yml
+++ b/.github/workflows/browser_tests.yml
@@ -64,7 +64,7 @@ jobs:
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
       - name: Install Aspell
-        run: sudo apt-get -y install aspell aspell-en aspell-de
+        run: sudo apt-get -y update && sudo apt-get -y install --no-install-recommends aspell aspell-en aspell-de
 
       - name: Execute tests
         if: ${{ matrix.php != '8.5' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
       - name: Install Aspell/Hunspell
-        run: sudo apt-get -y install aspell aspell-en aspell-de hunspell-en-us
+        run: sudo apt-get -y update && sudo apt-get -y install --no-install-recommends aspell aspell-en aspell-de hunspell-en-us
 
       - name: Execute tests
         if: ${{ matrix.php != '8.5' }}


### PR DESCRIPTION
For some reason we now have to run `apt-get update` in some workflows before installing the packages. But it's good practice anyways.

At this opportunity I introduce --no-install-recommends as well, to keep the number of installed packages low.