### PR TITLE
Add nt-binary hashing method in password plugin

### DIFF
--- a/plugins/password/config.inc.php.dist
+++ b/plugins/password/config.inc.php.dist
@@ -47,9 +47,10 @@ $config['password_force_new_user'] = false;
 
 // Password hashing/crypting algorithm.
 // Possible options: des-crypt, ext-des-crypt, md5-crypt, blowfish-crypt,
-// sha256-crypt, sha512-crypt, md5, sha, smd5, ssha, ssha256, ssha512, samba, ad, dovecot, clear.
+// sha256-crypt, sha512-crypt, md5, sha, smd5, ssha, ssha256, ssha512, samba|nt-hex, nt-binary, ad, dovecot, clear.
 // Also supported are password_hash() algoriths: hash-bcrypt, hash-argon2i, hash-argon2id.
 // Default: 'clear' (no hashing)
+// Hash type nt-binary is NOT human-readable and its corresponding DB column must be of type 'BYTEA' for PostgreSQL or BINARY(16) for MySQL.
 // For details see password::hash_password() method.
 $config['password_algorithm'] = 'clear';
 

--- a/plugins/password/password.php
+++ b/plugins/password/password.php
@@ -658,8 +658,21 @@ class password extends rcube_plugin
                 $prefix = '{SMD5}';
                 break;
             case 'samba':
+            case 'nt-hex':
                 if (function_exists('hash')) {
                     $crypted = hash('md4', rcube_charset::convert($password, RCUBE_CHARSET, 'UTF-16LE'));
+                    $crypted = strtoupper($crypted);
+                } else {
+                    rcube::raise_error([
+                        'code' => 600,
+                        'message' => 'Password plugin: Your PHP installation does not have hash() function',
+                    ], true, true);
+                }
+
+                break;
+            case 'nt-binary':
+                if (function_exists('hash')) {
+                    $crypted = hash('md4', rcube_charset::convert($password, RCUBE_CHARSET, 'UTF-16LE'), true);
                     $crypted = strtoupper($crypted);
                 } else {
                     rcube::raise_error([


### PR DESCRIPTION
Right now Roundcube’s `password` plugin has no raw 16-byte NT hash (binary), which seems to be the cleaner storage format for FreeRADIUS, Samba , sometimes LDAP and high-volume authentication systems (16 bit storage instead of 32, direct use, no formatting problems and smaller index).
I also added an alternative name for samba (nt-hex) for reason of conformity, and put a note in the config for the nt-binary DB column format.