### PR TITLE
Add rel='noopener' to all links opening in a new window

### DIFF
--- a/plugins/help/help.php
+++ b/plugins/help/help.php
@@ -162,7 +162,7 @@ class help extends rcube_plugin
             && $rcmail->request_status == rcube::REQUEST_ERROR_URL
             && ($url = $rcmail->config->get('help_csrf_info'))
         ) {
-            $args['text'] .= '<p>' . html::a(['href' => $url, 'target' => '_blank'], $this->gettext('csrfinfo')) . '</p>';
+            $args['text'] .= '<p>' . html::a(['href' => $url, 'target' => '_blank', 'rel' => 'noopener'], $this->gettext('csrfinfo')) . '</p>';
         }
 
         return $args;

--- a/program/actions/contacts/show.php
+++ b/program/actions/contacts/show.php
@@ -194,6 +194,7 @@ class rcmail_action_contacts_show extends rcmail_action_contacts_index
         return html::a([
                 'href' => $prefix . $url,
                 'target' => '_blank',
+                'rel' => 'noopener',
                 'class' => 'url',
             ],
             rcube::Q($url)

--- a/program/actions/mail/index.php
+++ b/program/actions/mail/index.php
@@ -1324,6 +1324,7 @@ class rcmail_action_mail_index extends rcmail_action
                 }
             } elseif (!empty($attrib['href']) && $attrib['href'][0] != '#') {
                 $attrib['target'] = '_blank';
+                $attrib['rel'] = 'noopener';
             }
 
             // Better security by adding rel="noreferrer" (#1484686)

--- a/program/actions/settings/about.php
+++ b/program/actions/settings/about.php
@@ -43,10 +43,10 @@ class rcmail_action_settings_about extends rcmail_action
             },
             'license' => static function () {
                 return 'This program is free software; you can redistribute it and/or modify it under the terms '
-                    . 'of the <a href="https://www.gnu.org/licenses/gpl.html" target="_blank">GNU General Public License</a> '
+                    . 'of the <a href="https://www.gnu.org/licenses/gpl.html" target="_blank" rel="noopener">GNU General Public License</a> '
                     . 'as published by the Free Software Foundation, either version 3 of the License, '
                     . 'or (at your option) any later version.<br/>'
-                    . 'Some <a href="https://roundcube.net/license" target="_blank">exceptions</a> '
+                    . 'Some <a href="https://roundcube.net/license" target="_blank" rel="noopener">exceptions</a> '
                     . 'for skins &amp; plugins apply.';
             },
         ]);
