### PR TITLE
 Fix syntax error in DDL scripts for Postgres (#10052)

### DIFF
--- a/SQL/postgres/2025092300.sql
+++ b/SQL/postgres/2025092300.sql
@@ -1,3 +1,3 @@
 ALTER TABLE "session" RENAME COLUMN changed TO expires_at;
-ALTER TABLE "session" RENAME INDEX session_changed_idx TO session_expires_at_idx;
+ALTER INDEX "session_changed_idx" RENAME TO "session_expires_at_idx";
 UPDATE "session" SET expires_at = expires_at + INTERVAL '10 minutes';


### PR DESCRIPTION
The previous commit https://github.com/roundcube/roundcubemail/commit/366ad7a1745eb7913536fb937924d7725257d633 didn't actually fix the incorrect index rename syntax.