### PR TITLE
Cancel concurrent CI workflow runs

### DIFF
--- a/.github/workflows/browser_tests.yml
+++ b/.github/workflows/browser_tests.yml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -9,6 +9,10 @@ on:
     # Rebuild automatically each monday early morning.
     - cron: "42 5 * * 1"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build_and_push:
     if: github.repository == 'roundcube/roundcubemail'

--- a/.github/workflows/message_rendering.yml
+++ b/.github/workflows/message_rendering.yml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,10 @@ name: Unit
 on:
   push:
   pull_request:
+    
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read


### PR DESCRIPTION
Here's another attempt at reducing duplicated CI workflow jobs, which in my understanding should not impair forks.

@mvorisek I'd like to hear your opinion, too.

(For context, the previous attempt was https://github.com/roundcube/roundcubemail/pull/9942)