### PR TITLE
skin(elastic): show pointer cursor on clickable items in listings

### DIFF
--- a/skins/elastic/styles/styles.less
+++ b/skins/elastic/styles/styles.less
@@ -474,4 +474,13 @@ body.task-error-login #layout {
     @import "dark";
 }
 
+/* UX: show hand cursor on clickable items in listings */
+.records-table tbody tr[role="link"],
+.listing li[role="link"],
+.listing a,
+#layout-list .listing a,
+#layout-sidebar .listing a {
+  cursor: pointer;
+}
+
 @import (optional) "_styles";


### PR DESCRIPTION
### Summary
Makes clickable elements (messages, folders, address book entries) use the 
pointer cursor for better UX consistency.

### Changes
- Added a small CSS rule in `skins/elastic/styles/styles.less` to apply `cursor: pointer`
  on clickable list items and rows.

### Notes
- This is a UI-only change; no JS or PHP logic affected.
- Maintainers can recompile the Elastic LESS files as needed.

Fixes #9999 