### PR TITLE
Fix URL matching for domain names with port numbers in string replacer

### DIFF
--- a/program/lib/Roundcube/rcube_string_replacer.php
+++ b/program/lib/Roundcube/rcube_string_replacer.php
@@ -57,7 +57,7 @@ class rcube_string_replacer
         $this->options = $options;
         $this->linkref_index = '/\[([^<>\]#]+)\](:?\s*' . substr($this->pattern, 1, -1) . ')/';
         $this->linkref_pattern = '/\[([^<>\]#]+)\]/';
-        $this->link_pattern = "/({$link_prefix})(({$ip_address}(:[0-9]{1,5})?|{$utf_domain})([\\/?#]\\S*[^\\s.:;,]+)*[\\/?#]?)/";
+        $this->link_pattern = "/({$link_prefix})(({$ip_address}|{$utf_domain})(:[0-9]{1,5})?([\\/?#]\\S*[^\\s.:;,]+)*[\\/?#]?)/";
         $this->mailto_pattern = '/('
             . '[-\w!\#$%&*+~\/^`|{}=]+(?:\.[-\w!\#$%&*+~\/^`|{}=]+)*' // local-part
             . '@' . $utf_domain                                       // domain-part

--- a/tests/Framework/StringReplacerTest.php
+++ b/tests/Framework/StringReplacerTest.php
@@ -72,6 +72,10 @@ class StringReplacerTest extends TestCase
             ['http://192.168.56.1/.', '<a href="http://192.168.56.1/">http://192.168.56.1/</a>.'],
             ['ftp://1.1.1.101/test.', '<a href="ftp://1.1.1.101/test">ftp://1.1.1.101/test</a>.'],
             ['http://[::1]:8000/test.', '<a href="http://[::1]:8000/test">http://[::1]:8000/test</a>.'],
+            // Port number in URL with domain name
+            ['http://example.com:8080/path', '<a href="http://example.com:8080/path">http://example.com:8080/path</a>'],
+            ['https://example.com:3000', '<a href="https://example.com:3000">https://example.com:3000</a>'],
+            ['https://example.com:8443/path?q=1 end', '<a href="https://example.com:8443/path?q=1">https://example.com:8443/path?q=1</a> end'],
             // Non-unicode characters should be supported
             ['http://link.com ' . chr(206) . 'a', '<a href="http://link.com">http://link.com</a> ' . chr(206) . 'a'],
             // #9538: unicode Fullwidth Left Parenthesis (U+FF08)


### PR DESCRIPTION
Since commit 2c3b46c ("Fix regression in handling of non-unicode characters in a plain text message"), URLs with domain names and port numbers (e.g. `http://example.com:8080/path`) are no longer converted into links in plain text messages.

The port number pattern `(:[0-9]{1,5})?` in `$link_pattern` was placed inside the `$ip_address` branch only:

    (({$ip_address}(:[0-9]{1,5})?|{$utf_domain})(...))

Since `:` is excluded from `$utf_domain`, domain-name URLs stop matching at the colon and the port number is lost.

This moves `(:[0-9]{1,5})?` outside both branches so it applies to both IP addresses and domain names:

    (({$ip_address}|{$utf_domain})(:[0-9]{1,5})?(...))

The existing test case `http://link.com:test` is unaffected because `:test` does not match `[0-9]{1,5}`.

Added test cases for domain-name URLs with port numbers.