### PR TITLE
Show the sender's timezone in reply/forward intro lines (#7352)

### DIFF
--- a/program/actions/mail/compose.php
+++ b/program/actions/mail/compose.php
@@ -896,10 +896,14 @@ class rcmail_action_mail_compose extends rcmail_action_mail_index
         $list = rcube_mime::decode_address_list($message->get_header('from'), 1, false, $message->headers->charset);
         $from = array_pop($list);
 
+        // Format the date in the sender's timezone and make the offset explicit,
+        // so the reference is unambiguous for every reader of the reply (#7352)
+        $date_format = $rcmail->config->get('date_long', 'Y-m-d H:i') . ' O';
+
         return $rcmail->gettext([
             'name' => 'mailreplyintro',
             'vars' => [
-                'date' => $rcmail->format_date($message->get_header('date'), $rcmail->config->get('date_long')),
+                'date' => $rcmail->format_date($message->get_header('date'), $date_format, false),
                 'sender' => !empty($from['name']) ? $from['name'] : rcube_utils::idn_to_utf8($from['mailto']),
             ],
         ]);
@@ -925,7 +929,10 @@ class rcmail_action_mail_compose extends rcmail_action_mail_index
         }
 
         $rcmail = rcmail::get_instance();
-        $date = $rcmail->format_date($message->get_header('date'), $rcmail->config->get('date_long'));
+
+        // Format the date in the sender's timezone with an explicit offset (#7352)
+        $date_format = $rcmail->config->get('date_long', 'Y-m-d H:i') . ' O';
+        $date = $rcmail->format_date($message->get_header('date'), $date_format, false);
 
         if (!$bodyIsHtml) {
             $prefix = "\n\n\n-------- " . $rcmail->gettext('originalmessage') . " --------\n";

--- a/program/include/rcmail.php
+++ b/program/include/rcmail.php
@@ -1601,17 +1601,11 @@ class rcmail extends rcube
     public function format_date($date, $format = null, $convert = true)
     {
         if (!$date instanceof \DateTimeInterface) {
-            if (!empty($date)) {
-                $timestamp = rcube_utils::strtotime($date);
-            }
+            // Parse the input preserving a timezone specified there (if any), so that
+            // with $convert=false the date is presented in its original timezone
+            $date = !empty($date) ? rcube_utils::anytodatetime($date) : false;
 
-            if (empty($timestamp)) {
-                return '';
-            }
-
-            try {
-                $date = new \DateTime('@' . $timestamp);
-            } catch (\Exception $e) {
+            if (!$date || $date->getTimestamp() <= 0) {
                 return '';
             }
         }
@@ -1619,7 +1613,6 @@ class rcmail extends rcube
         if ($convert) {
             try {
                 // convert to the right timezone
-                $stz = date_default_timezone_get();
                 $tz = new \DateTimeZone($this->config->get('timezone'));
                 $date = clone $date; // don't modify the original object
                 $date->setTimezone($tz);

--- a/tests/Actions/Mail/ComposeTest.php
+++ b/tests/Actions/Mail/ComposeTest.php
@@ -38,4 +38,23 @@ class ComposeTest extends ActionTestCase
 
         $this->assertSame($expected, $result);
     }
+
+    /**
+     * Test rcmail_action_mail_compose::get_reply_header()
+     */
+    public function test_get_reply_header()
+    {
+        $rcmail = \rcmail::get_instance();
+        $rcmail->config->set('date_long', 'Y-m-d H:i');
+
+        // The date must be presented in the sender's timezone with an explicit offset (#7352)
+        $message = (new \ReflectionClass(\rcube_message::class))->newInstanceWithoutConstructor();
+        $message->headers = new \rcube_message_header();
+        $message->headers->set('From', 'Steve Jobs <steve@example.com>');
+        $message->headers->set('Date', 'Tue, 28 Apr 2020 10:35:20 +0900');
+
+        $result = \rcmail_action_mail_compose::get_reply_header($message);
+
+        $this->assertSame('On 2020-04-28 10:35 +0900, Steve Jobs wrote:', $result);
+    }
 }

--- a/tests/Rcmail/RcmailTest.php
+++ b/tests/Rcmail/RcmailTest.php
@@ -316,5 +316,15 @@ class RcmailTest extends ActionTestCase
         $this->assertSame('Europe/Berlin', $date->getTimezone()->getName());
         $date = new \DateTime('2020-06-01 12:00:00', new \DateTimeZone('Europe/Berlin'));
         $this->assertSame('12:00 Europe/Berlin', $rcmail->format_date($date, 'H:i e', false));
+
+        // Test that string input preserves the timezone specified in the input (#7352)
+        $date = 'Tue, 28 Apr 2020 10:35:20 +0900';
+        $this->assertSame('2020-04-28 10:35 +0900', $rcmail->format_date($date, 'Y-m-d H:i O', false));
+        $this->assertSame('2020-04-28 01:35 +0000', $rcmail->format_date($date, 'Y-m-d H:i O', true));
+
+        // Invalid and zero dates
+        $this->assertSame('', $rcmail->format_date(''));
+        $this->assertSame('', $rcmail->format_date('an invalid date'));
+        $this->assertSame('', $rcmail->format_date('0000-00-00 00:00:00'));
     }
 }


### PR DESCRIPTION
Implements #7352. Opened as a **draft** to agree on the exact format/behavior before finalizing (see the questions below).

## What it does

The reply intro (`On <date>, <sender> wrote:`) and the forward header (`Date: <date>`) currently show the original message date converted to the *quoting user's* local time, with no timezone information — ambiguous for everyone else reading the reply. With this change, the date is formatted **in the sender's original timezone with an explicit UTC offset**, like Mutt and Claws Mail do (as suggested in the issue and welcomed there):

> On 2020-04-28 10:35 +0900, Steve Jobs wrote:

The user's configured `date_long` format is still honored (localization included); only ` O` (the offset) is appended.

## Bug fixed along the way

@metalefty's in-house attempt in the issue failed because `rcmail::format_date($string, $fmt, false)` didn't behave as documented: for string input, the `rcube_utils::strtotime()` → `new DateTime('@'.$ts)` roundtrip *discards* the timezone contained in the input, so with `$convert=false` dates were rendered in **UTC** — neither the user's nor the original timezone. This PR switches the parsing to `rcube_utils::anytodatetime()` (which preserves the input's timezone and falls back to the same `strtotime()`), making `$convert=false` finally mean "keep the original timezone".

