### PR TITLE
Elastic: improve extensability of hover menu

### DIFF
--- a/skins/elastic/ui.js
+++ b/skins/elastic/ui.js
@@ -3165,13 +3165,14 @@ function rcube_elastic_ui() {
     function message_list_hover_menu_init(list_element) {
         var record,
             menu = $('<div class="menu listing-hover-menu">'
-                + '<span class="txt"></span>'
+                + '<span class="txt date"></span>'
+                + '<span class="txt size"></span>'
                 // + '<a class="button read" data-flag="read" title="' + rcmail.gettext('markasread') + '"></a>'
                 // + '<a class="button unread d-none" data-flag="unread" title="' + rcmail.gettext('markasunread') + '"></a>'
-                + '<a class="button flag" data-flag="flagged" title="' + rcmail.gettext('markasflagged') + '"></a>'
-                + '<a class="button unflag d-none" data-flag="unflagged" title="' + rcmail.gettext('markasunflagged') + '"></a>'
                 + '<a class="button delete" data-flag="delete" title="' + rcmail.gettext('deletemessage') + '"></a>'
                 + '<a class="button undo d-none" data-flag="undelete" title="' + rcmail.gettext('undeletemessage') + '"></a>'
+                + '<a class="button flag" data-flag="flagged" title="' + rcmail.gettext('markasflagged') + '"></a>'
+                + '<a class="button unflag d-none" data-flag="unflagged" title="' + rcmail.gettext('markasunflagged') + '"></a>'
                 + '</div>'
             ),
             hide_menu = function () {
@@ -3230,12 +3231,15 @@ function rcube_elastic_ui() {
         menu.css({ top: top + 'px' });
 
         // Show/hide buttons according to the hovered message state
+        menu[message.flagged ? 'addClass' : 'removeClass']('flagged');
+        menu[message.deleted ? 'addClass' : 'removeClass']('deleted');
         Object.keys(buttons).forEach(function (btn) {
             menu.find('a.' + btn)[buttons[btn] ? 'removeClass' : 'addClass']('d-none');
         });
 
-        // Update the txt element in the menu
-        menu.find('span.txt').text(element.closest('table').is('.sort-size') ? message.date : message.size);
+        // Update the txt elements in the menu
+        menu.find('span.txt.date')[element.closest('table').is('.sort-size') ? 'removeClass' : 'addClass']('d-none').text(message.date);
+        menu.find('span.txt.size')[!element.closest('table').is('.sort-size') ? 'removeClass' : 'addClass']('d-none').text(message.size);
 
         rcmail.triggerEvent('skin-message-list-hover-menu', { menu: menu, record: record });
     }


### PR DESCRIPTION
I know I could do this with a plugin and the `skin-message-list-hover-menu-init` and `skin-message-list-hover-menu` hooks but the only visible effect of this change is to swap the delete and flag icons around (so that hover menu, or no hover menu, the flag stays in one place).

<img width="334" height="118" alt="Recording 2026-06-20 143133" src="https://github.com/user-attachments/assets/eb14bd09-f9c2-46af-9745-033ed02946bf" />

with these changes then using only custom styling in `_styles.less` its possible to customise the menu quite a lot more than currently.
1. adding `flagged`/`deleted` class to the menu - allows for the text colour to change like it does on the row itself to reflect the status of the message
2. having both the `date` and `size` text spans populated allows both bits of information to be displayed if required

in the example above the date is no longer obscured during hover and both the date and size are visible