### PR TITLE
Fix link pattern matching HTML tag characters in URL path

### DIFF
--- a/program/lib/Roundcube/rcube_string_replacer.php
+++ b/program/lib/Roundcube/rcube_string_replacer.php
@@ -57,7 +57,7 @@ class rcube_string_replacer
         $this->options = $options;
         $this->linkref_index = '/\[([^<>\]#]+)\](:?\s*' . substr($this->pattern, 1, -1) . ')/';
         $this->linkref_pattern = '/\[([^<>\]#]+)\]/';
-        $this->link_pattern = "/({$link_prefix})(({$ip_address}|{$utf_domain})(:[0-9]{1,5})?([\\/?#]\\S*[^\\s.:;,]+)*[\\/?#]?)/";
+        $this->link_pattern = "/({$link_prefix})(({$ip_address}|{$utf_domain})(:[0-9]{1,5})?([\\/?#][^\\s<>\"']*[^\\s.:;,<>\"'])*[\\/?#]?)/";
         $this->mailto_pattern = '/('
             . '[-\w!\#$%&*+~\/^`|{}=]+(?:\.[-\w!\#$%&*+~\/^`|{}=]+)*' // local-part
             . '@' . $utf_domain                                       // domain-part

--- a/tests/Framework/StringReplacerTest.php
+++ b/tests/Framework/StringReplacerTest.php
@@ -80,6 +80,10 @@ class StringReplacerTest extends TestCase
             ['http://link.com ' . chr(206) . 'a', '<a href="http://link.com">http://link.com</a> ' . chr(206) . 'a'],
             // #9538: unicode Fullwidth Left Parenthesis (U+FF08)
             // ['http://www.domain.tld/abc（哇哇）', '<a href="http://www.domain.tld/abc">http://www.domain.tld/abc</a>（哇哇）'],
+            // HTML tag characters should not be consumed as part of URL path
+            ['<a href="https://example.com/">click here</a>', '<a href="<a href="https://example.com/">https://example.com/</a>">click here</a>'],
+            ['<img src="https://example.com/img.png"/>', '<img src="<a href="https://example.com/img.png">https://example.com/img.png</a>"/>'],
+            ['<https://example.com/>', '<<a href="https://example.com/">https://example.com/</a>>'],
         ];
     }
 

--- a/tests/Framework/Text2HtmlTest.php
+++ b/tests/Framework/Text2HtmlTest.php
@@ -160,6 +160,20 @@ class Text2HtmlTest extends TestCase
     }
 
     /**
+     * Test that HTML tag characters in plain text don't break URL detection
+     */
+    public function test_text2html_html_in_text()
+    {
+        $input = '<a href="https://example.com/">click here</a>';
+        $t2h = new \rcube_text2html($input);
+
+        $html = $t2h->get_html();
+
+        $this->assertStringContainsString('href="https://example.com/"', $html);
+        $this->assertStringNotContainsString('href="https://example.com/&quot;', $html);
+    }
+
+    /**
      * Test bug #8021
      */
     public function test_text2html_8021()


### PR DESCRIPTION
The link_pattern introduced in 2c3b46c1f uses \S (non-whitespace) for the URL path segment, which also matches <, >, ", and ' characters. This causes URLs inside HTML-like markup in plain text (e.g. <a href="https://example.com/">click here</a>) to consume the tag characters as part of the URL.

Replace \S with [^\s<>"'] to exclude HTML tag delimiters and quote characters from URL path matching, and [^\s.:;,] with [^\s.:;,<>"'] for the path segment terminator.