### PR TITLE
maganesieve: disable rule adv opts button when none available

### DIFF
--- a/plugins/managesieve/managesieve.js
+++ b/plugins/managesieve/managesieve.js
@@ -770,6 +770,14 @@ function rule_header_select(id) {
     }
 
     obj.style.width = h == '...' ? '40px' : '';
+
+    var adv_btn = $('#ruleadv' + id);
+    if ($('#rule_advanced' + id).children().filter(function () { return $(this).css('display') != 'none'; }).length == 0) {
+        rule_adv_switch(id, adv_btn[0], true);
+        adv_btn.addClass('disabled');
+    } else {
+        adv_btn.removeClass('disabled');
+    }
 }
 
 function rule_op_select(obj, id, header) {
@@ -826,8 +834,12 @@ function rule_join_radio(value) {
     $('#rules').css('display', value == 'any' ? 'none' : 'block');
 }
 
-function rule_adv_switch(id, elem) {
-    var elem = $(elem), enabled = elem.hasClass('hide'), adv = $('#rule_advanced' + id);
+function rule_adv_switch(id, elem, hide = false) {
+    var elem = $(elem), enabled = hide || elem.hasClass('hide'), adv = $('#rule_advanced' + id);
+
+    if (elem.hasClass('disabled')) {
+        return;
+    }
 
     if (enabled) {
         adv.get(0).style.display = 'none';


### PR DESCRIPTION
Trivial.

Currently the advanced options button on each rule row in the UI is always enabled, even when there are no advanced options available for the selected rule type.

There is a small visual glitch if you click the button when the div is empty so this simply disables the button when there are no options.

<img width="1472" height="394" alt="Screenshot 2026-01-28 185245" src="https://github.com/user-attachments/assets/a81554d3-865a-452e-82c3-5f6755b8fdc8" />

The deprecated Classic/Larry skins do not style the `disabled` class but the button is disabled all the same.

<img width="988" height="144" alt="Screenshot 2026-01-28 185336" src="https://github.com/user-attachments/assets/9eabb8f9-cd9a-4056-99aa-4c3097a558af" />
