### PR TITLE
Be more strict on the action mode check

### DIFF
--- a/program/actions/mail/compose.php
+++ b/program/actions/mail/compose.php
@@ -530,7 +530,7 @@ class rcmail_action_mail_compose extends rcmail_action_mail_index
                 . "googie.setDecoration(false);\n"
                 . "googie.decorateTextarea(rcmail.env.composebody);\n",
                 $rcmail->output->asset_url($rcmail->output->get_skin_path()),
-                $rcmail->url(['_task' => 'utils', '_action' => 'spell', '_remote' => 1]),
+                $rcmail->url(['_task' => 'utils', '_action' => 'spell']),
                 !empty($dictionary) ? 'true' : 'false',
                 rcube::JQ(rcube::Q($rcmail->gettext('checkspelling'))),
                 rcube::JQ(rcube::Q($rcmail->gettext('resumeediting'))),

--- a/program/include/iniset.php
+++ b/program/include/iniset.php
@@ -130,7 +130,7 @@ function rcmail_fatal_error()
 {
     if (\PHP_SAPI === 'cli') {
         echo "Fatal error: Please check the Roundcube error log and/or server error logs for more information.\n";
-    } elseif (!empty($_REQUEST['_remote'])) {
+    } elseif (rcube_utils::request_header('X-Roundcube-Request')) {
         // Ajax request from UI
         header('Content-Type: application/json; charset=UTF-8');
         echo json_encode(['code' => 500, 'message' => 'Internal Server Error']);

--- a/program/include/rcmail.php
+++ b/program/include/rcmail.php
@@ -141,7 +141,7 @@ class rcmail extends rcube
         // init output class
         if (\PHP_SAPI == 'cli') {
             $this->output = new rcmail_output_cli();
-        } elseif (!empty($_REQUEST['_remote'])) {
+        } elseif (rcube_utils::request_header('X-Roundcube-Request')) {
             $this->json_init();
         } elseif (!empty($_SERVER['REMOTE_ADDR'])) {
             $this->load_gui(!empty($_REQUEST['_framed']));

--- a/program/include/rcmail_action.php
+++ b/program/include/rcmail_action.php
@@ -68,11 +68,7 @@ abstract class rcmail_action
         $rcmail = rcmail::get_instance();
 
         if (static::$mode) {
-            if (!(static::$mode & self::MODE_HTTP) && empty($rcmail->output->ajax_call)) {
-                return false;
-            }
-
-            if (!(static::$mode & self::MODE_AJAX) && !empty($rcmail->output->ajax_call)) {
+            if (!(static::$mode & self::MODE_AJAX) && $rcmail->output->ajax_call) {
                 return false;
             }
         }

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -9576,7 +9576,6 @@ function rcube_webmail() {
             data = rcube_parse_query(data);
         }
 
-        data._remote = 1;
         data._unlock = lock ? lock : 0;
 
         // trigger plugin hook
@@ -10110,7 +10109,7 @@ function rcube_webmail() {
         // prepare multipart form data composition
         var uri,
             files = e.target.files || e.dataTransfer.files,
-            args = { _id: this.env.compose_id || this.env.cid || '', _remote: 1, _from: this.env.action };
+            args = { _id: this.env.compose_id || this.env.cid || '', _from: this.env.action };
 
         if (!files || !files.length) {
             // Roundcube attachment, pass its uri to the backend and attach
@@ -10153,7 +10152,7 @@ function rcube_webmail() {
             formdata = new FormData(),
             fieldname = props.name || '_file[]',
             limit = props.single ? 1 : files.length;
-        args = $.extend({ _remote: 1, _from: this.env.action }, post_args || {});
+        args = $.extend({ _from: this.env.action }, post_args || {});
 
         // add files to form data
         for (i = 0; numfiles < limit && (f = files[i]); i++) {

--- a/program/js/editor.js
+++ b/program/js/editor.js
@@ -114,7 +114,7 @@ function rcube_text_editor(config, id) {
         $.extend(conf, {
             plugins: 'autolink charmap code directionality link lists image media nonbreaking'
                 + ' paste table tabfocus searchreplace spellchecker',
-            spellchecker_rpc_url: abs_url + '/?_task=utils&_action=spell_html&_remote=1',
+            spellchecker_rpc_url: abs_url + '/?_task=utils&_action=spell_html',
             spellchecker_language: rcmail.env.spell_lang,
         });
     }


### PR DESCRIPTION
- Fix action mode checks, it didn't really work as it should.
- Use X-Roundcube-Request header instead of _remote parameter.

I did not notice any regressions, but it might cause issues for external plugins.

Fixes #10118