### PR TITLE
Fix garbled non-MIME-encoded UTF-8 headers

### DIFF
--- a/program/lib/Roundcube/rcube_mime.php
+++ b/program/lib/Roundcube/rcube_mime.php
@@ -162,6 +162,11 @@ class rcube_mime
     {
         $default_charset = $fallback ?: self::get_charset();
 
+        // RFC 6532: detect raw UTF-8 in headers to avoid wrong charset conversion
+        if ($fallback !== false && mb_check_encoding($input, 'UTF-8') && preg_match('/[\x80-\xFF]/', $input)) {
+            $default_charset = 'UTF-8';
+        }
+
         // rfc: all line breaks or other characters not found
         // in the Base64 Alphabet must be ignored by decoding software
         // delete all blanks between MIME-lines, differently we can

--- a/tests/Framework/MimeTest.php
+++ b/tests/Framework/MimeTest.php
@@ -217,6 +217,23 @@ class MimeTest extends TestCase
     }
 
     /**
+     * Test decoding of raw UTF-8 headers (RFC 6532)
+     * Uses rcube_mime::decode_mime_string()
+     */
+    public function test_header_decode_raw_utf8()
+    {
+        // Raw UTF-8 Korean with wrong fallback charset - should be preserved
+        $korean = "\xEC\x95\x88\xEB\x85\x95\xED\x95\x98\xEC\x84\xB8\xEC\x9A\x94"; // 안녕하세요
+        $res = \rcube_mime::decode_mime_string($korean, 'ISO-8859-1');
+        $this->assertSame($korean, $res, 'Raw UTF-8 header with Latin-1 fallback');
+
+        // Latin-1 high bytes (not valid UTF-8) - should still be converted
+        $latin1 = "caf\xE9"; // café in ISO-8859-1
+        $res = \rcube_mime::decode_mime_string($latin1, 'ISO-8859-1');
+        $this->assertSame('café', $res, 'Latin-1 header should be converted');
+    }
+
+    /**
      * Test headers parsing
      */
     public function test_parse_headers()


### PR DESCRIPTION
`decode_mime_string()` blindly applies the body charset to non-MIME-encoded headers. If the header is raw UTF-8 but the body charset differs, the header gets corrupted.

Check for valid UTF-8 before falling back to the body charset, same approach as Thunderbird's `convert8BitHeader()`: https://searchfox.org/comm-central/source/mailnews/mime/jsmime/jsmime.mjs#675

[RFC 6532](https://datatracker.ietf.org/doc/html/rfc6532) (2012) legitimizes raw UTF-8 in email headers via SMTPUTF8 extension.

## Screenshots

### Before
<img width="787" height="101" alt="image" src="https://github.com/user-attachments/assets/67649083-e003-4816-a21d-cd4bcae6c26b" />

### After
<img width="780" height="106" alt="image" src="https://github.com/user-attachments/assets/70a1ebf4-b820-4cd5-bb7a-1bd40f7a0aa4" />