### PR TITLE
managesieve: add support for date :zone param in UI

### DIFF
--- a/plugins/managesieve/localization/en_US.inc
+++ b/plugins/managesieve/localization/en_US.inc
@@ -152,6 +152,7 @@ $labels['string'] = 'String';
 $labels['currdate'] = 'Current date';
 $labels['datetest'] = 'Date';
 $labels['dateheader'] = 'header:';
+$labels['datezone'] = 'time-zone:';
 $labels['year'] = 'year';
 $labels['month'] = 'month';
 $labels['day'] = 'day';

--- a/plugins/managesieve/managesieve.js
+++ b/plugins/managesieve/managesieve.js
@@ -690,9 +690,10 @@ function rule_header_select(id) {
         mime_part = document.getElementById('rule_mime_part' + id),
         datepart = document.getElementById('rule_date_part' + id),
         dateheader = document.getElementById('rule_date_header_div' + id),
+        time_zone = document.getElementById('rule_time_zone' + id),
         rule = $('#rule_op' + id),
         h = obj.value,
-        set = [op, header, custstr, mod, trans, comp, size, mime, mime_part];
+        set = [op, header, custstr, mod, trans, comp, size, mime, mime_part, time_zone];
 
     if (h == 'size') {
         if (msg) {
@@ -736,6 +737,7 @@ function rule_header_select(id) {
         comp.style.display = '';
         mod.style.display = is_header ? '' : 'none';
         trans.style.display = h == 'body' ? '' : 'none';
+        time_zone.style.display = h == 'date' || h == 'currentdate' ? '' : 'none';
         if (spamtest) {
             spamtest.style.display = 'none';
         }


### PR DESCRIPTION
I understand #10076 is closed but I thought I'd have a go at adding support for the `:zone` param into the regular UI. I did this by adding it as an advanced option for date/currentdate rules.

Having the param unset remains the default behaviour so no existing rules will be impacted.

With this change if a rule is created using the Vacation UI and then saved in the regular UI the result remains the same.

I added the `datezone` label only because of the `:` needed at the end of the label to match the other advanced options in en-US.

The select box uses the numeric representation of the time zone e.g. `+0000` as that is what sieve uses and there is no way to know which of the 26 possible named zones is intended.