### PR TITLE
Preserve the original message date on import of EML messages (#5559)

### DIFF
--- a/program/actions/mail/import.php
+++ b/program/actions/mail/import.php
@@ -216,6 +216,18 @@ class rcmail_action_mail_import extends rcmail_action
         }
 
         $message = rtrim($message);
+
+        // Fall back to the message's Date header (an EML input, or an mbox from-line
+        // without a recognized date), so imported messages keep their original date
+        // as the INTERNALDATE instead of the import time (#5559)
+        if (!$date) {
+            $headers = rcube_mime::parse_headers(preg_split('/\r?\n\r?\n/', $message, 2)[0]);
+
+            if (!empty($headers['date'])) {
+                $date = rcube_utils::anytodatetime($headers['date']) ?: null;
+            }
+        }
+
         $rcmail = rcmail::get_instance();
 
         if ($rcmail->storage->save_message($folder, $message, '', false, [], $date)) {

--- a/tests/Actions/Mail/ImportTest.php
+++ b/tests/Actions/Mail/ImportTest.php
@@ -61,6 +61,9 @@ class ImportTest extends ActionTestCase
         $args = $storage->methodCalls[1]['args'];
         $this->assertSame('Test', $args[0]);
         $this->assertTrue(str_starts_with($args[1], 'From: "Thomas B." <thomas@roundcube.net>'));
+        // The message date (from the Date header) is used as INTERNALDATE
+        $this->assertInstanceOf(\DateTime::class, $args[5]);
+        $this->assertSame('2014-05-23 19:44:50 +0200', $args[5]->format('Y-m-d H:i:s O'));
 
         // Upload a MBOX file
         $_FILES['_file'] = [
@@ -90,6 +93,9 @@ class ImportTest extends ActionTestCase
         $this->assertSame('Test', $args[0]);
         $this->assertTrue(str_starts_with($args[1], 'From: test@rc.net'));
         $this->assertStringContainsString('1234', $args[1]);
+        // The date from the mbox from-line is used as INTERNALDATE
+        $this->assertInstanceOf(\DateTime::class, $args[5]);
+        $this->assertSame('2023-07-16 15:06:25 +0000', $args[5]->format('Y-m-d H:i:s O'));
 
         $args = $storage->methodCalls[2]['args'];
         $this->assertSame('Test', $args[0]);
@@ -104,5 +110,53 @@ class ImportTest extends ActionTestCase
         // TODO: Test error handling
         // TODO: Test ZIP file input
         $this->markTestIncomplete();
+    }
+
+    /**
+     * Test save_message() setting the message date (INTERNALDATE)
+     */
+    public function test_save_message_date()
+    {
+        $storage = self::mockStorage()
+            ->registerFunction('save_message', 1)
+            ->registerFunction('save_message', 2)
+            ->registerFunction('save_message', 3)
+            ->registerFunction('save_message', 4)
+            ->registerFunction('save_message', 5);
+
+        // EML: use the Date header
+        $message = "From: a@example.com\r\nDate: Thu, 1 Jan 2015 10:20:30 +0900\r\n\r\nBody";
+        \rcmail_action_mail_import::save_message('Test', $message, 'eml');
+
+        // EML without a body (headers only)
+        $message = "From: a@example.com\r\nDate: Thu, 1 Jan 2015 10:20:30 +0900";
+        \rcmail_action_mail_import::save_message('Test', $message, 'eml');
+
+        // EML without a Date header: a date-like line in the body must be ignored
+        $message = "From: a@example.com\r\nSubject: Test\r\n\r\nDate: Thu, 1 Jan 2015 10:20:30 +0900";
+        \rcmail_action_mail_import::save_message('Test', $message, 'eml');
+
+        // EML with an unparsable Date header
+        $message = "From: a@example.com\r\nDate: not a date\r\n\r\nBody";
+        \rcmail_action_mail_import::save_message('Test', $message, 'eml');
+
+        // Mbox from-line without a recognized date: fall back to the Date header
+        $message = "From sender@example.com\nFrom: a@example.com\nDate: Thu, 1 Jan 2015 10:20:30 +0900\n\nBody";
+        \rcmail_action_mail_import::save_message('Test', $message, 'mbox');
+
+        $dates = array_map(static function ($call) {
+            return $call['args'][5] ? $call['args'][5]->format('Y-m-d H:i:s O') : null;
+        }, $storage->methodCalls);
+
+        $this->assertSame(
+            [
+                '2015-01-01 10:20:30 +0900',
+                '2015-01-01 10:20:30 +0900',
+                null,
+                null,
+                '2015-01-01 10:20:30 +0900',
+            ],
+            $dates
+        );
     }
 }


### PR DESCRIPTION
## Problem

Since #5559 the import action preserves the original message date, but only for **mbox** input, where the received date is taken from the mbox from-line and passed to IMAP `APPEND` as the message INTERNALDATE. As noted back then:

> Implemented. Of course it works only with mbox format which stores the date in "from line".

For **EML** input (single files or inside ZIP archives) no date is extracted at all, so every imported message gets the time of the import as its INTERNALDATE. That affects sorting by arrival date, `SEARCH BEFORE/SINCE`, and the message list when the arrival date is displayed — a mailbox restored from EML backups shows all messages as "received" at import time.

## Change

When no date was found, `rcmail_action_mail_import::save_message()` now falls back to the message's `Date` header:

- **EML input** — the `Date` header is the only original date an EML file carries, and it is close enough to the delivery time that INTERNALDATE is supposed to hold. Other clients (e.g. Thunderbird's ImportExportTools) do the same on EML import.
- **mbox input whose from-line has no recognized date** — previously these messages also fell through to `null`; the Date header is a strictly better fallback than the import time.
- The mbox from-line date keeps precedence when present (it is the actual received date).

Implementation notes:

- The header block is split off at the first empty line **before** parsing (`rcube_mime::parse_headers()`), so `Date:`-like lines in the message body cannot be picked up.
- Parsing uses the existing `rcube_utils::anytodatetime()`; RFC 2822 dates keep their original UTC offset all the way into the `APPEND` date-time string.
- A missing or unparsable `Date` header keeps the previous behavior (`APPEND` without a date-time, i.e. server assigns the current time).

## Testing

- New `ImportTest::test_save_message_date()` covers: EML with Date header, header-only message, missing Date header with a Date-like line in the body (must be ignored), unparsable Date header, and the mbox from-line fallback.
- The existing upload tests in `ImportTest` now also assert the date argument passed to `save_message()` for both the EML and the mbox path (the mbox from-line date extraction was previously untested).
- Full chain verified locally down to the `APPEND` command: `Date: Fri, 23 May 2014 19:44:50 +0200` → `rcube_utils::anytodatetime()` → `rcube_imap::date_format()` → `"23-May-2014 19:44:50 +0200"`; `null` propagates to an `APPEND` without date-time.
- Full PHPUnit suite passes; php-cs-fixer and phpstan clean on the changed files.

---

*This contribution was prepared with AI assistance (Claude); the analysis, implementation and tests were reviewed and verified by test runs as described above.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)