### PR TITLE
allow "target" in html attributes when saving signature

### DIFF
--- a/program/actions/settings/index.php
+++ b/program/actions/settings/index.php
@@ -1806,7 +1806,7 @@ class rcmail_action_settings_index extends rcmail_action
             'charset' => RCUBE_CHARSET,
             'html_elements' => ['body', 'link'],
             'ignore_elements' => ['body'],
-            'html_attribs' => ['rel', 'type'],
+            'html_attribs' => ['rel', 'type', 'target'],
             'add_comments' => false,
         ];
 

--- a/tests/Actions/Settings/IndexTest.php
+++ b/tests/Actions/Settings/IndexTest.php
@@ -112,8 +112,8 @@ class IndexTest extends ActionTestCase
 
         $this->assertSame('<p>test</p>', $result);
 
-        $resultLink = \rcmail_action_settings_index::wash_html('<a href="#" target="_blank">test</a>');
+        $resultLink = \rcmail_action_settings_index::wash_html('<a href="https://roundcube.net" target="_blank">test</a>');
 
-        $this->assertSame('<a href="#" target="_blank">test</a>', $resultLink);
+        $this->assertSame('<a href="https://roundcube.net" target="_blank">test</a>', $resultLink);
     }
 }

--- a/tests/Actions/Settings/IndexTest.php
+++ b/tests/Actions/Settings/IndexTest.php
@@ -111,5 +111,9 @@ class IndexTest extends ActionTestCase
         $result = \rcmail_action_settings_index::wash_html('<p>test</p>');
 
         $this->assertSame('<p>test</p>', $result);
+
+        $resultLink = \rcmail_action_settings_index::wash_html('<a href="#" target="_blank">test</a>');
+
+        $this->assertSame('<a href="#" target="_blank">test</a>', $resultLink);
     }
 }


### PR DESCRIPTION
Allow the `target` attribute in HTML when saving the signature.
Sidenote: this also affects saving responses.

Fixes #10005