### PR TITLE
Fix incorrect unfolding of folded lines for vCard 2.1 imports (#9647)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This file includes only changes we consider noteworthy for users, admins and plu
 - Fix an infinite loop in TNEF (winmail.dat) decoder (#10193)
 - Fix bug where installto.sh would fail if public_html folder does not exist in the target directory (#10202)
 - Revert "Prefer 8bit over quoted-printable for HTML parts, when force_7bit is disabled (#8477)" (#10198)
+- Fix incorrect unfolding of folded lines when importing vCard 2.1 contacts (#9647)
 
 ## Release 1.7.1
 

--- a/program/lib/Roundcube/rcube_vcard.php
+++ b/program/lib/Roundcube/rcube_vcard.php
@@ -680,6 +680,29 @@ class rcube_vcard
     }
 
     /**
+     * Perform vCard line unfolding.
+     *
+     * vCard 3.0/4.0 (RFC 2425/2426) folds a logical line by inserting a CRLF
+     * followed by a single whitespace, and unfolding removes both. vCard 2.1
+     * (RFC 822) instead regards "CRLF immediately followed by a LWSP-char as
+     * equivalent to the LWSP-char", i.e. the folding whitespace is kept. See #9647.
+     *
+     * @param string $vcard vCard block to unfold
+     *
+     * @return string Unfolded vCard block (with CR removed, lines delimited by LF)
+     */
+    private static function unfold($vcard)
+    {
+        $vcard = str_replace("\r", '', $vcard);
+
+        if (preg_match('/^VERSION:2\.1\s*$/im', $vcard)) {
+            return str_replace(["\n ", "\n\t"], [' ', "\t"], $vcard);
+        }
+
+        return str_replace(["\n ", "\n\t"], '', $vcard);
+    }
+
+    /**
      * Decodes a vcard block (vcard 3.0 format, unfolded) into an array structure
      *
      * @param string $vcard vCard block to parse
@@ -688,8 +711,8 @@ class rcube_vcard
      */
     private static function vcard_decode($vcard)
     {
-        // Perform RFC2425 line unfolding and split lines
-        $vcard = str_replace(["\r", "\n ", "\n\t"], '', $vcard);
+        // Perform line unfolding and split lines
+        $vcard = self::unfold($vcard);
         $lines = explode("\n", $vcard);
         $result = [];
 
@@ -992,8 +1015,8 @@ class rcube_vcard
         // Extract the plain text from the vCard, so the detection is more accurate
         // This will for example exclude photos
 
-        // Perform RFC2425 line unfolding and split lines
-        $string = str_replace(["\r", "\n ", "\n\t"], '', $string);
+        // Perform line unfolding and split lines
+        $string = self::unfold($string);
         $lines = explode("\n", $string);
         $string = '';
 

--- a/tests/Framework/VCardTest.php
+++ b/tests/Framework/VCardTest.php
@@ -124,6 +124,28 @@ class VCardTest extends TestCase
         $this->assertSame('an example', $result['notes'][0]);
     }
 
+    /**
+     * vCard 2.1 unfolds a CRLF followed by a whitespace to that whitespace
+     * (RFC 822), i.e. the folding whitespace is kept - unlike vCard 3.0/4.0
+     * (RFC 2425) which drops it entirely. See #9647.
+     */
+    public function test_parse_v21_continuation_line_keeps_whitespace()
+    {
+        $vcard_string = "BEGIN:VCARD\r\n"
+            . "VERSION:2.1\r\n"
+            . "N:Doe;Jane;;;\r\n"
+            . "FN:Jane Doe\r\n"
+            . "NOTE:an\r\n"
+            . " example\r\n"
+            . "END:VCARD\r\n";
+
+        $vcard = new \rcube_vcard($vcard_string);
+
+        $result = $vcard->get_assoc();
+
+        $this->assertSame('an example', $result['notes'][0]);
+    }
+
     public function test_import()
     {
         $input = file_get_contents($this->_srcpath('apple.vcf'));


### PR DESCRIPTION
## Summary

Fixes #9647.

vCard line unfolding was hardcoded to the RFC 2425 rule used by vCard 3.0/4.0, which drops the folding whitespace entirely. vCard **2.1** instead follows RFC 822, where *"CRLF immediately followed by a LWSP-char is equivalent to the LWSP-char"* — i.e. the folding whitespace must be **kept**.

As a result, importing a folded vCard 2.1 value such as:

```
NOTE:an
 example
```

produced `anexample` instead of `an example`. Multi-word notes, organizations, etc. got their words fused together on import.

## Changes

- Extract a version-aware `unfold()` helper in `rcube_vcard`.
- For `VERSION:2.1`, keep the single folding whitespace; otherwise behave exactly as before (drop it, per RFC 2425).
- Use the helper at both unfolding sites (`vcard_decode()` and `detect_encoding()`), mirroring how #9637 fixed the related 3.0/4.0 whitespace bug.

## Tests

- Added `test_parse_v21_continuation_line_keeps_whitespace` to `tests/Framework/VCardTest.php`, alongside the existing 3.0 continuation-line test.
- Full `VCardTest` suite passes; the existing 3.0/4.0 behaviour is unchanged.

## Notes

This complements #9637 (which fixed the analogous whitespace handling for vCard 3.0/4.0). See also sabre/vobject#690 for the same distinction.