### PR TITLE
Allow NULL in identities.organization on MySQL (#10148)

### DIFF
--- a/SQL/mysql.initial.sql
+++ b/SQL/mysql.initial.sql
@@ -177,7 +177,7 @@ CREATE TABLE `identities` (
  `del` tinyint(1) NOT NULL DEFAULT '0',
  `standard` tinyint(1) NOT NULL DEFAULT '0',
  `name` varchar(128) NOT NULL,
- `organization` varchar(128) NOT NULL DEFAULT '',
+ `organization` varchar(128) DEFAULT NULL,
  `email` varchar(128) NOT NULL,
  `reply-to` varchar(128) NOT NULL DEFAULT '',
  `bcc` varchar(128) NOT NULL DEFAULT '',
@@ -272,4 +272,4 @@ CREATE TABLE `system` (
 
 SET FOREIGN_KEY_CHECKS=1;
 
-INSERT INTO `system` (`name`, `value`) VALUES ('roundcube-version', '2025092300');
+INSERT INTO `system` (`name`, `value`) VALUES ('roundcube-version', '2026070500');

--- a/SQL/mysql/2026070500.sql
+++ b/SQL/mysql/2026070500.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `identities` MODIFY `organization` varchar(128) DEFAULT NULL;

--- a/SQL/postgres.initial.sql
+++ b/SQL/postgres.initial.sql
@@ -390,4 +390,4 @@ CREATE TABLE "system" (
     value text
 );
 
-INSERT INTO "system" (name, value) VALUES ('roundcube-version', '2025092300');
+INSERT INTO "system" (name, value) VALUES ('roundcube-version', '2026070500');

--- a/SQL/postgres/2026070500.sql
+++ b/SQL/postgres/2026070500.sql
@@ -1,0 +1,1 @@
+-- MySQL only

--- a/SQL/sqlite.initial.sql
+++ b/SQL/sqlite.initial.sql
@@ -274,4 +274,4 @@ CREATE TABLE system (
   value text NOT NULL
 );
 
-INSERT INTO system (name, value) VALUES ('roundcube-version', '2025092300');
+INSERT INTO system (name, value) VALUES ('roundcube-version', '2026070500');

--- a/SQL/sqlite/2026070500.sql
+++ b/SQL/sqlite/2026070500.sql
@@ -1,0 +1,1 @@
+-- MySQL only


### PR DESCRIPTION
Fixes #10148

## Problem

The `identities.organization` column allows NULL on PostgreSQL and SQLite, but is defined as `NOT NULL DEFAULT ''` on MySQL. As noted in #10148, the schemas should be unified.

An `INSERT` with an explicit NULL fails on MySQL (with the default strict SQL mode) with:

```
DB Error: [1048] Column 'organization' cannot be null
```

`rcube_user::insert_identity()` passes identity records through as-is, so a NULL `organization` supplied via the `user_create`/`identity_create` hooks (e.g. by the `new_user_identity` plugin when the LDAP attribute is absent) triggers this error and aborts the creation of new user accounts — which matches the reporter's observation that new accounts could not log in until the plugin was disabled.

## Changes

- `SQL/mysql.initial.sql`: `organization varchar(128) NOT NULL DEFAULT ''` → `organization varchar(128) DEFAULT NULL` (matches the PostgreSQL definition)
- New migration `2026070500.sql` (MySQL: `ALTER TABLE ... MODIFY`; comment-only placeholder for PostgreSQL/SQLite, as in previous single-driver migrations)
- Bumped the `roundcube-version` stamp in all three `*.initial.sql` files
- CHANGELOG entry

Not touched (possible follow-up): `reply-to` and `bcc` have the same NULL-ability divergence between MySQL/SQLite and PostgreSQL, and SQLite keeps its `DEFAULT ''` for `organization` (changing a column default in SQLite would require a table rebuild, which seems disproportionate here since the NULL insert already works there).

## Testing

Verified locally against MariaDB 12.3 (strict mode: `STRICT_TRANS_TABLES,...`) and SQLite; the `MODIFY` statement is elementary DDL and follows the same pattern already used for this very column in `SQL/mysql/2011121400.sql`:

- **Bug reproduction**: applied the current (pre-change) `mysql.initial.sql`, inserted an identity with `organization = NULL` → fails with `ERROR 1048 (23000): Column 'organization' cannot be null`
- **Fresh install**: applied the new `mysql.initial.sql` → column is `NULL`-able, NULL insert succeeds, version stamped `2026070500`
- **Upgrade path**: applied the old schema, ran `bin/updatedb.sh --package=roundcube --dir=SQL` → migration applies cleanly, NULL insert succeeds, version updated
- **Schema consistency**: `SHOW CREATE TABLE identities` is identical between a fresh install and an upgraded install
- **SQLite upgrade path**: comment-only migration applies cleanly via `bin/updatedb.sh` and bumps the stored version
- Full PHPUnit suite passes (one pre-existing, unrelated local failure of `RcubeTest::test_exec` due to BSD vs GNU `date` on macOS)

This contribution was prepared with AI assistance (Claude Code); the analysis and all test results above were verified against a real database as described.

🤖 Generated with [Claude Code](https://claude.com/claude-code)