### PR TITLE
add new list_hover_menu option

### DIFF
--- a/config/defaults.inc.php
+++ b/config/defaults.inc.php
@@ -938,6 +938,9 @@ $config['message_sort_order'] = 'DESC';
 // subject, from, to, fromto, cc, replyto, date, size, status, flag, attachment, priority
 $config['list_cols'] = ['subject', 'status', 'fromto', 'date', 'size', 'flag', 'attachment'];
 
+// show the hover menu in the message list
+$config['list_hover_menu'] = true;
+
 // the default locale setting (leave empty for auto-detection)
 // RFC1766 formatted language name like en_US, de_DE, de_CH, fr_FR, pt_BR
 $config['language'] = null;

--- a/program/actions/mail/index.php
+++ b/program/actions/mail/index.php
@@ -117,6 +117,7 @@ class rcmail_action_mail_index extends rcmail_action
             $rcmail->output->set_env('reply_all_mode', (int) $rcmail->config->get('reply_all_mode'));
             $rcmail->output->set_env('layout', $rcmail->config->get('layout') ?: 'widescreen');
             $rcmail->output->set_env('quota', $rcmail->storage->get_capability('QUOTA'));
+            $rcmail->output->set_env('list_hover_menu', $rcmail->config->get('list_hover_menu', true));
 
             // set special folders
             foreach (['drafts', 'trash', 'junk'] as $mbox) {
@@ -226,6 +227,12 @@ class rcmail_action_mail_index extends rcmail_action
         $threading = $a_threading[$_SESSION['mbox']] ?? $default_threading;
 
         $rcmail->storage->set_threading($threading);
+
+        // toggle list hover menu
+        if (isset($_GET['_hmenu'])) {
+            $hmenu = !empty($_GET['_hmenu']) ? true : false;
+            $rcmail->user->save_prefs(['list_hover_menu' => $hmenu]);
+        }
     }
 
     /**

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -2657,7 +2657,7 @@ function rcube_webmail() {
         this.env.sort_order = sort_order;
     };
 
-    this.set_list_options = function (cols, sort_col, sort_order, threads, layout) {
+    this.set_list_options = function (cols, sort_col, sort_order, threads, layout, hover_menu) {
         var update, post_data = {};
 
         if (sort_col === undefined) {
@@ -2709,6 +2709,11 @@ function rcube_webmail() {
                 update = 1;
                 post_data._cols = newcols.join(',');
             }
+        }
+
+        if (hover_menu !== null && this.env.list_hover_menu != hover_menu) {
+            update = 1;
+            post_data._hmenu = hover_menu;
         }
 
         if (update) {

--- a/program/localization/en_US/labels.inc
+++ b/program/localization/en_US/labels.inc
@@ -226,6 +226,8 @@ $labels['layoutwidescreendesc'] = 'Widescreen (3-column view)';
 $labels['layoutdesktopdesc'] = 'Desktop (wide list and mail preview below)';
 $labels['layoutlistdesc'] = 'List (no mail preview)';
 
+$labels['listhovermenu'] = 'Enable quick menu';
+
 $labels['folderactions'] = 'Folder actions...';
 $labels['compact'] = 'Compact';
 $labels['empty'] = 'Empty';

--- a/program/localization/en_US/labels.inc
+++ b/program/localization/en_US/labels.inc
@@ -226,7 +226,7 @@ $labels['layoutwidescreendesc'] = 'Widescreen (3-column view)';
 $labels['layoutdesktopdesc'] = 'Desktop (wide list and mail preview below)';
 $labels['layoutlistdesc'] = 'List (no mail preview)';
 
-$labels['listhovermenu'] = 'Enable quick menu';
+$labels['listhovermenu'] = 'Mouse-over menu';
 
 $labels['folderactions'] = 'Folder actions...';
 $labels['compact'] = 'Compact';

--- a/skins/elastic/templates/mail.html
+++ b/skins/elastic/templates/mail.html
@@ -213,6 +213,14 @@
 		</div>
 	</div>
 	<roundcube:endif />
+	<roundcube:if condition="!in_array('list_hover_menu', (array)config:dont_override)" />
+	<div class="form-group row">
+		<label for="listoptions-hovermenu" class="col-form-label col-sm-4"><roundcube:label name="listhovermenu" /></label>
+		<div class="col-sm-8">
+            <input type="checkbox" id="listoptions-hovermenu" name="hover_menu" value="1" />
+		</div>
+	</div>
+	<roundcube:endif />
 	<roundcube:container name="listoptions" id="listoptionsmenu" />
 	<roundcube:add_label name="listoptionstitle" />
 </div>

--- a/skins/elastic/ui.js
+++ b/skins/elastic/ui.js
@@ -2714,9 +2714,10 @@ function rcube_elastic_ui() {
         $('select[name="sort_col"]', dialog).val(rcmail.env.sort_col || '');
         $('select[name="sort_ord"]', dialog).val(rcmail.env.sort_order || 'ASC');
         $('select[name="mode"]', dialog).val(rcmail.env.threading ? 'threads' : 'list');
+        $('input[name="hover_menu"]', dialog).prop('checked', rcmail.env.list_hover_menu);
 
         // Fix id/for attributes
-        $('select', dialog).each(function () {
+        $('select,input', dialog).each(function () {
             this.id = this.id + '-clone';
         });
         $('label', dialog).each(function () {
@@ -2730,9 +2731,10 @@ function rcube_elastic_ui() {
 
             var col = $('select[name="sort_col"]', dialog).val(),
                 ord = $('select[name="sort_ord"]', dialog).val(),
-                mode = $('select[name="mode"]', dialog).val();
+                mode = $('select[name="mode"]', dialog).val(),
+                hmenu = $('input[name="hover_menu"]', dialog).is(':checked');
 
-            rcmail.set_list_options([], col, ord, mode == 'threads' ? 1 : 0);
+            rcmail.set_list_options([], col, ord, mode == 'threads' ? 1 : 0, null, hmenu ? 1 : 0);
             return true;
         };
 
@@ -3182,7 +3184,7 @@ function rcube_elastic_ui() {
         // Append the menu to the list wrapper, handle events to show/hide menu on hover
         list_element.append(menu)
             .on('mouseenter', 'tr', function (e) {
-                if (record != e.currentTarget) {
+                if (rcmail.env.list_hover_menu && record != e.currentTarget) {
                     message_list_hover_menu(menu, record = e.currentTarget);
                 }
             })


### PR DESCRIPTION
Closes #10223

This adds a new config option `list_hover_menu` and includes it has part of the list options. the change is backwards compatible.

<img width="632" height="423" alt="Screenshot 2026-06-10 143923" src="https://github.com/user-attachments/assets/fca5d800-9bc5-4827-abd8-2a4537bef16c" />

I'll mark this as draft for now because it turned out to be a bigger change than I was expecting but I can't think of another way right now.

I'm also not sure if `Enable quick menu` is the right label.