### PR TITLE
Fix example_addressbook search() reporting zero results despite matches (#9022)

### DIFF
--- a/plugins/example_addressbook/example_addressbook_backend.php
+++ b/plugins/example_addressbook/example_addressbook_backend.php
@@ -144,6 +144,7 @@ class example_addressbook_backend extends rcube_addressbook
 
                 if ($found) {
                     $result->add($record);
+                    $result->count++;
                 }
             }
         }

--- a/plugins/example_addressbook/tests/ExampleAddressbookTest.php
+++ b/plugins/example_addressbook/tests/ExampleAddressbookTest.php
@@ -32,4 +32,20 @@ class ExampleAddressbookTest extends TestCase
 
         $this->assertSame('static', $result['sources']['static']['id']);
     }
+
+    /**
+     * Test search()
+     */
+    public function test_search()
+    {
+        $backend = new \example_addressbook_backend('static');
+
+        // "Jane" matches only the Jane Example record
+        $result = $backend->search(['name'], 'Jane');
+
+        $this->assertInstanceOf('rcube_result_set', $result);
+        $this->assertCount(1, $result->records);
+        $this->assertSame(1, $result->count);
+        $this->assertSame('112', $result->records[0]['ID']);
+    }
 }


### PR DESCRIPTION
## Problem

Searching an address book provided by the `example_addressbook` plugin returned no results in the UI even when records matched the query. The plugin serves as the reference implementation for custom address book backends, so the bug also misleads plugin authors who copy it.

## Root cause

In `plugins/example_addressbook/example_addressbook_backend.php`, `search()` (line ~146) adds each matching record to the result set via `$result->add($record)`, but `rcube_result_set::add()` only appends to `records` — it does not update `count`. The result set is constructed with the default `count = 0` and that value is never updated, so the caller sees `count === 0` and treats the search as empty, regardless of how many records were actually matched.

## Fix

Increment `$result->count` alongside each `$result->add($record)` in `search()`, mirroring the counting pattern already used in the backend's `count()` and `get_record()` methods.

## Testing

Added `test_search()` in `plugins/example_addressbook/tests/ExampleAddressbookTest.php`, which searches for a value matching exactly one of the static demo records and asserts both `records` and `count`. The test fails on unmodified code (`count` is 0, expected 1) and passes with the fix. The full test file passes (3 tests) and phpstan (level 4) reports no new errors on the changed file.

Fixes #9022