### PR TITLE
managesieve: show warning when actions in wrong order

### DIFF
--- a/plugins/managesieve/lib/Roundcube/rcube_sieve_engine.php
+++ b/plugins/managesieve/lib/Roundcube/rcube_sieve_engine.php
@@ -1649,7 +1649,8 @@ class rcube_sieve_engine
 
         $this->rc->output->add_label(
             'managesieve.ruledeleteconfirm',
-            'managesieve.actiondeleteconfirm'
+            'managesieve.actiondeleteconfirm',
+            'managesieve.saving.actionordererror'
         );
         $this->rc->output->set_env('rule_disabled', !empty($scr['disabled']));
         $this->rc->output->add_gui_object('sieveform', 'filterform');
@@ -2214,7 +2215,7 @@ class rcube_sieve_engine
             'onchange' => "action_type_select({$id})",
         ]);
         if (in_array('fileinto', $this->exts)) {
-            $select_action->add($this->plugin->gettext('messagemoveto'), 'fileinto');
+            $select_action->add($this->plugin->gettext('messagemoveto'), 'fileinto', ['data-priority' => -1]);
         }
         if (in_array('fileinto', $this->exts) && in_array('copy', $this->exts)) {
             $select_action->add($this->plugin->gettext('messagecopyto'), 'fileinto_copy');
@@ -2250,7 +2251,7 @@ class rcube_sieve_engine
             $select_action->add($this->plugin->gettext('notify'), 'notify');
         }
         $select_action->add($this->plugin->gettext('messagekeep'), 'keep');
-        $select_action->add($this->plugin->gettext('rulestop'), 'stop');
+        $select_action->add($this->plugin->gettext('rulestop'), 'stop', ['data-priority' => -2]);
 
         $select_type = $action['type'];
         if (in_array($action['type'], ['fileinto', 'redirect']) && !empty($action['copy'])) {

--- a/plugins/managesieve/lib/Roundcube/rcube_sieve_engine.php
+++ b/plugins/managesieve/lib/Roundcube/rcube_sieve_engine.php
@@ -2215,7 +2215,7 @@ class rcube_sieve_engine
             'onchange' => "action_type_select({$id})",
         ]);
         if (in_array('fileinto', $this->exts)) {
-            $select_action->add($this->plugin->gettext('messagemoveto'), 'fileinto', ['data-priority' => -1]);
+            $select_action->add($this->plugin->gettext('messagemoveto'), 'fileinto');
         }
         if (in_array('fileinto', $this->exts) && in_array('copy', $this->exts)) {
             $select_action->add($this->plugin->gettext('messagecopyto'), 'fileinto_copy');
@@ -2251,7 +2251,7 @@ class rcube_sieve_engine
             $select_action->add($this->plugin->gettext('notify'), 'notify');
         }
         $select_action->add($this->plugin->gettext('messagekeep'), 'keep');
