### PR TITLE
Fix vCard import mis-detecting folded continuation lines as BEGIN/END:VCARD (#9593)

### DIFF
--- a/program/lib/Roundcube/rcube_vcard.php
+++ b/program/lib/Roundcube/rcube_vcard.php
@@ -562,6 +562,13 @@ class rcube_vcard
                 $vcard_block .= $line . "\n";
             }
 
+            // A folded/continuation line starts with whitespace (RFC 2426) and
+            // must never be mistaken for a block boundary. It is already kept as
+            // content above, so skip the boundary checks for it.
+            if (isset($line[0]) && ($line[0] === ' ' || $line[0] === "\t")) {
+                continue;
+            }
+
             $line = trim($line);
 
             if (preg_match('/^END:VCARD$/i', $line)) {

--- a/tests/Framework/VCardTest.php
+++ b/tests/Framework/VCardTest.php
@@ -250,4 +250,39 @@ class VCardTest extends TestCase
 
         $this->assertSame($result, "BEGIN:VCARD\r\nVERSION:3.0\r\nFN:\r\nN:;;;;\r\nEND:VCARD");
     }
+
+    /**
+     * A folded continuation line whose content equals END:VCARD (or surrounding
+     * whitespace around the real boundary) must not break block detection (#9593)
+     */
+    public function test_import_continuation_endvcard()
+    {
+        // The NOTE value is folded (RFC 2426) so its continuation line starts
+        // with a space and reads " END:VCARD". It must not end the first card,
+        // and the following card must still be detected.
+        $input = "BEGIN:VCARD\r\n"
+            . "VERSION:3.0\r\n"
+            . "FN:First Card\r\n"
+            . "N:Card;First;;;\r\n"
+            . "NOTE:This note folds onto a line reading\r\n"
+            . " END:VCARD\r\n"
+            . "EMAIL:first@example.com\r\n"
+            . "END:VCARD\r\n"
+            . "BEGIN:VCARD\r\n"
+            . "VERSION:3.0\r\n"
+            . "FN:Second Card\r\n"
+            . "N:Card;Second;;;\r\n"
+            . "END:VCARD\r\n";
+
+        $vcards = \rcube_vcard::import($input);
+
+        $this->assertCount(2, $vcards, 'Both vcards detected despite folded END:VCARD');
+        $this->assertSame('First Card', $vcards[0]->displayname, 'First card parsed fully');
+        $this->assertSame('Second Card', $vcards[1]->displayname, 'Second card still detected');
+
+        $assoc = $vcards[0]->get_assoc();
+        // The folded line is unfolded (RFC 2426 strips the single leading space).
+        $this->assertSame('This note folds onto a line readingEND:VCARD', $assoc['notes'][0], 'Folded NOTE value preserved');
+        $this->assertSame('first@example.com', $assoc['email:other'][0], 'EMAIL after folded line preserved');
+    }
 }


### PR DESCRIPTION
## Problem

When importing a vCard whose property value (e.g. NOTE) is folded onto a continuation line and that continuation line, after trimming, reads `END:VCARD` (or `BEGIN:VCARD`), the importer prematurely closes the current card and splits it into multiple bogus records. Per RFC 2426, folded lines begin with a space or tab, but the importer stripped that leading whitespace before checking for block boundaries.

## Root cause

`rcube_vcard::import()` (program/lib/Roundcube/rcube_vcard.php:565-583) appends the raw line to the current block, then does `$line = trim($line)` and matches the trimmed line against `/^END:VCARD$/i` and `/^BEGIN:VCARD$/i`. A folded continuation line such as ` END:VCARD` becomes `END:VCARD` after trimming and is wrongly treated as a block boundary.

## Fix

Before trimming, record whether the line began with whitespace (`$is_folded`), which per RFC 2426 marks a continuation line. Skip the BEGIN/END boundary checks for folded lines. The trim is still used for the comparison so trailing whitespace around a real boundary is tolerated, and the raw line remains preserved as block content (it is appended before the trim), so folded values are unfolded normally.

## Testing

Added `VCardTest::test_import_continuation_endvcard`, which imports a card whose NOTE folds onto a ` END:VCARD` line followed by a second card. It asserts exactly two cards are detected, the first card's NOTE and trailing EMAIL are preserved, and the second card still parses. The test fails on unmodified code (3 cards detected) and passes after the fix. The full VCardTest suite (15 tests) passes, and phpstan level 4 reports no new errors.

Fixes #9593