### PR TITLE
[Security] Restrict allowed_classes in session (Redis/Memcache) and cache unserialize() to prevent PHP Object Injection

### DIFF
--- a/program/lib/Roundcube/rcube_cache.php
+++ b/program/lib/Roundcube/rcube_cache.php
@@ -29,6 +29,16 @@ class rcube_cache
     protected $prefix;
     protected $ttl;
     protected $packed;
+
+    /**
+     * Controls the allowed_classes option passed to unserialize().
+     * Set to false to disallow all object deserialization (safest for caches that
+     * only store scalar/array values), or an array of class names to restrict which
+     * PHP objects may be instantiated. Defaults to true for backwards compatibility.
+     *
+     * @var bool|array
+     */
+    protected $allowed_classes = true;
     protected $indexed;
     protected $index;
     protected $index_update;
@@ -455,7 +465,8 @@ class rcube_cache
         }
 
         $data = $this->get_item($this->ikey());
-        $this->index = $data ? unserialize($data) : [];
+        // The index only stores an array of string cache keys — never PHP objects.
+        $this->index = $data ? unserialize($data, ['allowed_classes' => false]) : [];
     }
 
     /**
@@ -609,7 +620,15 @@ class rcube_cache
      */
     protected function unserialize($data)
     {
-        return $this->packed ? @unserialize($data) : $data;
+        if (!$this->packed) {
+            return $data;
+        }
+
+        if ($this->allowed_classes !== true) {
+            return @unserialize($data, ['allowed_classes' => $this->allowed_classes]);
+        }
+
+        return @unserialize($data);
     }
 
     /**

--- a/program/lib/Roundcube/rcube_cache.php
+++ b/program/lib/Roundcube/rcube_cache.php
@@ -33,10 +33,13 @@ class rcube_cache
     /**
      * Controls the allowed_classes option passed to unserialize().
      * Set to false to disallow all object deserialization (safest for caches that
-     * only store scalar/array values), or an array of class names to restrict which
-     * PHP objects may be instantiated. Defaults to true for backwards compatibility.
+     * only store scalar/array values), or an array of fully-qualified class names
+     * to restrict which PHP objects may be instantiated on deserialization.
+     * Defaults to true (allow all) for backwards compatibility with plugins.
      *
-     * @var bool|array
+     * Use set_allowed_classes() to configure this after construction.
+     *
+     * @var bool|string[]
      */
     protected $allowed_classes = true;
     protected $indexed;
@@ -107,6 +110,23 @@ class rcube_cache
         $this->prefix = $prefix;
         $this->packed = $packed;
         $this->indexed = $indexed;
+    }
+
+    /**
+     * Restrict which PHP classes may be instantiated during unserialize().
+     *
+     * Pass false to disallow all objects (safest for caches that only store
+     * scalar/array values), or an array of fully-qualified class names to
+     * allow only those specific classes.
+     *
+     * Example — allow only Roundcube data-transfer objects:
+     *   $cache->set_allowed_classes([\rcube_message_header::class, \rcube_message_part::class]);
+     *
+     * @param bool|string[] $classes false to disallow all, or array of class names
+     */
+    public function set_allowed_classes($classes): void
+    {
+        $this->allowed_classes = $classes;
     }
 
     /**

--- a/program/lib/Roundcube/session/memcache.php
+++ b/program/lib/Roundcube/session/memcache.php
@@ -113,7 +113,10 @@ class rcube_session_memcache extends rcube_session
     public function read($key)
     {
         if ($value = $this->memcache->get($key)) {
-            $arr = unserialize($value);
+            // The session envelope only contains scalar fields (expires_at, ip, vars);
+            // disallow object deserialization to prevent PHP Object Injection via a
+            // compromised or unauthenticated Memcache backend.
+            $arr = unserialize($value, ['allowed_classes' => false]);
             // Use a fallback to avoid errors in case expires_at is unset
             $this->expires_at = $arr['expires_at'] ?? time();
             $this->ip = $arr['ip'];

--- a/program/lib/Roundcube/session/redis.php
+++ b/program/lib/Roundcube/session/redis.php
@@ -127,7 +127,10 @@ class rcube_session_redis extends rcube_session
         }
 
         if ($value) {
-            $arr = unserialize($value);
+            // The session envelope only contains scalar fields (expires_at, ip, vars);
+            // disallow object deserialization to prevent PHP Object Injection via a
+            // compromised or unauthenticated Redis backend.
+            $arr = unserialize($value, ['allowed_classes' => false]);
             // Use a fallback to avoid errors in case expires_at is unset
             $this->expires_at = $arr['expires_at'] ?? time();
             $this->ip = $arr['ip'];


### PR DESCRIPTION
## Summary

Three `unserialize()` call sites in Roundcube read data from external backends (Redis, Memcache, database cache) without restricting the `allowed_classes` option. An attacker who can write to these backends can inject a crafted PHP serialized payload containing a **gadget chain** and achieve **Remote Code Execution**.

## Affected locations

| File | Line | Backend | Risk |
|------|------|---------|------|
| `session/redis.php` | ~130 | Redis | **Critical** — unauthenticated Redis is common |
| `session/memcache.php` | ~116 | Memcache | **High** — Memcache has no auth by default |
| `rcube_cache.php` | ~458 | DB / any | **Medium** — cache index deserialization |

## Attack scenario

1. Attacker can write to the Redis or Memcache backend (unauthenticated instance, SSRF, or lateral movement on shared hosting).
2. Attacker injects a serialized payload using gadget classes loaded by Roundcube/Symfony (e.g., any library with a dangerous `__destruct`/`__wakeup`).
3. On the next request, the session is read and deserialized → gadget chain fires → **RCE**.

## Fixes

- **session/redis.php** / **session/memcache.php**: Add `'allowed_classes' => false` — the session envelope only stores scalar fields (`expires_at`, `ip`, `vars`); no PHP objects should ever be present.
- **rcube_cache.php**: Add `'allowed_classes' => false` for the cache index read (plain array of string keys). Add an `$allowed_classes` property (default `true`) to `rcube_cache` so subclasses can restrict their data reads.

## Files changed

- `program/lib/Roundcube/session/redis.php`
- `program/lib/Roundcube/session/memcache.php`
- `program/lib/Roundcube/rcube_cache.php`