### PR TITLE
Fix double charset conversion for non-UTF-8 message bodies

### DIFF
--- a/program/lib/Roundcube/rcube_message.php
+++ b/program/lib/Roundcube/rcube_message.php
@@ -349,7 +349,9 @@ class rcube_message
         }
 
         // ..convert charset encoding
-        $body = rcube_charset::convert($body, $part->charset);
+        if (!mb_check_encoding($body, 'UTF-8')) {
+            $body = rcube_charset::convert($body, $part->charset);
+        }
 
         return $body;
     }


### PR DESCRIPTION
## Problem
Messages with charset=windows-1251 (quoted-printable encoding) display as garbled text in Roundcube. Other clients (Thunderbird, K-9, mutt) display them correctly.

## Root Cause
`get_message_part()` already converts body charset to UTF-8, but `format_part_body()` converts it again using `$part->charset` which still contains the original charset (e.g. windows-1251). This double conversion produces garbled output.

## Fix
Check `mb_check_encoding()` before converting — if body is already valid UTF-8, skip conversion.

## Tested
Roundcube 1.6.13 + Stalwart mail server, windows-1251 quoted-printable messages now display correctly.

## Related
Similar UTF-8 detection approach used in #10078.