### PR TITLE
Fixed implicit int main in plugin helpers

### DIFF
--- a/plugins/password/helpers/chgdbmailusers.c
+++ b/plugins/password/helpers/chgdbmailusers.c
@@ -12,7 +12,7 @@
   chmod 4550 chgdbmailusers
 */
 
-main(int argc, char *argv[])
+int main(int argc, char *argv[])
 {
   int rc, cc;
 

--- a/plugins/password/helpers/chgsaslpasswd.c
+++ b/plugins/password/helpers/chgsaslpasswd.c
@@ -13,7 +13,7 @@
   chmod 4550 chgsaslpasswd
 */
 
-main(int argc, char *argv[])
+int main(int argc, char *argv[])
 {
   int rc,cc;
 


### PR DESCRIPTION
GCC rejects implicit int main(), so the helpers don't always compile.