### PR TITLE
Validate _filter parameter against known IMAP search keywords

### DIFF
--- a/program/actions/mail/search.php
+++ b/program/actions/mail/search.php
@@ -214,6 +214,18 @@ class rcmail_action_mail_search extends rcmail_action_mail_index
     {
         $headers = $headers ? explode(',', $headers) : ['subject'];
 
+        // Validate $filter against the known set of IMAP search keywords.
+        // Any value outside this list (including CRLF-injected payloads) is
+        // silently discarded, preventing IMAP command injection via _filter.
+        $allowed_filters = [
+            'ALL', 'UNSEEN', 'SEEN', 'FLAGGED', 'UNFLAGGED',
+            'DELETED', 'UNDELETED', 'ANSWERED', 'UNANSWERED', 'RECENT',
+        ];
+
+        if ($filter && !in_array(strtoupper($filter), $allowed_filters)) {
+            $filter = '';
+        }
+
         // Add list filter string
         $result = $filter && $filter != 'ALL' ? $filter : '';
 

--- a/tests/Actions/Mail/SearchTest.php
+++ b/tests/Actions/Mail/SearchTest.php
@@ -300,6 +300,34 @@ class SearchTest extends ActionTestCase
                 '"-from:test1"',
                 'HEADER SUBJECT -from:test1',
             ],
+            // Security: CRLF injection via _filter must be rejected (CVE candidate)
+            // An injected payload like "UNSEEN\r\nA099 STORE 1:* +FLAGS (\Deleted)"
+            // would append a second IMAP command to the socket stream if $filter is
+            // not validated. The allowlist in search_input() discards any value that
+            // is not a recognised IMAP search keyword, so the injected string below
+            // must produce an empty result.
+            [
+                ['', 'subject', "UNSEEN\r\nA099 STORE 1:* +FLAGS (\\Deleted)\r\nA100 EXPUNGE", null],
+                '',
+            ],
+            [
+                ['', 'subject', "UNSEEN\nSTORE 1:* +FLAGS (\\Deleted)", null],
+                '',
+            ],
+            // Unknown / arbitrary filter values must be discarded
+            [
+                ['', 'subject', 'ARBITRARY_VALUE', null],
+                '',
+            ],
+            // Valid filter keywords must still pass through
+            [
+                ['', 'subject', 'UNSEEN', null],
+                'UNSEEN',
+            ],
+            [
+                ['', 'subject', 'FLAGGED', null],
+                'FLAGGED',
+            ],
         ];
     }
 


### PR DESCRIPTION
 ## Validate _filter parameter against known IMAP search keywords

 ### Summary

 The `_filter` GET parameter in the mail search action (program/actions/mail/search.php) is read from user input and passed into the IMAP SEARCH command string without any validation of its value. The only sanitization applied is strip_tags() and trim(), neither of which enforces that the value is a legitimate IMAP search keyword.

### Problem

`$filter` is appended directly to the IMAP query in search_input():

$result = $filter && $filter != 'ALL' ? $filter : '';

There is no check that `$filter` is one of the expected values (UNSEEN, SEEN, FLAGGED, etc.). This means any arbitrary string that passes strip_tags() is concatenated verbatim into the IMAP protocol stream, which could cause the IMAP server to misinterpret the query or behave unexpectedly depending on its implementation.

### Fix

Validate `$filter` against an explicit allowlist of the IMAP search keywords that the Roundcube UI legitimately produces before it is used in the query:

```php
$allowed_filters = [
      'ALL', 'UNSEEN', 'SEEN', 'FLAGGED', 'UNFLAGGED',
      'DELETED', 'UNDELETED', 'ANSWERED', 'UNANSWERED', 'RECENT',
  ];

if ($filter && !in_array(strtoupper($filter), $allowed_filters)) {
      $filter = '';
 }
```
Any value outside this set is discarded. Valid UI-produced filter values continue to work unchanged.

### Tests

Test cases added to tests/Actions/Mail/SearchTest.php covering:
  - Invalid/unexpected filter values → discarded
  - Valid filter keywords (UNSEEN, FLAGGED) → pass through unchanged