### PR TITLE
add left padding to dark.less

### DIFF
--- a/skins/elastic/styles/dark.less
+++ b/skins/elastic/styles/dark.less
@@ -822,6 +822,7 @@ html.dark-mode {
         background-color: white;
         color: @color-font;
         padding: 0;
+        padding-left: .3rem;
         margin-top: .5rem;
     }
 


### PR DESCRIPTION
In dark mode, the message body usually still has a white background, but there is no margin / padding between the surrounding dark interface and the white email body. This adds a slight padding to make the email slightly more visually pleasant.

Fixes issue #10002