### PR TITLE
feat: preserve requested url on oidc login

### DIFF
--- a/program/include/rcmail.php
+++ b/program/include/rcmail.php
@@ -1093,8 +1093,17 @@ class rcmail extends rcube
         foreach (array_merge($pre, $p) as $key => $val) {
             if ($val !== '' && $val !== null) {
                 $par = $key[0] == '_' ? $key : ('_' . $key);
-                $url .= $delm . urlencode($par) . '=' . urlencode($val);
-                $delm = '&';
+
+                // Handle array values
+                if (is_array($val)) {
+                    foreach ($val as $array_val) {
+                        $url .= $delm . urlencode($par) . '[]=' . urlencode($array_val);
+                        $delm = '&';
+                    }
+                } else {
+                    $url .= $delm . urlencode($par) . '=' . urlencode($val);
+                    $delm = '&';
+                }
             }
         }
 

--- a/program/include/rcmail_oauth.php
+++ b/program/include/rcmail_oauth.php
@@ -1359,7 +1359,7 @@ class rcmail_oauth
             $this->options['login_redirect']
             && !$this->rcmail->output->ajax_call
             && !$this->no_redirect
-            && empty($options['error'])
+            && (empty($options['error']) || $options['error'] === 'sessionerror')
             && $options['http_code'] === 200
         ) {
             $this->login_redirect();

--- a/tests/Rcmail/OauthTest.php
+++ b/tests/Rcmail/OauthTest.php
@@ -495,8 +495,8 @@ class OauthTest extends ActionTestCase
             'authorization' => 'Bearer token',
         ]);
 
-        // Clear any existing $_POST['_url']
-        unset($_POST['_url']);
+        // Initialize $_POST with known shape (value will be overwritten by authenticate)
+        $_POST = ['_url' => null];
 
         $result = $oauth->authenticate([]);
 
@@ -519,8 +519,8 @@ class OauthTest extends ActionTestCase
             'authorization' => 'Bearer token',
         ]);
 
-        // Clear any existing $_POST['_url']
-        unset($_POST['_url']);
+        // Initialize $_POST with known shape (value will be overwritten by authenticate)
+        $_POST = ['_url' => null];
 
         $result = $oauth->authenticate([]);
 
@@ -582,6 +582,6 @@ class OauthTest extends ActionTestCase
 
         // Step 2: unauthenticated hook should NOT store login URLs
         $oauth->unauthenticated([]);
-        $this->assertFalse(isset($_SESSION['oauth_redirect_uri']));
+        $this->assertArrayNotHasKey('oauth_redirect_uri', $_SESSION);
     }
 }

--- a/tests/Rcmail/RcmailTest.php
+++ b/tests/Rcmail/RcmailTest.php
@@ -147,6 +147,13 @@ class RcmailTest extends ActionTestCase
             $rcmail->url(['_action' => 'test', '_b' => 'BB', '_c' => null]),
             'Prefixed parameters (skip empty)'
         );
+
+        $this->assertSame(
+            '/sub/?_task=cli&_action=test&_files[]=file1.txt&_files[]=file2.txt',
+            $rcmail->url(['_action' => 'test', '_files' => ['file1.txt', 'file2.txt']]),
+            'Array parameters'
+        );
+
         $this->assertSame('/sub/?_task=cli', $rcmail->url([]), 'Empty input');
 
         $this->assertSame(


### PR DESCRIPTION
Currently, users are always redirected to the inbox after OAuth login, regardless of what page they originally requested. This breaks external application integrations (like external applications opening compose windows) and bookmarks.

This PR preserves the originally requested URL through the OAuth flow by storing it in the session before redirect, preserving it through the login session kill via `login_phase`, and restoring the parameters in the `login_after` hook.

Additionally, this fixes the `url()` method in `rcmail.php` to handle array parameters correctly, which was causing fatal errors when plugins or external apps passed array values like file attachments.

This should be fully backwards compatible with no configuration changes required.
