### PR TITLE
Improve PHP CS Fixer config/speed

### DIFF
--- a/.php-cs-fixer-fully_qualified_strict_types.php
+++ b/.php-cs-fixer-fully_qualified_strict_types.php
@@ -228,7 +228,7 @@ class Foo extends \Other\BaseClass implements \Other\Interface1, \Other\Interfac
      */
     public function getPriority(): int
     {
-        return 6;
+        return 7;
     }
 
     public function isCandidate(Tokens $tokens): bool

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -105,6 +105,7 @@ return (new Config())
         'octal_notation' => false,
 
         // TODO remove after https://github.com/roundcube/roundcubemail/pull/9481
+        'fully_qualified_strict_types' => false,
         'Custom/fully_qualified_strict_types' => ['leading_backslash_in_global_namespace' => static function (string $fqcn): bool {
             $pluginsRegex = 'filesystem_attachments|password|new_user_identity|identicon|example_addressbook|enigma';
 


### PR DESCRIPTION
fix #9935

The priority did not change in the official PHP CS Fixer.

The issue was the standard `fully_qualified_strict_types` rule was not disabled, but as the priority was the same, the apply order was undefined.

This PR improves CI speed as the CS is stable during CS fixing.