### PR TITLE
Fix TypeError in current_username() when no user is authenticated

### DIFF
--- a/program/include/rcmail_output_html.php
+++ b/program/include/rcmail_output_html.php
@@ -2249,7 +2249,7 @@ class rcmail_output_html extends rcmail_output
             $username = $this->app->user->get_username();
         }
 
-        $username = rcube_utils::idn_to_utf8($username);
+        $username = rcube_utils::idn_to_utf8((string) $username);
 
         return html::quote($username);
     }

--- a/tests/Rcmail/OutputHtmlTest.php
+++ b/tests/Rcmail/OutputHtmlTest.php
@@ -337,6 +337,20 @@ class OutputHtmlTest extends TestCase
     }
 
     /**
+     * Test current_username() with no authenticated user
+     */
+    public function test_current_username()
+    {
+        $rcmail = \rcube::get_instance();
+        $rcmail->user = new \rcube_user(null);
+        unset($_SESSION['username']);
+
+        $output = new \rcmail_output_html();
+
+        $this->assertSame('', $output->current_username([]));
+    }
+
+    /**
      * Test abs_url()
      */
     public function test_abs_url()


### PR DESCRIPTION
Closes #10214.

`rcube_user::get_username()` can return null when there is no authenticated user, which then reaches `html::quote()` (typed `string`) and throws `TypeError`. Cast the value to string before `idn_to_utf8()` so an empty username renders as an empty string instead of crashing.