### PR TITLE
ci: Bump shivammathur/setup-php from v2.32.0 to v2.37.0

### DIFF
--- a/.github/workflows/browser_tests.yml
+++ b/.github/workflows/browser_tests.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2.32.0
+        uses: shivammathur/setup-php@fcafdd6392932010c2bd5094439b8e33be2a8a09 # v2.37.0
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, fileinfo, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd, ldap, intl, pspell

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2.32.0
+        uses: shivammathur/setup-php@fcafdd6392932010c2bd5094439b8e33be2a8a09 # v2.37.0
         with:
           php-version: "8.1"
           extensions: mbstring
@@ -60,7 +60,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2.32.0
+        uses: shivammathur/setup-php@fcafdd6392932010c2bd5094439b8e33be2a8a09 # v2.37.0
         with:
           php-version: "8.4"
           extensions: mbstring

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2.32.0
+        uses: shivammathur/setup-php@fcafdd6392932010c2bd5094439b8e33be2a8a09 # v2.37.0
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, fileinfo, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd, ldap, intl, pspell, enchant
@@ -63,7 +63,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2.32.0
+        uses: shivammathur/setup-php@fcafdd6392932010c2bd5094439b8e33be2a8a09 # v2.37.0
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, fileinfo, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite, gd, ldap, intl


### PR DESCRIPTION
## Summary

Closes #10153.

Bump `shivammathur/setup-php` action from v2.32.0 to v2.37.0 across all
3 workflow files (5 pin sites total) to fix the Linux PHP 8.4/8.5 CI
jobs that have been failing across every PR since ~2026-04-29:

```
W: GPG error: https://setup-php.com/ondrej/php/ubuntu noble InRelease:
   The following signatures couldn't be verified because the public key is not available:
   NO_PUBKEY 71DAEAAB4AD4CAB6 NO_PUBKEY 4F4EA0AAE5267A6C
E: The repository 'https://setup-php.com/ondrej/php/ubuntu noble InRelease' is not signed.
##[error]Process completed with exit code 100.
```

## Why this fixes it

v2.32.0 fetches the ondrej/php PPA's GPG fingerprint from the Launchpad
API as a single source with **no fallback**. When that lookup fails or
returns stale data (which it intermittently does), the apt source ends
up unsigned and `apt-get update` errors out on Ubuntu Noble for the PHP
versions that depend on the PPA (8.4, 8.5).

[v2.35.5 hardened this](https://github.com/shivammathur/setup-php/blob/2.37.0/src/scripts/tools/ppa.sh#L153-L160)
with a three-tier fallback chain:
1. Primary Launchpad API
2. Alternate Launchpad API
3. setup-php's own fingerprint mirror

v2.37.0 (latest, released 2026-03-15) also brings:
- PHP 8.5 stable support (added in v2.36.0)
- Node.js 24 runtime
- Improved PPA handling (deb822 sources, components merging)

## Test plan

- [ ] CI runs trigger on this PR; verify Linux / PHP 8.4 and 8.5 jobs
      complete the apt step successfully and proceed to the test phase
- [ ] All other jobs (Linux 8.1–8.3, Windows 8.1–8.5, Coding Style,
      Static Analysis, E2E, Message Rendering) continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)