### PR TITLE
Add option message_show_address_comments to show comments when displaying address headers.

### DIFF
--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -1577,6 +1577,9 @@ $config['available_font_sizes'] = ['8pt', '9pt', '10pt', '11pt', '12pt', '14pt',
 // Enables display of email address with name instead of a name (and address in title)
 $config['message_show_email'] = false;
 
+// Enables display of address comments in message headers and the message list
+$config['message_show_address_comments'] = false;
+
 // Default behavior of Reply-All button:
 // 0 - Reply-All always
 // 1 - Reply-List if mailing list is detected

--- a/program/actions/mail/index.php
+++ b/program/actions/mail/index.php
@@ -1344,15 +1344,16 @@ class rcmail_action_mail_index extends rcmail_action
      * Decode address string and re-format it as HTML links
      */
     public static function address_string($input, $max = null, $linked = false, $addicon = null,
-        $default_charset = null, $title = null, $spoofcheck = true)
+        $default_charset = null, $title = null, $spoofcheck = true, $show_comments = null)
     {
-        $a_parts = rcube_mime::decode_address_list($input, null, true, $default_charset);
+        $rcmail = rcmail::get_instance();
+        $show_comments = $show_comments ?? (bool) $rcmail->config->get('message_show_address_comments');
+        $a_parts = rcube_mime::decode_address_list($input, null, true, $default_charset, false, $show_comments);
 
         if (!count($a_parts)) {
             return null;
         }
 
-        $rcmail = rcmail::get_instance();
         $c = count($a_parts);
         $j = 0;
         $out = '';

--- a/program/actions/mail/index.php
+++ b/program/actions/mail/index.php
@@ -1341,6 +1341,22 @@ class rcmail_action_mail_index extends rcmail_action
     }
 
     /**
+     * Clean up display names with redundant escaped quotes.
+     */
+    private static function clean_address_display_name($name)
+    {
+        if (preg_match('/^"((?:\\\\.|[^"\\\\])*)"(.*)$/', $name, $matches)) {
+            $quoted = rcube_mime::unquote('"' . $matches[1] . '"');
+
+            if (strlen($quoted) > 1 && $quoted[0] === '"' && $quoted[-1] === '"') {
+                return $quoted . $matches[2];
+            }
+        }
+
+        return $name;
+    }
+
+    /**
      * Decode address string and re-format it as HTML links
      */
     public static function address_string($input, $max = null, $linked = false, $addicon = null,
@@ -1380,6 +1396,7 @@ class rcmail_action_mail_index extends rcmail_action
             if ($string == $mailto) {
                 $string = rcube_utils::idn_to_utf8($string);
             }
+            $name = self::clean_address_display_name($name);
             $mailto = rcube_utils::idn_to_utf8($mailto);
 
             // Homograph attack detection (#6891),

--- a/program/actions/settings/index.php
+++ b/program/actions/settings/index.php
@@ -553,6 +553,21 @@ class rcmail_action_settings_index extends rcmail_action
                         ];
                     }
 
