### PR TITLE
OAuth: don't log an error when a refreshed token's TTL is below refresh_interval (#10213)

### DIFF
--- a/program/include/rcmail_oauth.php
+++ b/program/include/rcmail_oauth.php
@@ -905,7 +905,9 @@ class rcmail_oauth
             // refresh_token is optional, there will be no refreshes
             $data['expires'] = time() + $data['expires_in'] - 5;
         } elseif ($data['expires_in'] <= $refresh_interval) {
-            rcube::raise_error(sprintf('Token TTL (%s) is smaller than refresh_interval (%s)', $data['expires_in'], $refresh_interval), true);
+            // short-lived token: it expires before the next refresh interval would trigger.
+            // This is an expected case, so only log it at debug level (not as an error).
+            $this->log_debug('token TTL (%s) is smaller than refresh_interval (%s)', $data['expires_in'], $refresh_interval);
             // note: remove 10 sec by security (avoid tangent issues)
             $data['expires'] = time() + $data['expires_in'] - 10;
         } else {

--- a/tests/Rcmail/OauthTest.php
+++ b/tests/Rcmail/OauthTest.php
@@ -302,6 +302,50 @@ class OauthTest extends ActionTestCase
     }
 
     /**
+     * Test request_access_token() with a short-lived token (expires_in <= refresh_interval).
+     *
+     * This is a normal case for short-lived tokens and must not emit an error-level log.
+     */
+    public function test_request_access_token_short_lived()
+    {
+        $payload = [
+            'token_type' => 'Bearer',
+            'access_token' => 'FAKE-ACCESS-TOKEN',
+            'expires_in' => 30, // below the default refresh_interval (60)
+            'refresh_token' => 'FAKE-REFRESH-TOKEN',
+            'refresh_expires_in' => 1800,
+            'id_token' => $this->generate_fake_id_token(), // inject a generated identity
+            'not-before-policy' => 0,
+            'session_state' => 'fake-session',
+            'scope' => 'openid profile email',
+        ];
+
+        HttpClientMock::setResponses([
+            [200, ['Content-Type' => 'application/json'], json_encode($payload)],
+        ]);
+
+        $oauth = new \rcmail_oauth((array) $this->config);
+        $oauth->init();
+
+        $_SESSION['oauth_state'] = 'random-state'; // ensure state identiquals
+        $_SESSION['oauth_nonce'] = 'fake-nonce';
+
+        StderrMock::start();
+        $response = $oauth->request_access_token('fake-code', 'random-state');
+        StderrMock::stop();
+
+        $this->assertTrue($response);
+
+        // A short-lived token is a normal case and must not raise an error
+        $this->assertSame('', trim(StderrMock::$output));
+
+        $login_phase = getProperty($oauth, 'login_phase');
+
+        $this->assertSame('Bearer FAKE-ACCESS-TOKEN', $login_phase['authorization']);
+        $this->assertTrue(isset($login_phase['token']['expires']));
+    }
+
+    /**
      * Test request_access_token() method without identity, code will have to fetch the identity using the access token
      */
     public function test_request_access_token_without_id_token()


### PR DESCRIPTION
## Problem

Every time a valid token grant is parsed for a provider that issues short-lived tokens (`expires_in` less than or equal to the configured `refresh_interval`, default 60s), Roundcube writes a scary error line to the log, e.g.:

```
ERROR: Token TTL (30) is smaller than refresh_interval (60)
```

This is a normal, expected situation for short-lived tokens — the response is valid and tokens parse correctly — yet it produces an error-level log entry on every login and every refresh, polluting logs and triggering error monitoring.

## Root cause

In `program/include/rcmail_oauth.php`, `parse_tokens()` (line 907-908) unconditionally calls `rcube::raise_error(..., true)` in the `expires_in <= refresh_interval` branch. `raise_error(..., $log=true)` logs at error level, even though this branch is a normal case, not a failure. The code still computes a valid `expires` value (`time() + expires_in - 10`) right after, so nothing actually went wrong.

## Fix

Replace the `rcube::raise_error(..., true)` call with `$this->log_debug(...)`, which only writes when OAuth debug logging is enabled and never emits an error. The refresh-timing computation is unchanged, and genuine error paths in `parse_tokens()` (missing `access_token`, nonce mismatch) are untouched.

## Testing

Added `test_request_access_token_short_lived` in `tests/Rcmail/OauthTest.php`, modeled on the existing `test_request_access_token`, with `expires_in` = 30 (below the default `refresh_interval` of 60). It captures stderr via `StderrMock` and asserts no error is logged while the token still parses (authorization set, `expires` computed). The test fails on current master (`ERROR: Token TTL (30) is smaller than refresh_interval (60)`) and passes with this change.

phpstan (level 4) on the changed file reports no errors.

Fixes #10213