Impact on existing `$convert=false` callers (contact date fields in `contacts/index.php`, managesieve vacation dates): they now render dates in the timezone they were written in, instead of a UTC rendering that could be **shifted by a day** for servers with non-zero UTC offsets — a latent off-by-one fixed by this change. Behavior for `$convert=true` (all other callers) is unchanged: same instant, converted to the user's timezone as before. Invalid/zero dates (`0000-00-00 00:00:00`) still return an empty string (now guarded explicitly).

## Questions for maintainers (why this is a draft)

1. Is `date_long . ' O'` the right format (e.g. `2020-04-28 10:35 +0900`), or would you prefer a dedicated config option (e.g. `reply_date_format`) so admins/users can control it?
2. Should this stay unconditional (like Mutt), or be opt-in?
3. The issue's reporter also wished for timezone display in the message view — that's a separate UI/config topic; users can already add `O`/`e` to their `date_format` settings. I'd keep it out of scope here.

## Testing

- New unit test `ComposeTest::test_get_reply_header()` asserting the exact intro line for a `+0900` message date.
- `RcmailTest::test_format_date()` extended: string input with `$convert=false` preserves the input offset, `$convert=true` converts as before; empty/invalid/zero-date inputs return `''`.
- Full PHPUnit suite passes (PHP 8.5.8; single pre-existing local failure of `RcubeTest::test_exec`, BSD vs GNU `date` on macOS, unrelated).
- `php-cs-fixer` and `phpstan` clean on all changed files.

This contribution was prepared with AI assistance (Claude Code); analysis and test results were verified as described.

🤖 Generated with [Claude Code](https://claude.com/claude-code)