@@ -117,6 +117,7 @@ class rcmail_action_settings_about extends rcmail_action
             if ($uri) {
                 $uri = html::a([
                         'target' => '_blank',
+                        'rel' => 'noopener',
                         'href' => rcube::Q($uri),
                     ],
                     rcube::Q($rcmail->gettext('download'))
@@ -128,6 +129,7 @@ class rcmail_action_settings_about extends rcmail_action
             if (!empty($data['license_uri'])) {
                 $license = html::a([
                         'target' => '_blank',
+                        'rel' => 'noopener',
                         'href' => rcube::Q($data['license_uri']),
                     ],
                     rcube::Q($data['license'])
@@ -155,7 +157,7 @@ class rcmail_action_settings_about extends rcmail_action
             html::span('skinitem', html::span('skinname', rcube::Q($meta['name'])) . (!empty($meta['version']) ? '&nbsp;(' . $meta['version'] . ')' : '') . html::br()
                 . (!empty($meta['author_link']) ? html::span('skinauthor', $rcmail->gettext(['name' => 'skinauthor', 'vars' => ['author' => $meta['author_link']]])) . html::br() : '')
                 . (!empty($meta['license_link']) ? html::span('skinlicense', $rcmail->gettext('license') . ':&nbsp;' . $meta['license_link']) . html::br() : '')
-                . (!empty($meta['uri']) ? html::span('skinhomepage', $rcmail->gettext('source') . ':&nbsp;' . html::a(['href' => $meta['uri'], 'target' => '_blank', 'tabindex' => '-1'], rcube::Q($rcmail->gettext('download')))) : ''))
+                . (!empty($meta['uri']) ? html::span('skinhomepage', $rcmail->gettext('source') . ':&nbsp;' . html::a(['href' => $meta['uri'], 'target' => '_blank', 'rel' => 'noopener', 'tabindex' => '-1'], rcube::Q($rcmail->gettext('download')))) : ''))
         );
 
         return $content;

--- a/program/actions/settings/index.php
+++ b/program/actions/settings/index.php
@@ -1513,7 +1513,7 @@ class rcmail_action_settings_index extends rcmail_action
                             'content' => html::div(
                                 ['style' => 'display:none', 'class' => 'boxwarning', 'id' => 'mailvelope-warning'],
                                 str_replace(
-                                    'Mailvelope', '<a href="https://www.mailvelope.com" target="_blank">Mailvelope</a>',
+                                    'Mailvelope', '<a href="https://www.mailvelope.com" target="_blank" rel="noopener">Mailvelope</a>',
                                     rcube::Q($rcmail->gettext('mailvelopenotfound'))
                                 )
                                 . html::script([], "if (!parent.mailvelope) \$('#mailvelope-warning').show()")

--- a/program/include/rcmail_install.php
+++ b/program/include/rcmail_install.php
@@ -811,7 +811,7 @@ class rcmail_install
         $hint = rcube::Q($message);
 
         if ($url) {
-            $hint .= ($hint ? '; ' : '') . 'See <a href="' . rcube::Q($url) . '" target="_blank">' . rcube::Q($url) . '</a>';
+            $hint .= ($hint ? '; ' : '') . 'See <a href="' . rcube::Q($url) . '" target="_blank" rel="noopener">' . rcube::Q($url) . '</a>';
         }
 
         if ($hint) {

--- a/program/include/rcmail_output.php
+++ b/program/include/rcmail_output.php
@@ -73,8 +73,8 @@ abstract class rcmail_output extends rcube_output
         $meta = INSTALL_PATH . "skins/{$skin}/meta.json";
         if (is_readable($meta) && ($json = json_decode(file_get_contents($meta), true))) {
             $data = $json;
-            $data['author_link'] = !empty($json['url']) ? html::a(['href' => $json['url'], 'target' => '_blank'], rcube::Q($json['author'])) : rcube::Q($json['author']);
-            $data['license_link'] = !empty($json['license-url']) ? html::a(['href' => $json['license-url'], 'target' => '_blank', 'tabindex' => '-1'], rcube::Q($json['license'])) : rcube::Q($json['license']);
+            $data['author_link'] = !empty($json['url']) ? html::a(['href' => $json['url'], 'target' => '_blank', 'rel' => 'noopener'], rcube::Q($json['author'])) : rcube::Q($json['author']);
+            $data['license_link'] = !empty($json['license-url']) ? html::a(['href' => $json['license-url'], 'target' => '_blank', 'rel' => 'noopener', 'tabindex' => '-1'], rcube::Q($json['license'])) : rcube::Q($json['license']);
         }
 
         $composer = INSTALL_PATH . "/skins/{$skin}/composer.json";

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -4425,7 +4425,13 @@ function rcube_webmail() {
 
             li.append($('<label>').addClass('keyid').text(ref.get_label('keyid')));
             li.append($('<a>').text(keyrec.keyid.substr(-8).toUpperCase())
-                .attr({ href: keyrec.info, target: '_blank', tabindex: '-1' }));
+                .attr({
+                    href: keyrec.info,
+                    target: '_blank',
+                    rel: 'noopener',
+                    tabindex: '-1',
+                })
+            );
 
             li.append($('<label>').addClass('keylen').text(ref.get_label('keylength')));
             li.append($('<span>').text(keyrec.keylen));

--- a/program/js/editor.js
+++ b/program/js/editor.js
@@ -195,7 +195,7 @@ function rcube_text_editor(config, id) {
         ed.on('click', function (e) {
             var link = $(e.target).closest('a');
             if (link.length && e.shiftKey) {
-                window.open(link.get(0).href, '_blank');
+                window.open(link.get(0).href, '_blank', 'noopener=true');
                 return false;
             }
         });

--- a/program/lib/Roundcube/rcube_text2html.php
+++ b/program/lib/Roundcube/rcube_text2html.php
@@ -139,7 +139,7 @@ class rcube_text2html
     protected function converter($text)
     {
         // make links and email-addresses clickable
-        $attribs = ['link_attribs' => ['rel' => 'noreferrer', 'target' => '_blank']];
+        $attribs = ['link_attribs' => ['rel' => 'noreferrer noopener', 'target' => '_blank']];
         $replacer = new $this->config['replacer']($attribs);
 
         if ($this->config['flowed']) {

--- a/skins/elastic/templates/includes/footer.html
+++ b/skins/elastic/templates/includes/footer.html
@@ -1,7 +1,7 @@
 <roundcube:if condition="!env:framed || env:extwin" />
 </div>
 <roundcube:if condition="config:support_url" />
-<a href="<roundcube:var name='config:support_url' />" target="_blank" id="supportlink" class="hidden"><roundcube:label name="support" /></a>
+<a href="<roundcube:var name='config:support_url' />" target="_blank" rel="noopener" id="supportlink" class="hidden"><roundcube:label name="support" /></a>
 <roundcube:endif />
 <roundcube:endif />
 

--- a/skins/elastic/templates/login.html
+++ b/skins/elastic/templates/login.html
@@ -10,7 +10,7 @@
 			<roundcube:object name="productname" condition="config:display_product_info &gt; 0" />
 			<roundcube:object name="version" condition="config:display_product_info == 2" />
 			<roundcube:if condition="config:support_url" />
-				&nbsp;&bull;&nbsp; <a href="<roundcube:var name='config:support_url' />" target="_blank" class="support-link"><roundcube:label name="support" /></a>
+				&nbsp;&bull;&nbsp; <a href="<roundcube:var name='config:support_url' />" target="_blank" rel="noopener" class="support-link"><roundcube:label name="support" /></a>
 			<roundcube:endif />
 			<roundcube:container name="loginfooter" id="login-footer" />
 		</div>

--- a/tests/Actions/Contacts/ShowTest.php
+++ b/tests/Actions/Contacts/ShowTest.php
@@ -87,7 +87,7 @@ class ShowTest extends ActionTestCase
     public function test_render_url_value()
     {
         $input = 'http://test/<123';
-        $expected = '<a href="http://test/&lt;123" target="_blank" class="url">http://test/&lt;123</a>';
+        $expected = '<a href="http://test/&lt;123" target="_blank" rel="noopener" class="url">http://test/&lt;123</a>';
         $this->assertSame($expected, \rcmail_action_contacts_show::render_url_value($input));
     }
 

--- a/tests/Actions/Mail/IndexTest.php
+++ b/tests/Actions/Mail/IndexTest.php
@@ -535,12 +535,12 @@ class IndexTest extends ActionTestCase
             'Mailto links with onclick'
         );
         $this->assertMatchesRegularExpression(
-            '#<a rel="noreferrer" target="_blank" href="http://www.apple.com/legal/privacy">http://www.apple.com/legal/privacy</a>#',
+            '#<a rel="noreferrer noopener" target="_blank" href="http://www.apple.com/legal/privacy">http://www.apple.com/legal/privacy</a>#',
             $html,
             'Links with target=_blank'
         );
         $this->assertMatchesRegularExpression(
-            '#\[<a rel="noreferrer" target="_blank" href="http://example.com/\?tx\[a\]=5">http://example.com/\?tx\[a\]=5</a>\]#',
+            '#\[<a rel="noreferrer noopener" target="_blank" href="http://example.com/\?tx\[a\]=5">http://example.com/\?tx\[a\]=5</a>\]#',
             $html,
             'Links with square brackets'
         );

--- a/tests/Framework/Text2HtmlTest.php
+++ b/tests/Framework/Text2HtmlTest.php
@@ -153,7 +153,7 @@ class Text2HtmlTest extends TestCase
         $html = $t2h->get_html();
 
         $expected = "<div class=\"pre\"><br>\n[&lt;script&gt;evil&lt;/script&gt;] "
-            . "<a rel=\"noreferrer\" target=\"_blank\" href=\"https://google.com\">https://google.com</a><br>\n"
+            . "<a rel=\"noreferrer noopener\" target=\"_blank\" href=\"https://google.com\">https://google.com</a><br>\n"
             . '</div>';
 
         $this->assertSame($expected, $html);
@@ -175,7 +175,7 @@ class Text2HtmlTest extends TestCase
 
         $t2h = new \rcube_text2html($input);
         $html = $t2h->get_html();
-        $html = preg_replace('/ (rel|target)="(noreferrer|_blank)"/', '', $html);
+        $html = preg_replace('/ (rel|target)="(noreferrer noopener|_blank)"/', '', $html);
 
         $this->assertSame($expected, $html);
     }


### PR DESCRIPTION
Browsers younger than ~5 years don't need this, but older browsers might cause problems.