### PR TITLE
feat: add getter for cached oauth options

### DIFF
--- a/program/include/rcmail_oauth.php
+++ b/program/include/rcmail_oauth.php
@@ -363,6 +363,16 @@ class rcmail_oauth
     }
 
     /**
+     * Getter for OAuth options
+     *
+     * @return array OAuth configuration options
+     */
+    public function get_options()
+    {
+        return $this->options;
+    }
+
+    /**
      * Callback for `loginform_content` hook
      *
      * Append Oauth button on login page if defined (this is a hook)


### PR DESCRIPTION
This adds a getter for the options inside `rcmail_oauth`.

I'm implementing a plugin which needs to do a token exchange and for that I need access to the `token_uri` which is already retrieved via `discover()`.
It would be nice to reuse whatever mechanism roundcube is using to stay always consistent with that. The correct approach seems to me to give acesss to the `token_uri` in options.

Personally I don't mind if we add a getter for just that one value or options - but I assume we would need to add whole lot more getters in the long run.
