### PR TITLE
elastic: restore color to unread icon

### DIFF
--- a/skins/elastic/styles/widgets/lists.less
+++ b/skins/elastic/styles/widgets/lists.less
@@ -733,6 +733,7 @@ table.fixedcopy {
 
         &.unread:before {
             content: @fa-var-circle;
+            color: @color-list-unread-status;
             font-size: .5rem;
         }
 


### PR DESCRIPTION
revert 1 line from 9427ec1d35445170cd5d25b3aae9b69950610c3b, restore the colour to the unread icon in the message list of the elastic skin.

I think its not clear why this commit removed the colour and feedback on the change is negative. resolves #9862