### PR TITLE
password: support regular expressions in password_login_exceptions

### DIFF
--- a/plugins/password/config.inc.php.dist
+++ b/plugins/password/config.inc.php.dist
@@ -28,8 +28,9 @@ $config['password_minimum_score'] = 0;
 // Enables logging of password changes into logs/password
 $config['password_log'] = false;
 
-// Array of login exceptions for which password change
+// Array of username exceptions for which password change
 // will be not available (no Password tab in Settings)
+// or PCRE patterns (including // delimiters e.g. '/@domain.com$/').
 $config['password_login_exceptions'] = null;
 
 // Array of hosts that support password changing.

--- a/plugins/password/password.php
+++ b/plugins/password/password.php
@@ -482,7 +482,7 @@ class password extends rcube_plugin
             $username = $_SESSION['username'];
 
             foreach ($exceptions as $ec) {
-                if ($username === $ec) {
+                if ($username === $ec || (str_starts_with($ec, '/') && preg_match($ec, $username))) {
                     return false;
                 }
             }


### PR DESCRIPTION
This was inspired by #10233 the ticket specifically mentions the password plugin which has a `password_login_exceptions` config option which uses a hardcoded list of usernames.

I think that ticket described a niche use case however adding support for regular expressions in `password_login_exceptions` could make management of more complex environments simpler.