### PR TITLE
Zipdownload: various improvements to this plugin

### DIFF
--- a/plugins/zipdownload/composer.json
+++ b/plugins/zipdownload/composer.json
@@ -3,7 +3,7 @@
     "type": "roundcube-plugin",
     "description": "Adds an option to download all attachments to a message in one zip file, when a message has multiple attachments. Also allows the download of a selection of messages in one zip file. Supports mbox and maildir format.",
     "license": "GPL-3.0-or-later",
-    "version": "3.6",
+    "version": "3.8",
     "authors": [
         {
             "name": "Thomas Bruederli",

--- a/plugins/zipdownload/config.inc.php.dist
+++ b/plugins/zipdownload/config.inc.php.dist
@@ -16,4 +16,4 @@ $config['zipdownload_attachments'] = 1;
 $config['zipdownload_selection'] = '50MB';
 
 // Charset to use for filenames inside the zip
-$config['zipdownload_charset'] = 'ISO-8859-1';
+$config['zipdownload_charset'] = 'UTF-8';

--- a/plugins/zipdownload/zipdownload.php
+++ b/plugins/zipdownload/zipdownload.php
@@ -19,6 +19,7 @@ class zipdownload extends rcube_plugin
     private $charset = 'ASCII';
     private $names = [];
     private $default_limit = '50MB';
+    private $timezone;
 
     // RFC4155: mbox date format
     public const MBOX_DATE_FORMAT = 'D M d H:i:s Y';
@@ -251,14 +252,15 @@ class zipdownload extends rcube_plugin
             foreach ($uids as $uid) {
                 $headers = $imap->get_message_headers($uid);
 
+                // Received (internal) date
+                $date = rcube_utils::anytodatetime($headers->internaldate);
+
                 if ($mode == 'mbox') {
                     // Sender address
                     $from = rcube_mime::decode_address_list($headers->from, null, true, $headers->charset, true);
                     $from = array_shift($from);
                     $from = preg_replace('/\s/', '-', $from);
 
-                    // Received (internal) date
-                    $date = rcube_utils::anytodatetime($headers->internaldate);
                     if ($date) {
                         $date = $date->setTimezone($timezone)->format(self::MBOX_DATE_FORMAT);
                     } else {
@@ -277,7 +279,7 @@ class zipdownload extends rcube_plugin
                     $path = $folders ? str_replace($delimiter, '/', $mbox) . '/' : '';
                     $disp_name = $path . $uid . ($subject ? " {$subject}" : '') . '.eml';
 
-                    $messages[$uid . ':' . $mbox] = $disp_name;
+                    $messages[$uid . ':' . $mbox] = ($date ? $date->getTimestamp() : '') . ':' . $disp_name;
                 }
 
                 $size += $headers->size;
@@ -305,6 +307,7 @@ class zipdownload extends rcube_plugin
         }
 
         // open zip file
+        putenv('TZ=UTC');  // see _datetime_to_ziplocal() comments
         $zip = new \ZipArchive();
         $zip->open($tmpfname, \ZipArchive::OVERWRITE);
 
@@ -331,12 +334,17 @@ class zipdownload extends rcube_plugin
                     fwrite($tmpfp, "\r\n");
                 }
             } else { // maildir
+                [$date, $filename] = explode(':', $value, 2);
                 $tmpfn = rcube_utils::temp_filename('zipmessage');
                 $fp = fopen($tmpfn, 'w');
                 $imap->get_raw_body($uid, $fp);
                 $tempfiles[] = $tmpfn;
                 fclose($fp);
-                $zip->addFile($tmpfn, $value);
+                $zip->addFile($tmpfn, $filename);
+                if ($date) {
+                    $date = $this->_datetime_to_ziplocal(new \DateTime('@' . $date));
+                    $zip->setMtimeName($filename, $date->getTimestamp());
+                }
             }
         }
 
@@ -358,6 +366,41 @@ class zipdownload extends rcube_plugin
         }
 
         exit;