+                    // show checkbox to preserve comments in address headers
+                    if (!isset($no_override['message_show_address_comments'])) {
+                        if (!$current) {
+                            continue 2;
+                        }
+
+                        $field_id = 'rcmfd_message_show_address_comments';
+                        $input = new html_checkbox(['name' => '_message_show_address_comments', 'id' => $field_id, 'value' => 1]);
+
+                        $blocks['main']['options']['message_show_address_comments'] = [
+                            'title' => html::label($field_id, rcube::Q($rcmail->gettext('showaddresscomments'))),
+                            'content' => $input->show($config['message_show_address_comments'] ? 1 : 0),
+                        ];
+                    }
+
                     // show checkbox for HTML/plaintext messages
                     if (!isset($no_override['prefer_html'])) {
                         if (!$current) {

--- a/program/actions/settings/prefs_save.php
+++ b/program/actions/settings/prefs_save.php
@@ -76,6 +76,7 @@ class rcmail_action_settings_prefs_save extends rcmail_action
                 $a_user_prefs = [
                     'message_extwin' => self::prefs_input_int('message_extwin'),
                     'message_show_email' => isset($_POST['_message_show_email']),
+                    'message_show_address_comments' => isset($_POST['_message_show_address_comments']),
                     'prefer_html' => isset($_POST['_prefer_html']),
                     'inline_images' => isset($_POST['_inline_images']),
                     'show_images' => self::prefs_input_int('show_images'),

--- a/program/lib/Roundcube/rcube_mime.php
+++ b/program/lib/Roundcube/rcube_mime.php
@@ -83,18 +83,25 @@ class rcube_mime
      * @param int          $max      List only this number of addresses
      * @param bool         $decode   Decode address strings
      * @param string       $fallback Fallback charset if none specified
-     * @param bool         $addronly Return flat array with e-mail addresses only
+     * @param bool         $addronly          Return flat array with e-mail addresses only
+     * @param bool         $preserve_comments Preserve comments in the display name
      *
      * @return array Indexed list of addresses
      */
-    public static function decode_address_list($input, $max = null, $decode = true, $fallback = null, $addronly = false)
-    {
+    public static function decode_address_list(
+        $input,
+        $max = null,
+        $decode = true,
+        $fallback = null,
+        $addronly = false,
+        $preserve_comments = false
+    ) {
         // A common case when the same header is used many times in a mail message
         if (is_array($input)) {
             $input = implode(', ', $input);
         }
 
-        $a = self::parse_address_list((string) $input, $decode, $fallback);
+        $a = self::parse_address_list((string) $input, $decode, $fallback, $preserve_comments);
         $out = [];
         $j = 0;
 
@@ -312,15 +319,15 @@ class rcube_mime
     /**
      * E-mail address list parser
      */
-    private static function parse_address_list($str, $decode = true, $fallback = null)
+    private static function parse_address_list($str, $decode = true, $fallback = null, $preserve_comments = false)
     {
         // remove any newlines and carriage returns before
         $str = preg_replace('/\r?\n(\s|\t)?/', ' ', $str);
 
-        // extract list items, remove comments
+        // extract list items, optionally preserving comments for display
         // We don't support groups in address-lists, thus we also split on the semicolon here and check for a group-name
         // later.
-        $str = self::explode_header_string(',;', $str, true);
+        $str = self::explode_header_string(',;', $str, !$preserve_comments);
 
         // simplified regexp, supporting quoted local part
         $email_rx = '([^\s:]+|("\s*(?:[^"\f\n\r\t\v\b\s]+\s*)+"))@\S+';
@@ -334,7 +341,7 @@ class rcube_mime
             $val = trim($val);
 
             // Check for group names and store them for later, if present.
-            $tokens = self::explode_header_string(':', $val, true);
+            $tokens = self::explode_header_string(':', $val, !$preserve_comments);
             switch (count($tokens)) {
                 case 1:
                     // No colon, nothing to do.
@@ -440,7 +447,14 @@ class rcube_mime
                 } elseif ($str[$i] == '(') {
                     $comment++;
                 } elseif ($str[$i] == '\\') {
+                    if (!$remove_comments) {
+                        $out .= '\\';
+                    }
                     $i++;
+                }
+
+                if (!$remove_comments && isset($str[$i])) {
+                    $out .= $str[$i];
                 }
 
                 continue;
@@ -458,8 +472,12 @@ class rcube_mime
                 $quoted = true;
             }
             // start of comment
-            elseif ($remove_comments && $str[$i] == '(') {
+            elseif ($str[$i] == '(') {
                 $comment++;
+                if (!$remove_comments) {
+                    $out .= $str[$i];
+                }
+                continue;
             }
 
             if ($comment <= 0) {
@@ -467,7 +485,7 @@ class rcube_mime
             }
         }
 
-        if ($out && $comment <= 0) {
+        if ($out && ($comment <= 0 || !$remove_comments)) {
             $result[] = $out;
         }
 

--- a/program/lib/Roundcube/rcube_mime.php
+++ b/program/lib/Roundcube/rcube_mime.php
@@ -361,6 +361,9 @@ class rcube_mime
                 // remove it later, because $email_rx will catch it (#8164)
                 $address = rtrim($m[2], '>');
                 $name = trim($m[1]);
+            } elseif (preg_match('/^(' . $email_rx . ')(\s*\(.+\))$/', $val, $m)) {
+                $address = $m[1];
+                $name = $preserve_comments ? $val : '';
             } elseif (preg_match('/^(' . $email_rx . ')$/', $val, $m)) {
                 $address = $m[1];
                 $name = '';
@@ -371,6 +374,8 @@ class rcube_mime
                 $name = substr($val, 0, -strlen($m[1]));
             } elseif (preg_match('/(' . $email_rx . ')/', $val, $m)) {
                 $name = $m[1];
+            } elseif (strcasecmp($val, 'root') === 0) {
+                $address = $val;
             } else {
                 $name = $val;
             }

--- a/program/localization/en_US/labels.inc
+++ b/program/localization/en_US/labels.inc
@@ -548,6 +548,7 @@ $labels['htmlonreply'] = 'on reply to HTML message';
 $labels['htmlonreplyandforward'] = 'on forward or reply to HTML message';
 $labels['htmlsignature'] = 'HTML signature';
 $labels['showemail'] = 'Show email address with display name';
+$labels['showaddresscomments'] = 'Show comments in address headers';
 $labels['previewpane'] = 'Show preview pane';
 $labels['skin'] = 'Interface skin';
 $labels['logoutclear'] = 'Clear Trash on logout';

--- a/tests/Actions/Mail/IndexTest.php
+++ b/tests/Actions/Mail/IndexTest.php
@@ -240,6 +240,11 @@ class IndexTest extends ActionTestCase
 
         $this->assertSame($expected, $result);
 
+        $result = $action->address_string('\"\\\"test.user@domain.tld\\\"\" (via Test Mailing List) <test@domain.tld>', null, false, null, null, null, false, true);
+        $expected = '<span class="adr"><span title="test@domain.tld" class="rcmContactAddress">&quot;test.user@domain.tld&quot; (via Test Mailing List)</span></span>';
+
+        $this->assertSame($expected, $result);
+
         setProperty($action, 'PRINT_MODE', true);
 
         $result = $action->address_string('test@domain.com');

--- a/tests/Framework/MimeTest.php
+++ b/tests/Framework/MimeTest.php
@@ -50,6 +50,8 @@ class MimeTest extends TestCase
             // invalid addr-spec (#8164)
             26 => '"Test.org"<test@domain.tld',
             27 => '<test@domain.tld',
+            28 => 'root@domain.tld (Cron Daemon)',
+            29 => 'root',
         ];
 
         $results = [
@@ -82,6 +84,8 @@ class MimeTest extends TestCase
             25 => [1, '', 'user@domain.tld'],
             26 => [1, 'Test.org', 'test@domain.tld'],
             27 => [1, '', 'test@domain.tld'],
+            28 => [1, '', 'root@domain.tld'],
+            29 => [1, '', 'root'],
         ];
 
         foreach ($headers as $idx => $header) {
@@ -101,6 +105,7 @@ class MimeTest extends TestCase
     {
         $headers = [
             'Test User (test@domain.tld) <list@domain.tld>' => 'Test User (test@domain.tld)',
+            'root@domain.tld (Cron Daemon)' => 'root@domain.tld (Cron Daemon)',
             'Test User (via Test Mailing List) <list@domain.tld>' => 'Test User (via Test Mailing List)',
             'Test User (via: Test, Mailing List) <list@domain.tld>' => 'Test User (via: Test, Mailing List)',
             '"\\"test.user@domain.tld\\"" (via Test Mailing List) <test@domain.tld>' => '"\\"test.user@domain.tld\\"" (via Test Mailing List)',

--- a/tests/Framework/MimeTest.php
+++ b/tests/Framework/MimeTest.php
@@ -94,6 +94,26 @@ class MimeTest extends TestCase
     }
 
     /**
+     * Test decoding address comments when requested for display
+     * Uses rcube_mime::decode_address_list()
+     */
+    public function test_decode_address_comments_for_display()
+    {
+        $headers = [
+            'Test User (test@domain.tld) <list@domain.tld>' => 'Test User (test@domain.tld)',
+            'Test User (via Test Mailing List) <list@domain.tld>' => 'Test User (via Test Mailing List)',
+            'Test User (via: Test, Mailing List) <list@domain.tld>' => 'Test User (via: Test, Mailing List)',
+            '"\\"test.user@domain.tld\\"" (via Test Mailing List) <test@domain.tld>' => '"\\"test.user@domain.tld\\"" (via Test Mailing List)',
+        ];
+
+        foreach ($headers as $header => $name) {
+            $res = \rcube_mime::decode_address_list($header, null, true, null, false, true);
+
+            $this->assertSame($name, $res[1]['name'], 'Name part with comments for header: ' . $header);
+        }
+    }
+
+    /**
      * Test decoding of address groups
      * Uses rcube_mime::decode_address_list()
      */


### PR DESCRIPTION

This PR implements:

- a configuration option `$config['message_show_address_comments'] = true;`
- a user preference setting in Preferences -> Displaying Messages -> "Show comments in address headers"

Roundcube seems to over-sanitize when displaying From: headers, which can hide important information in the RFC5322 / RFC2822  comment part of the header.

### Examples

```
RFC5322 / RFC2822 Header                                             | Before                          | After
---------------------------------------------------------------------|---------------------------------|------------------------------------------------------------------------------
Test User (test@domain.tld) <list@domain.tld>                        | Test User <list@domain.tld>     | "Test User (test@domain.tld)" <list@domain.tld>
Test User (via Test Mailing List) <list@domain.tld>                  | Test User <list@domain.tld>     | "Test User (via Test Mailing List)" <list@domain.tld>
Test User (via: Test, Mailing List) <list@domain.tld>                | Test User <list@domain.tld>     | "Test User (via: Test, Mailing List)" <list@domain.tld>
"\"test.user@domain.tld\"" (via Test Mailing List) <test@domain.tld> | "test.user@domain.tld" <test@domain.tld> | "test.user@domain.tld" (via Test Mailing List) <test@domain.tld>
root@domain.tld (Cron Daemon)                                        | (not displayed in RC 1.7.0)     | "root@domain.tld (Cron Daemon)" <root@domain.tld>
root                                                                 | (not displayed in RC 1.7.0)     | root
---------------------------------------------------------------------|---------------------------------|------------------------------------------------------------------------------
```

I don't think the last case of local-part with no domain name is strictly RFC compliant, but things like cron can often generate this header if the local MTA is broken, isn't configured with a domain, doesn't add a domain to From: headers missing a domain, for example.

The very neat new anti-spoofing warning feature isn't affected. 

(I always enable `$config['message_show_email']` globally and never allow users to turn it off.)

```
// Always show sender email address (not just name)
$config['message_show_email'] = true;

// don't allow users to change:
$config['dont_override'] = ['message_show_email' ];
```
