### PR TITLE
identity_select: match received header in reverse order (#10158)

### DIFF
--- a/plugins/identity_select/identity_select.php
+++ b/plugins/identity_select/identity_select.php
@@ -60,11 +60,15 @@ class identity_select extends rcube_plugin
         }
 
         $rcmail = rcmail::get_instance();
+        $identities = [];
+        foreach ($p['identities'] as $idx => $ident) {
+            $identities[$idx] = $ident['email'];
+        }
 
         foreach ((array) $rcmail->config->get('identity_select_headers', []) as $header) {
             if ($emails = $this->get_email_from_header($p['message'], $header)) {
-                foreach ($p['identities'] as $idx => $ident) {
-                    if (in_array($ident['email_ascii'], $emails)) {
+                foreach ($emails as $email) {
+                    if (($idx = array_search($email, $identities)) !== false) {
                         $p['selected'] = $idx;
                         break 2;
                     }
@@ -83,17 +87,16 @@ class identity_select extends rcube_plugin
         $value = $message->headers->get($header, false);
 
         if (strtolower($header) == 'received') {
-            // find first email address in all Received headers
-            $email = null;
+            // find all email addresses in all Received headers
+            $emails = [];
             // reverse the header array as RFC 5321 requires additional Received headers are prepended
             foreach (array_reverse((array) $value) as $entry) {
                 if (preg_match('/[\s\t]+for\s+<?([^\s>@]+@[^\s]+\.[^\s>;]+)>?/u', $entry, $matches)) {
-                    $email = $matches[1];
-                    break;
+                    $emails[] = $matches[1];
                 }
             }
 
-            $value = $email;
+            $value = $emails;
         }
 
         return (array) $value;

--- a/plugins/identity_select/identity_select.php
+++ b/plugins/identity_select/identity_select.php
@@ -85,8 +85,9 @@ class identity_select extends rcube_plugin
         if (strtolower($header) == 'received') {
             // find first email address in all Received headers
             $email = null;
-            foreach ((array) $value as $entry) {
-                if (preg_match('/[\s\t]+for[\s\t]+<([^>]+)>/', $entry, $matches)) {
+            // reverse the header array as RFC 5321 requires additional Received headers are prepended
+            foreach (array_reverse((array) $value) as $entry) {
+                if (preg_match('/[\s\t]+for\s+<?([^\s>@]+@[^\s]+\.[^\s>;]+)>?/u', $entry, $matches)) {
                     $email = $matches[1];
                     break;
                 }

--- a/plugins/identity_select/identity_select.php
+++ b/plugins/identity_select/identity_select.php
@@ -62,13 +62,13 @@ class identity_select extends rcube_plugin
         $rcmail = rcmail::get_instance();
         $identities = [];
         foreach ($p['identities'] as $idx => $ident) {
-            $identities[$idx] = $ident['email'];
+            $identities[$idx] = mb_strtolower($ident['email']);
         }
 
         foreach ((array) $rcmail->config->get('identity_select_headers', []) as $header) {
             if ($emails = $this->get_email_from_header($p['message'], $header)) {
                 foreach ($emails as $email) {
-                    if (($idx = array_search($email, $identities)) !== false) {
+                    if (($idx = array_search(mb_strtolower($email), $identities)) !== false) {
                         $p['selected'] = $idx;
                         break 2;
                     }

--- a/plugins/identity_select/tests/IdentitySelectTest.php
+++ b/plugins/identity_select/tests/IdentitySelectTest.php
@@ -4,6 +4,8 @@ namespace Roundcube\Plugins\Tests;
 
 use PHPUnit\Framework\TestCase;
 
+use function Roundcube\Tests\invokeMethod;
+
 class IdentitySelectTest extends TestCase
 {
     /**
@@ -16,5 +18,48 @@ class IdentitySelectTest extends TestCase
 
         $this->assertInstanceOf('identity_select', $plugin);
         $this->assertInstanceOf('rcube_plugin', $plugin);
+    }
+
+    /**
+     * Test get_email_from_header() method
+     */
+    public function test_get_email_from_header()
+    {
+        $rcube = \rcube::get_instance();
+        $plugin = new \identity_select($rcube->plugins);
+        $message = new \stdClass();
+
+        $headers = [
+            'Delivered-To' => 'user@example.com',
+            'Received' => 'from github.com ([10.48.109.45]) by smtp.github.com (Postfix) with ESMTPA id 8C9B4E0075'
+                . ' for <john@domain.tld>; Sat, 28 Nov 2020 22:45:44 -0800 (PST)',
+        ];
+        $message->headers = \rcube_message_header::from_array($headers);
+        $result = invokeMethod($plugin, 'get_email_from_header', [$message, 'Delivered-To']);
+        $this->assertSame('user@example.com', $result[0]);
+        $result = invokeMethod($plugin, 'get_email_from_header', [$message, 'Received']);
+        $this->assertSame('john@domain.tld', $result[0]);
+
+        $headers = [
+            'Received' => [
+                'from mail.aliasprovider.com (mail.aliasprovider.com [198.51.100.20]) by smtp.example.com (Postfix) with ESMTP id 555AAA777'
+                    . ' for chris.smith@example.com; Sun, 10 May 2026 16:00:01 -0400 (EDT)',
+                'from mail.external.com (mail.external.com [203.0.113.45]) by mail.aliasprovider.com (Postfix) with ESMTP id 444BBB666'
+                    . ' for bob.smith@example.com; Sun, 10 May 2026 16:00:00 -0400 (EDT)',
+                'from client.mail.com (client.mail.com [192.0.2.10]) by mail.external.com (Postfix) with ESMTP id 333CCC555'
+                    . ' for sales@example.com; Sun, 10 May 2026 15:59:58 -0400 (EDT)',
+            ],
+        ];
+        $message->headers = \rcube_message_header::from_array($headers);
+        $result = invokeMethod($plugin, 'get_email_from_header', [$message, 'Received']);
+        $this->assertSame('sales@example.com', $result[0]);
+
+        $headers = [
+            'Received' => 'from mail.aliasprovider.com (mail.aliasprovider.com [198.51.100.20]) by smtp.example.com (Postfix) with ESMTP id 555AAA777'
+                . ' for <josé.müller@example.com>; Sun, 10 May 2026 16:30:01 -0400 (EDT)',
+        ];
+        $message->headers = \rcube_message_header::from_array($headers);
+        $result = invokeMethod($plugin, 'get_email_from_header', [$message, 'Received']);
+        $this->assertSame('josé.müller@example.com', $result[0]);
     }
 }

--- a/plugins/identity_select/tests/IdentitySelectTest.php
+++ b/plugins/identity_select/tests/IdentitySelectTest.php
@@ -36,9 +36,9 @@ class IdentitySelectTest extends TestCase
         ];
         $message->headers = \rcube_message_header::from_array($headers);
         $result = invokeMethod($plugin, 'get_email_from_header', [$message, 'Delivered-To']);
-        $this->assertSame('user@example.com', $result[0]);
+        $this->assertSame(['user@example.com'], $result);
         $result = invokeMethod($plugin, 'get_email_from_header', [$message, 'Received']);
-        $this->assertSame('john@domain.tld', $result[0]);
+        $this->assertSame(['john@domain.tld'], $result);
 
         $headers = [
             'Received' => [
@@ -52,7 +52,7 @@ class IdentitySelectTest extends TestCase
         ];
         $message->headers = \rcube_message_header::from_array($headers);
         $result = invokeMethod($plugin, 'get_email_from_header', [$message, 'Received']);
-        $this->assertSame('sales@example.com', $result[0]);
+        $this->assertSame(['sales@example.com', 'bob.smith@example.com', 'chris.smith@example.com'], $result);
 
         $headers = [
             'Received' => 'from mail.aliasprovider.com (mail.aliasprovider.com [198.51.100.20]) by smtp.example.com (Postfix) with ESMTP id 555AAA777'
@@ -60,6 +60,6 @@ class IdentitySelectTest extends TestCase
         ];
         $message->headers = \rcube_message_header::from_array($headers);
         $result = invokeMethod($plugin, 'get_email_from_header', [$message, 'Received']);
-        $this->assertSame('josé.müller@example.com', $result[0]);
+        $this->assertSame(['josé.müller@example.com'], $result);
     }
 }


### PR DESCRIPTION
RFC 5321 says that additional `Received` headers should be prepended:
> When forwarding a message into or out of the Internet environment, a
> gateway MUST prepend a Received: line, but it MUST NOT alter in any
> way a Received: line that is already in the header section.
I'm not sure adding an option to reverse the matching is needed, I think making it the behaviour "find the first address this message was sent to which matches an identity" makes sense.

I also adjusted the regex because having `<>` around the email address is common but not required.

closes #10158