### PR TITLE
Free Imagick resources after failing

### DIFF
--- a/program/lib/Roundcube/rcube_image.php
+++ b/program/lib/Roundcube/rcube_image.php
@@ -359,6 +359,14 @@ class rcube_image
                     return true;
                 }
             } catch (\Exception $e) {
+                // Free resources
+                if ($image instanceof \Imagick) {
+                    try {
+                        $image->clear();
+                    } catch (\Exception $e) {
+                        // Ignore errors
+                    }
+                }
                 rcube::raise_error($e, true, false);
             }
         }

--- a/program/lib/Roundcube/rcube_image.php
+++ b/program/lib/Roundcube/rcube_image.php
@@ -197,8 +197,11 @@ class rcube_image
                         } finally {
                             // Free resources
                             if ($image instanceof \Imagick) {
-                                $image->clear();
-                                $image->destroy();
+                                try {
+                                    $image->clear();
+                                } catch (\Exception $e) {
+                                    // Ignore errors
+                                }
                             }
                         }
                     }

--- a/program/lib/Roundcube/rcube_image.php
+++ b/program/lib/Roundcube/rcube_image.php
@@ -171,7 +171,6 @@ class rcube_image
                     // use PHP's Imagick class
                     else {
                         try {
-                            $image = null;
                             $image = new \Imagick($this->image_file);
 
                             try {

--- a/program/lib/Roundcube/rcube_image.php
+++ b/program/lib/Roundcube/rcube_image.php
@@ -193,7 +193,7 @@ class rcube_image
                             }
                         } catch (\Exception $e) {
                             // Free resources
-                            if ($image instanceof \Imagick) {
+                            if (!empty($image)) {
                                 try {
                                     $image->clear();
                                 } catch (\Exception $e) {
@@ -360,7 +360,7 @@ class rcube_image
                 }
             } catch (\Exception $e) {
                 // Free resources
-                if ($image instanceof \Imagick) {
+                if (!empty($image)) {
                     try {
                         $image->clear();
                     } catch (\Exception $e) {

--- a/program/lib/Roundcube/rcube_image.php
+++ b/program/lib/Roundcube/rcube_image.php
@@ -171,6 +171,7 @@ class rcube_image
                     // use PHP's Imagick class
                     else {
                         try {
+                            $image = null;
                             $image = new \Imagick($this->image_file);
 
                             try {
@@ -193,6 +194,12 @@ class rcube_image
                             }
                         } catch (\Exception $e) {
                             rcube::raise_error($e, true, false);
+                        } finally {
+                            // Free resources
+                            if ($image instanceof \Imagick) {
+                                $image->clear();
+                                $image->destroy();
+                            }
                         }
                     }
                 }

--- a/program/lib/Roundcube/rcube_image.php
+++ b/program/lib/Roundcube/rcube_image.php
@@ -192,8 +192,6 @@ class rcube_image
                                 $result = '';
                             }
                         } catch (\Exception $e) {
-                            rcube::raise_error($e, true, false);
-                        } finally {
                             // Free resources
                             if ($image instanceof \Imagick) {
                                 try {
@@ -202,6 +200,7 @@ class rcube_image
                                     // Ignore errors
                                 }
                             }
+                            rcube::raise_error($e, true, false);
                         }
                     }
                 }


### PR DESCRIPTION
Fixes #10230 

Forcing the release of Imagick resources, we can prevent the problem with abandoned large files in temporary storage.