### PR TITLE
Ensure correct permissions and absence of ACLs in files for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file includes only changes we consider noteworthy for users, admins and plu
 
 ## Unreleased
 
+- Ensure correct file permissions when building a release.
 - Installer: Fix broken link to download the created configuration file (#10092)
 
 ## 1.7-rc3

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,12 @@ roundcubemail-git: buildtools
 	(cd roundcubemail-git; rm -f .eslintrc.js .php-cs-fixer.dist.php .php-cs-fixer-fully_qualified_strict_types.php phpstan.neon.dist)
 	(cd roundcubemail-git; $(SEDI) 's/1.7-git/$(VERSION)/' program/include/iniset.php program/lib/Roundcube/bootstrap.php)
 	(cd roundcubemail-git; $(SEDI) 's/# Unreleased/# Release $(VERSION)'/ CHANGELOG.md)
+	# Some versions of sed on file systems mounted via virtiofs leave the edited files with wrong permissions
+	# (0600), so we make sure all files are readable for everyone, and also executable for everyone if they
+	# are for the owner.
+	chmod -R a+rX roundcubemail-git
+	# Also remove any ACLs that could have sneaked in (also observed as an artefact of sed+virtiofs).
+	setfacl --remove-all --recursive roundcubemail-git
 
 buildtools: /tmp/composer.phar npm-install
 


### PR DESCRIPTION
Some combinations of sed executed on virtiofs-mounted file systems produce files with wrong permissions (0600) and ACLs set, which we want to avoid. This change makes sure of that.