-        $select_action->add($this->plugin->gettext('rulestop'), 'stop', ['data-priority' => -2]);
+        $select_action->add($this->plugin->gettext('rulestop'), 'stop');
 
         $select_type = $action['type'];
         if (in_array($action['type'], ['fileinto', 'redirect']) && !empty($action['copy'])) {

--- a/plugins/managesieve/localization/en_US.inc
+++ b/plugins/managesieve/localization/en_US.inc
@@ -283,3 +283,4 @@ $messages['duplicate.conflict.err'] = 'Both header and unique identifier are not
 $messages['disabledaction'] = 'Action not permitted.';
 $messages['lastindexempty'] = 'Index is required when counting from end';
 $messages['noflagset'] = 'At least one flag must be selected.';
+$messages['saving.actionordererror'] = 'The \'$previous\' action must be after the \'$current\' action.';

--- a/plugins/managesieve/managesieve.js
+++ b/plugins/managesieve/managesieve.js
@@ -536,7 +536,7 @@ rcube_webmail.prototype.managesieve_save = function () {
         var action_priority_last = 0;
         $('#actions select[id^=action_type].error').removeClass('error is-invalid');
         $('#actions select[id^=action_type] option:selected').each(function (idx, elem) {
-            var priority = $(elem).data('priority') ? parseInt($(elem).data('priority'), 10) : 0;
+            var priority = rcmail.managesieve_action_priority($(elem).val());
 
             if (priority > action_priority_last) {
                 action_priority_errors.current = idx;
@@ -557,6 +557,17 @@ rcube_webmail.prototype.managesieve_save = function () {
         this.gui_objects.sieveform.submit();
     } else if (this.gui_objects.sievesetrawform) {
         this.gui_objects.sievesetrawform.submit();
+    }
+};
+
+rcube_webmail.prototype.managesieve_action_priority = function (val) {
+    switch (val) {
+        case 'fileinto':
+            return -1;
+        case 'stop':
+            return -2;
+        default:
+            return 0;
     }
 };
 

--- a/plugins/managesieve/managesieve.js
+++ b/plugins/managesieve/managesieve.js
@@ -530,6 +530,30 @@ rcube_webmail.prototype.managesieve_save = function () {
                 this.gui_objects.sieveform.elements._fid.value = parent.rcmail.filters_list.rows[id].uid;
             }
         }
+
+        // validate action order e.g. setflag not after fileinto (#6590)
+        var action_priority_errors = { previous: null, current: null };
+        var action_priority_last = 0;
+        $('#actions select[id^=action_type].error').removeClass('error is-invalid');
+        $('#actions select[id^=action_type] option:selected').each(function (idx, elem) {
+            var priority = $(elem).data('priority') ? parseInt($(elem).data('priority'), 10) : 0;
+
+            if (priority > action_priority_last) {
+                action_priority_errors.current = idx;
+            } else if (!action_priority_errors.current) {
+                action_priority_errors.previous = idx;
+                action_priority_last = priority;
+            }
+        });
+
+        if (action_priority_errors.current) {
+            $('#actions select[id^=action_type]').eq(action_priority_errors.previous).addClass('error is-invalid');
+            $('#actions select[id^=action_type]').eq(action_priority_errors.current).addClass('error is-invalid');
+            var action_priority_message = { previous: $('#actions select[id^=action_type] option:selected').eq(action_priority_errors.previous).text(), current: $('#actions select[id^=action_type] option:selected').eq(action_priority_errors.current).text() };
+            this.display_message(this.get_label('managesieve.saving.actionordererror', null, action_priority_message), 'error');
+            return;
+        }
+
         this.gui_objects.sieveform.submit();
     } else if (this.gui_objects.sievesetrawform) {
         this.gui_objects.sievesetrawform.submit();

--- a/skins/elastic/styles/widgets/forms.less
+++ b/skins/elastic/styles/widgets/forms.less
@@ -1263,6 +1263,12 @@ body > li.recipient.ui-sortable-helper {
 .form-control {
     color: @color-font;
 
+    // override bootstap default behaviour (specifically prevent .is-invalid issues)
+    &.custom-select {
+        padding-right: 1.75rem;
+        background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='4' height='5' viewBox='0 0 4 5'%3e%3cpath fill='%23343a40' d='M2 0L0 2h4zm0 5L0 3h4z'/%3e%3c/svg%3e") no-repeat right .75rem center/8px 10px;
+    }
+
     &:focus {
         color: @color-font;
         border-color: @color-input-border-focus;


### PR DESCRIPTION
possible solution for #6590 by creating a validation rule for actions based on priority: `* > fileinto > stop` and show a warning to the user on save, highlighting the problem rules.

<img width="1487" height="1008" alt="Screenshot 2025-10-10 152535" src="https://github.com/user-attachments/assets/a94ba0ea-c877-498f-909f-be6b5601c423" />

The change to `skins/elastic/styles/widgets/forms.less` might look a little out of place. Without this change `.custom-select.is-invalid` looks like this:

<img width="659" height="227" alt="Screenshot 2025-10-10 152909" src="https://github.com/user-attachments/assets/86d857b0-d3ff-4b88-99a2-7d50044ee5ce" />
<img width="668" height="227" alt="Screenshot 2025-10-10 152705" src="https://github.com/user-attachments/assets/039bc680-76d1-4270-9d60-5bf73e670d93" />

Elastic currently applies default bootstrap styling to `.custom-select.is-invalid` but this adds padding which breaks the alignment and also adds an extra icon in light mode but not dark (because dark mode already overrides the background image). Adding this CSS is a simple solution. Now `.is-invalid` only adds a red border, same as `input` fields in Elastic.