### PR TITLE
Fix decoding of multi-segment RFC2231 extended attachment filenames

### DIFF
--- a/program/lib/Roundcube/rcube_mime_decode.php
+++ b/program/lib/Roundcube/rcube_mime_decode.php
@@ -292,12 +292,18 @@ class rcube_mime_decode
                     $return['other'][strtolower($matches[1])] = $matches[2];
                 }
                 // Support RFC2231 encoding
-                elseif (preg_match('/^([[:alnum:]]+)\*([0-9]*)\*?="*([^"]+)"*/', $parts[$n], $matches)) {
+                elseif (preg_match('/^([[:alnum:]]+)\*([0-9]*)(\*?)="*([^"]+)"*/', $parts[$n], $matches)) {
                     $key = strtolower($matches[1]);
-                    $val = $matches[3];
+                    $val = $matches[4];
+                    // A trailing '*' marks an extended (percent-encoded) parameter
+                    $extended = $matches[3] === '*';
 
                     if (preg_match("/^(([^']*)'[^']*')/", $val, $m)) {
+                        // First segment carries the charset'lang' prefix
                         $val = rawurldecode(substr($val, strlen($m[0])));
+                    } elseif ($extended) {
+                        // Continuation segment of an extended parameter
+                        $val = rawurldecode($val);
                     }
 
                     if (isset($return['other'][$key])) {

--- a/tests/Framework/MimeDecodeTest.php
+++ b/tests/Framework/MimeDecodeTest.php
@@ -36,4 +36,45 @@ class MimeDecodeTest extends TestCase
         $this->assertSame('text/plain', $result->parts[2]->mimetype);
         $this->assertSame('lines_lf.txt', $result->parts[2]->filename);
     }
+
+    /**
+     * Test decoding of a multi-segment RFC2231 extended (encoded) filename.
+     * Both the first segment (with charset'lang' prefix) and the continuation
+     * segments must be rawurldecode()'d before concatenation.
+     */
+    public function test_decode_rfc2231_extended_continuation()
+    {
+        $mail = "Content-Type: text/plain\r\n"
+            . "Content-Disposition: attachment;\r\n"
+            . " filename*0*=UTF-8''%e2%82%ac;\r\n"
+            . " filename*1*=%e2%82%ac\r\n"
+            . "\r\n"
+            . "body\r\n";
+
+        $decoder = new \rcube_mime_decode();
+        $result = $decoder->decode($mail);
+
+        // Two euro signs, fully decoded (not left percent-encoded)
+        $this->assertSame("\xe2\x82\xac\xe2\x82\xac", $result->filename);
+    }
+
+    /**
+     * Test that plain (non-extended) RFC2231 continuation segments are kept
+     * literal and not rawurldecode()'d.
+     */
+    public function test_decode_rfc2231_plain_continuation()
+    {
+        $mail = "Content-Type: text/plain\r\n"
+            . "Content-Disposition: attachment;\r\n"
+            . " filename*0=a%20;\r\n"
+            . " filename*1=b\r\n"
+            . "\r\n"
+            . "body\r\n";
+
+        $decoder = new \rcube_mime_decode();
+        $result = $decoder->decode($mail);
+
+        // Plain continuations are literal; the "%20" must NOT be decoded
+        $this->assertSame('a%20b', $result->filename);
+    }
 }


### PR DESCRIPTION
## Problem

An attachment whose filename is split across multiple RFC2231 extended (percent-encoded) parameters is decoded only in its first segment; the continuation segments remain percent-encoded, producing a corrupted filename.

Example header:

```
Content-Disposition: attachment;
 filename*0*=UTF-8''%e2%82%ac;
 filename*1*=%e2%82%ac
```

was decoded to `€%e2%82%ac` instead of `€€`.

## Root cause

`rcube_mime_decode::parseHeaderValue()` (program/lib/Roundcube/rcube_mime_decode.php:295-307) applied `rawurldecode()` only when a segment carried the `charset'lang'` prefix (matched at line 299), which is present only on the first segment (`filename*0*`). Continuation segments (`filename*1*`, `filename*2*`, …) have no such prefix and fell through with their value appended raw, still percent-encoded.

## Fix

The parameter regex now captures the trailing `*` that marks an extended (percent-encoded) parameter. Continuation segments of an extended parameter are `rawurldecode()`'d before concatenation. Plain (non-extended) continuations (`filename*0=`, no trailing star) are still treated as literal and are not decoded, per RFC2231.

## Testing

Added `tests/Framework/MimeDecodeTest.php` cases:
- `test_decode_rfc2231_extended_continuation`: multi-segment `filename*0*`/`filename*1*` assembles to the fully decoded value (fails before the fix, passes after).
- `test_decode_rfc2231_plain_continuation`: plain `filename*0`/`filename*1` continuation stays literal (`%20` not decoded).

Full `MimeDecodeTest` passes (3 tests, 14 assertions); phpstan level 4 on the changed file reports no errors.