### PR TITLE
Don't defeat session.lazy_write in the php session driver (#9885)

### DIFF
--- a/program/lib/Roundcube/session/php.php
+++ b/program/lib/Roundcube/session/php.php
@@ -81,8 +81,11 @@ class rcube_session_php extends rcube_session
     #[\Override]
     public function write_close()
     {
+        // Do not set a modification-time variable here. It is not read anywhere,
+        // and changing session data on every request defeats session.lazy_write,
+        // forcing a storage write per request. Session keep-alive is handled by
+        // PHP natively via the save handler's updateTimestamp().
         $_SESSION['__IP'] = $this->ip;
-        $_SESSION['__MTIME'] = time();
 
         parent::write_close();
     }


### PR DESCRIPTION
Supersedes #9885, implementing what was agreed there between @tpayen and @alecpl about a year ago (the PR was not updated since); original analysis and measurement by @tpayen, credited as co-author.

## Problem

`rcube_session_php::write_close()` sets `$_SESSION['__MTIME'] = time()` on every request. The variable is not read anywhere in the codebase (verified via grep — the `$changed` property alecpl mentioned in #9885 has meanwhile been removed entirely by the `expires_at` rework). Its only effect is that session data *changes on every request*, which defeats PHP's `session.lazy_write` optimization: PHP writes the full session to storage on every request instead of skipping unchanged sessions. With a network-backed `session.save_handler` (e.g. phpredis, as in #9885), that is significant unnecessary traffic — the original reporter measured ~50% of their Redis session traffic caused by this.

## Change

Remove the `__MTIME` update (as agreed in #9885, rather than the throttling originally proposed there).

- **Keep-alive is not lost:** with `lazy_write`, PHP calls the save handler's `updateTimestamp()` for unchanged sessions, which refreshes the TTL (phpredis issues `EXPIRE`) or the file mtime (files handler). `session.gc_maxlifetime` is already set from `session_lifetime` in `rcube::session_init()`.
- `__IP` is kept — it is read back in `start()` and required for `ip_check` — and it is idempotent from the second request on, so it does not prevent `lazy_write`.
- Only the `php` driver is affected; the db/redis/memcache drivers register their own save handler and manage expiry via `expires_at` themselves.

## Testing

- Behavior demonstrated with a counting `SessionHandlerInterface` + `SessionUpdateTimestampHandlerInterface` over two simulated requests (fixed session id, `lazy_write=1`, second request changes nothing):
  - with `__MTIME` (current master): `write, write`
  - without `__MTIME` (this PR): `write, updateTimestamp`
- Full PHPUnit suite passes on the branch (PHP 8.5.8; single pre-existing local failure of `RcubeTest::test_exec`, BSD vs GNU `date` on macOS, unrelated).
- `php-cs-fixer` clean on the changed file.

This contribution was prepared with AI assistance (Claude Code); the analysis and test results above were independently verified as described.

🤖 Generated with [Claude Code](https://claude.com/claude-code)