### PR TITLE
Inherit PHP interpreter during `installto.sh`

### DIFF
--- a/bin/deluser.sh
+++ b/bin/deluser.sh
@@ -60,7 +60,7 @@ if (!empty($args['age']) && ($age = intval($args['age']))) {
             printf("%s (%s)\n", $user['username'], $user['mail_host']);
             continue;
         }
-        system(sprintf('%s/deluser.sh --host=%s %s', INSTALL_PATH . 'bin', escapeshellarg($user['mail_host']), escapeshellarg($user['username'])));
+        system(sprintf('%s %s/deluser.sh --host=%s %s', PHP_BINARY, INSTALL_PATH . 'bin', escapeshellarg($user['mail_host']), escapeshellarg($user['username'])));
     }
 
     exit(0);

--- a/bin/deluser.sh
+++ b/bin/deluser.sh
@@ -60,7 +60,7 @@ if (!empty($args['age']) && ($age = intval($args['age']))) {
             printf("%s (%s)\n", $user['username'], $user['mail_host']);
             continue;
         }
-        system(sprintf('%s %s/deluser.sh --host=%s %s', PHP_BINARY, INSTALL_PATH . 'bin', escapeshellarg($user['mail_host']), escapeshellarg($user['username'])));
+        system(sprintf('%s %s/deluser.sh --host=%s %s', \PHP_BINARY, INSTALL_PATH . 'bin', escapeshellarg($user['mail_host']), escapeshellarg($user['username'])));
     }
 
     exit(0);

--- a/bin/installto.sh
+++ b/bin/installto.sh
@@ -168,7 +168,7 @@ if (strtolower($input) == 'y') {
 
         if (!file_exists($dest_file) || sha1_file($dest_file) !== $package->sha1) {
             echo 'Installing JavaScript dependencies...';
-            system("cd {$target_dir} && " . \PHP_BINARY . " bin/install-jsdeps.sh");
+            system("cd {$target_dir} && " . \PHP_BINARY . ' bin/install-jsdeps.sh');
             echo "done.\n\n";
         }
     }

--- a/bin/installto.sh
+++ b/bin/installto.sh
@@ -168,7 +168,7 @@ if (strtolower($input) == 'y') {
 
         if (!file_exists($dest_file) || sha1_file($dest_file) !== $package->sha1) {
             echo 'Installing JavaScript dependencies...';
-            system("cd {$target_dir} && bin/install-jsdeps.sh");
+            system("cd {$target_dir} && " . PHP_BINARY . " bin/install-jsdeps.sh");
             echo "done.\n\n";
         }
     }
@@ -178,7 +178,7 @@ if (strtolower($input) == 'y') {
     }
 
     echo "Running update script at target...\n";
-    system("cd {$target_dir} && bin/update.sh --version={$oldversion}" . ($accept ? ' -y' : ''));
+    system("cd {$target_dir} && " . PHP_BINARY . " bin/update.sh --version={$oldversion}" . ($accept ? ' -y' : ''));
     echo "All done.\n";
 } else {
     echo "Update cancelled. See ya!\n";

--- a/bin/installto.sh
+++ b/bin/installto.sh
@@ -168,7 +168,7 @@ if (strtolower($input) == 'y') {
 
         if (!file_exists($dest_file) || sha1_file($dest_file) !== $package->sha1) {
             echo 'Installing JavaScript dependencies...';
-            system("cd {$target_dir} && " . PHP_BINARY . " bin/install-jsdeps.sh");
+            system("cd {$target_dir} && " . \PHP_BINARY . " bin/install-jsdeps.sh");
             echo "done.\n\n";
         }
     }
@@ -178,7 +178,7 @@ if (strtolower($input) == 'y') {
     }
 
     echo "Running update script at target...\n";
-    system("cd {$target_dir} && " . PHP_BINARY . " bin/update.sh --version={$oldversion}" . ($accept ? ' -y' : ''));
+    system("cd {$target_dir} && " . \PHP_BINARY . " bin/update.sh --version={$oldversion}" . ($accept ? ' -y' : ''));
     echo "All done.\n";
 } else {
     echo "Update cancelled. See ya!\n";

--- a/bin/update.sh
+++ b/bin/update.sh
@@ -317,13 +317,13 @@ function repo_key($repo)
 function find_composer()
 {
     if (is_file(INSTALL_PATH . 'composer.phar')) {
-        return PHP_BINARY . ' composer.phar';
+        return \PHP_BINARY . ' composer.phar';
     }
 
     foreach (['composer', 'composer.phar'] as $check_file) {
         $which = trim(rcube::exec("which {$check_file}"));
         if (!empty($which)) {
-            return PHP_BINARY . " {$which}";
+            return \PHP_BINARY . " {$which}";
         }
     }
 

--- a/bin/update.sh
+++ b/bin/update.sh
@@ -317,7 +317,7 @@ function repo_key($repo)
 function find_composer()
 {
     if (is_file(INSTALL_PATH . 'composer.phar')) {
-        return PHP_BINARY . 'composer.phar';
+        return PHP_BINARY . ' composer.phar';
     }
 
     foreach (['composer', 'composer.phar'] as $check_file) {

--- a/bin/update.sh
+++ b/bin/update.sh
@@ -317,13 +317,13 @@ function repo_key($repo)
 function find_composer()
 {
     if (is_file(INSTALL_PATH . 'composer.phar')) {
-        return 'php composer.phar';
+        return PHP_BINARY . 'composer.phar';
     }
 
     foreach (['composer', 'composer.phar'] as $check_file) {
         $which = trim(rcube::exec("which {$check_file}"));
         if (!empty($which)) {
-            return $which;
+            return PHP_BINARY . " {$which}";
         }
     }
 


### PR DESCRIPTION
Currently executing `phpX.Y ./bin/installto.sh` will invoke follow up steps with env-default  generic `php` command.

Given PHP now ships built in [`PHP_BINARY`](https://www.php.net/manual/en/reserved.constants.php#constant.php-binary) that indicates the currently running interpreter - reuse it.