+    }
+
+    /**
+     * Zip files do not store timezones; most extraction tools extract times
+     * as though they were local times. This converts the UTC times inside
+     * DateTime objects into a user's preferred local time (despite claiming
+     * to still be UTC) so that when added and later extracted to/from a zip
+     * file, they will be in that user's local time.
+     *
+     * Also, ZipArchive creation is affected the system's default timezone
+     * (NOT date_default_timezone_set); to mitigate this, putenv('TZ=UTC').
+     *
+     * @param \DateTimeInterface $real The accurate DateTime of a file (is not changed)
+     *
+     * @return \DateTimeInterface A "fake" DateTimeImmutable for inclusion into a zip
+     */
+    private function _datetime_to_ziplocal($real)
+    {
+        if (!$this->timezone) {
+            if ($this->timezone === false) {
+                return $real;
+            }
+            $rcmail = rcmail::get_instance();
+            try {
+                $this->timezone = new \DateTimeZone($rcmail->config->get('timezone'));
+            } catch (\DateInvalidTimeZoneException) {
+                $this->timezone = false;
+                return $real;
+            }
+        }
+
+        $real = \DateTime::createFromInterface($real);
+        $real->setTimezone($this->timezone);
+        $local = max($real->format('Y/m/d H:i:s'), '1980/01/01 00:00:00');  // Earliest supported by zip
+        return \DateTimeImmutable::createFromFormat('Y/m/d H:i:s O', $local . ' +0000');
     }
 
     /**

--- a/plugins/zipdownload/zipdownload.php
+++ b/plugins/zipdownload/zipdownload.php
@@ -369,7 +369,20 @@ class zipdownload extends rcube_plugin
 
         $rcmail->output->download_headers($filename, ['length' => filesize($tmpfname)]);
 
-        readfile($tmpfname);
+        $tmpfp = fopen($tmpfname, 'r');
+        if (!$tmpfp) {
+            return;
+        }
+        while (true) {
+            $data = fread($tmpfp, 512 * 1024);
+            if (strlen($data) == 0) {
+                break;
+            }
+            echo $data;
+            ob_flush();
+            flush();
+        }
+        fclose($tmpfp);
     }
 
     /**

--- a/public_html/.htaccess
+++ b/public_html/.htaccess
@@ -5,15 +5,21 @@ RewriteEngine On
 RewriteRule ^favicon\.ico$ static.php/skins/elastic/images/favicon.ico
 </IfModule>
 
+# https://httpd.apache.org/docs/2.4/env.html#cgilike
+SetEnv ap_trust_cgilike_cl 1
+
 <IfModule mod_deflate.c>
 SetOutputFilter DEFLATE
+# some assets have been compressed, so no need to do it again
+SetEnvIfNoCase Request_URI \.(?:gif|jpe?g|png|web[pm]|woff2?)$ no-gzip
+SetEnvIfExpr "%{QUERY_STRING} =~ /(?:^|&)_action=plugin\.zipdownload\.(?:attachments|messages)(?:&|$)/" no-gzip
 </IfModule>
 
 # prefer to brotli over gzip if brotli is available
 <IfModule mod_brotli.c>
 SetOutputFilter BROTLI_COMPRESS
-# some assets have been compressed, so no need to do it again
 SetEnvIfNoCase Request_URI \.(?:gif|jpe?g|png|web[pm]|woff2?)$ no-brotli
+SetEnvIfExpr "%{QUERY_STRING} =~ /(?:^|&)_action=plugin\.zipdownload\.(?:attachments|messages)(?:&|$)/" no-brotli
 </IfModule>
 
 <IfModule mod_expires.c>


### PR DESCRIPTION
(Extracted from #10175.)

This includes several improvements to zipdownload. Feel free to cherry-pick what looks useful, or ask me to split this into multiple PRs, or whatever makes most sense.

 * Currently the entire zip is written to the output buffer before sending which can easily cause an OOM. Instead, flush every 512 KiB.
 * Update the `.htaccess`, see 9bd686c for details.
 * For maildir exports, change the modified-time of each `.eml` file to the IMAP internal time to allow sorting extracted emails.
 * Change the default charset in the config to UTF-8, see a6b857f.
