### PR TITLE
Support $HasAttachment/$HasNoAttachment keywords for "With attachment" search filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This file includes only changes we consider noteworthy for users, admins and plu
 - Fix syntax error in DDL scripts for Postgres (#10052)
 - Fix Cross-Site-Scripting vulnerability via SVG's animate tag
 - Fix Information Disclosure vulnerability in the HTML style sanitizer
+- Support $HasAttachment/$HasNoAttachment keywords for "With attachment" search filter (#10053)
 
 ## 1.7-rc
 

--- a/program/actions/mail/index.php
+++ b/program/actions/mail/index.php
@@ -1548,10 +1548,11 @@ class rcmail_action_mail_index extends rcmail_action
         $ctypes = ['application/', 'multipart/mixed', 'multipart/signed', 'multipart/report'];
 
         // Build search string of "with attachment" filter
-        $attachment = trim(str_repeat(' OR', count($ctypes) - 1));
+        $attachment = trim(str_repeat(' OR', count($ctypes))) . ' KEYWORD $HasAttachment';
         foreach ($ctypes as $type) {
             $attachment .= ' HEADER Content-Type ' . rcube_imap_generic::escape($type);
         }
+        $attachment .= ' NOT KEYWORD $HasNoAttachment';
 
         $select = new html_select($attrib);
         $select->add($rcmail->gettext('all'), 'ALL');

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -2533,7 +2533,7 @@ function rcube_webmail() {
                     html = '<span class="report"></span>';
                 } else if (flags.ctype == 'multipart/encrypted' || flags.ctype == 'application/pkcs7-mime' || flags.ctype == 'application/x-pkcs7-mime') {
                     html = '<span class="encrypted"></span>';
-                } else if (flags.hasattachment || (!flags.hasnoattachment && /application\/|multipart\/(m|signed)/.test(flags.ctype))) {
+                } else if (flags.hasattachment || (!flags.hasnoattachment && /application\/|multipart\/(mixed|signed|report)/.test(flags.ctype))) {
                     html = '<span class="attachment" title="' + label + '"></span>';
                 } else {
                     html = '&nbsp;';


### PR DESCRIPTION
Also make content-types consistent between `app.js:add_message_row()` & `rcmail_action_mail_index()`

Fixes #10053