### PR TITLE
Managesieve: preserve an explicitly-selected i;ascii-casemap comparator (#9981)

### DIFF
--- a/plugins/managesieve/lib/Roundcube/rcube_sieve_script.php
+++ b/plugins/managesieve/lib/Roundcube/rcube_sieve_script.php
@@ -1052,10 +1052,11 @@ class rcube_sieve_script
             $exts[] = 'comparator-' . $test['comparator'];
         }
 
-        // skip default comparator
-        if ($test['comparator'] != 'i;ascii-casemap') {
-            $out .= ' :comparator ' . self::escape_string($test['comparator']);
-        }
+        // Emit the comparator. 'i;ascii-casemap' is the RFC default, but when
+        // it is present in the test it was set explicitly (the parser and the
+        // engine only populate 'comparator' on an explicit selection), so it
+        // must be preserved to reflect the user's choice and survive round-trips (#9981).
+        $out .= ' :comparator ' . self::escape_string($test['comparator']);
     }
 
     /**

--- a/plugins/managesieve/tests/ManagesieveScriptTest.php
+++ b/plugins/managesieve/tests/ManagesieveScriptTest.php
@@ -99,6 +99,39 @@ class ManagesieveScriptTest extends TestCase
         ];
     }
 
+    /**
+     * An explicitly selected 'i;ascii-casemap' comparator must be preserved
+     * on output and survive a round-trip (#9981).
+     */
+    public function test_explicit_ascii_casemap_comparator()
+    {
+        $input = "require [\"comparator-i;ascii-casemap\"];\r\n"
+            . "if header :comparator \"i;ascii-casemap\" :contains \"Subject\" \"test\"\r\n{\r\n\tdiscard;\r\n}\r\n";
+
+        $script = new \rcube_sieve_script($input, ['comparator-i;ascii-casemap']);
+        $result = $script->as_text();
+
+        // The explicit comparator must be emitted, not silently dropped
+        $this->assertStringContainsString(':comparator "i;ascii-casemap"', $result);
+
+        // And it must survive a round-trip (re-parse of the generated text)
+        $script2 = new \rcube_sieve_script($result, ['comparator-i;ascii-casemap']);
+        $this->assertStringContainsString(':comparator "i;ascii-casemap"', $script2->as_text());
+    }
+
+    /**
+     * When no comparator is explicitly set, none is emitted (#9981).
+     */
+    public function test_default_comparator_not_emitted()
+    {
+        $input = "if header :contains \"Subject\" \"test\"\r\n{\r\n\tdiscard;\r\n}\r\n";
+
+        $script = new \rcube_sieve_script($input);
+        $result = $script->as_text();
+
+        $this->assertStringNotContainsString(':comparator', $result);
+    }
+
     public function test_escape_string()
     {
         $output = \rcube_sieve_script::escape_string([]);

--- a/plugins/managesieve/tests/src/parser.out
+++ b/plugins/managesieve/tests/src/parser.out
@@ -6,7 +6,7 @@ if header :contains "X-DSPAM-Result" "Spam"
 	stop;
 }
 # rule:[test1]
-if header :contains ["From","To"] "test@domain.tld"
+if header :contains :comparator "i;ascii-casemap" ["From","To"] "test@domain.tld"
 {
 	discard;
 	stop;


### PR DESCRIPTION
## Problem

When a user explicitly selects the `i;ascii-casemap` comparator for a filter test, the choice is silently dropped from the generated Sieve script. The saved rule therefore does not reflect the explicit selection, and re-parsing/re-saving the script loses it entirely (round-trip loss). See #9981.

## Root cause

`plugins/managesieve/lib/Roundcube/rcube_sieve_script.php`, `add_comparator()` (previously ~line 1056):

```php
// skip default comparator
if ($test['comparator'] != 'i;ascii-casemap') {
    $out .= ' :comparator ' . self::escape_string($test['comparator']);
}
```

Because `i;ascii-casemap` is the RFC 5228 default comparator, the code unconditionally suppressed it on output. However, both the parser (`test_tokens()`) and the engine (`rcube_sieve_engine.php:1015`, only sets `comparator` when the user picked one) populate the `comparator` key **only** on an explicit selection — an unset comparator leaves the key empty and is already short-circuited by the `empty()` guard at the top of `add_comparator()`. So the presence of `comparator == 'i;ascii-casemap'` unambiguously means "the user chose it", yet it was still discarded.

## Fix

Emit the comparator whenever it is present. The existing `empty()` guard still means the default (unset) case emits nothing, so scripts without an explicit comparator are unchanged. Behavior for `i;octet` and `i;ascii-numeric` is unchanged, and `i;ascii-casemap` continues to be excluded from the `require`/extensions list (it is a built-in comparator requiring no capability).

## Testing

Added two focused tests in `plugins/managesieve/tests/ManagesieveScriptTest.php`:

- `test_explicit_ascii_casemap_comparator` — parses a rule with an explicit `:comparator "i;ascii-casemap"`, asserts `as_text()` emits it, and asserts it survives a re-parse round-trip. Fails on current master, passes after the fix.
- `test_default_comparator_not_emitted` — asserts that a rule with no explicit comparator emits no `:comparator` token (guards against regression).

The existing `parser`/`parser.out` fixture was updated to reflect the corrected (non-lossy) output for its explicit `i;ascii-casemap` case. Full `ManagesieveScriptTest` suite passes (35 tests). phpstan level 4 on the changed file reports no errors.

Fixes #9981