### PR TITLE
Exclude .php-cs-fixer-fully_qualified_strict_types.php from release tarballs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ roundcubemail-git: buildtools
 	(cd roundcubemail-git; find . -name '.gitignore' | xargs rm -f)
 	(cd roundcubemail-git; find . -name '.travis.yml' | xargs rm -f)
 	(cd roundcubemail-git; rm -rf tests plugins/*/tests .git* .tx* .ci* .editorconfig* index-test.php Dockerfile Makefile package.json package-lock.json node_modules)
-	(cd roundcubemail-git; rm -f .eslintrc.js .php-cs-fixer.dist.php phpstan.neon.dist)
+	(cd roundcubemail-git; rm -f .eslintrc.js .php-cs-fixer.dist.php .php-cs-fixer-fully_qualified_strict_types.php phpstan.neon.dist)
 	(cd roundcubemail-git; $(SEDI) 's/1.7-git/$(VERSION)/' program/include/iniset.php program/lib/Roundcube/bootstrap.php)
 	(cd roundcubemail-git; $(SEDI) 's/# Unreleased/# Release $(VERSION)'/ CHANGELOG.md)
 


### PR DESCRIPTION
That slipped in the beta release but shouldn't be included in the final release.