### PR TITLE
Fix out-of-bounds string reads on truncated compressed-RTF in the TNEF decoder

### DIFF
--- a/program/lib/Roundcube/rcube_tnef_decoder.php
+++ b/program/lib/Roundcube/rcube_tnef_decoder.php
@@ -520,6 +520,12 @@ class rcube_tnef_decoder
         }
 
         while ($out < ($size + $length_preload)) {
+            // Bail out if the input is exhausted to avoid out-of-bounds reads
+            // on truncated/malformed payloads.
+            if ($in >= $max_len) {
+                break;
+            }
+
             if (($flag_count++ % 8) == 0) {
                 $flags = ord($data[$in++]);
             } else {
@@ -527,6 +533,11 @@ class rcube_tnef_decoder
             }
 
             if (($flags & 1) != 0) {
+                // The back-reference branch reads two more bytes.
+                if ($in + 1 >= $max_len) {
+                    break;
+                }
+
                 $offset = ord($data[$in++]);
                 $length = ord($data[$in++]);
                 $offset = ($offset << 4) | ($length >> 4);
@@ -544,12 +555,13 @@ class rcube_tnef_decoder
                     $out++;
                 }
             } else {
+                // The literal branch reads one more byte.
+                if ($in >= $max_len) {
+                    break;
+                }
+
                 $uncomp .= $data[$in++];
                 $out++;
-            }
-
-            if ($in >= $max_len) {
-                break;
             }
         }
 

--- a/tests/Framework/TnefDecoderTest.php
+++ b/tests/Framework/TnefDecoderTest.php
@@ -81,6 +81,42 @@ class TnefDecoderTest extends TestCase
     }
 
     /**
+     * Test that a truncated compressed-RTF payload does not cause
+     * out-of-bounds string reads (PHP warnings) in _decompressRTF().
+     */
+    public function test_decompressRTF_truncated()
+    {
+        $tnef = new \rcube_tnef_decoder();
+
+        $method = new \ReflectionMethod('rcube_tnef_decoder', '_decompressRTF');
+
+        // First byte is a flags byte with bit 0 set, so the back-reference
+        // branch is taken. The branch needs two more bytes (offset + length),
+        // but the payload is truncated right after the flags byte. On
+        // unmodified code this triggers "Uninitialized string offset" warnings.
+        $truncated = [
+            "\x01",           // flags byte only, no data follows
+            "\x01\x00",       // flags + offset, length byte missing
+            "\x00\x00",       // literal branch, then out of data mid-loop
+        ];
+
+        // Turn PHP warnings/notices into exceptions so we can assert cleanly.
+        set_error_handler(static function ($errno, $errstr) {
+            throw new \ErrorException($errstr, 0, $errno);
+        });
+
+        try {
+            foreach ($truncated as $data) {
+                // A large $size forces the loop to keep consuming input.
+                $result = $method->invoke($tnef, $data, 1000);
+                $this->assertIsString($result);
+            }
+        } finally {
+            restore_error_handler();
+        }
+    }
+
+    /**
      * Test rtf2text()
      */
     public function test_rtf2text()


### PR DESCRIPTION
## Problem

`rcube_tnef_decoder::_decompressRTF()` reads compressed-RTF input byte by byte with `ord($data[$in++])`. On truncated or otherwise malformed compressed-RTF payloads the read index `$in` can advance past the end of the input within a single loop iteration, producing "Uninitialized string offset" PHP warnings (and reading out of bounds). The recent compressed-size sanity check (commit ed56e0855) did not close this: the only input-exhaustion guard was placed at the *bottom* of the loop, so multiple `ord($data[$in++])` reads in the back-reference branch — and the next iteration's flags read — could still run past `strlen($data)`.

## Root cause

`program/lib/Roundcube/rcube_tnef_decoder.php`, in `_decompressRTF()`: the `if ($in >= $max_len) break;` check sat at the end of the `while` body (previously ~line 551). Within one iteration the code performs up to three separate reads (flags byte, then offset+length in the back-reference branch), and the trailing check does not prevent the next iteration's `ord($data[$in++])` flags read when `$in` has already reached `$max_len`.

## Fix

Move the input-exhaustion check to the top of the loop and add a per-branch guard verifying that the required bytes remain before each read:
- top of loop: `if ($in >= $max_len) break;` (covers the flags read)
- back-reference branch: `if ($in + 1 >= $max_len) break;` (needs two more bytes)
- literal branch: `if ($in >= $max_len) break;` (needs one more byte)

Decompression output for valid input is unchanged.

## Testing

Added `TnefDecoderTest::test_decompressRTF_truncated`, which feeds several truncated compressed-RTF payloads to `_decompressRTF()` with an error handler that promotes PHP warnings to exceptions. The test fails on current master ("Uninitialized string offset" at the flags read) and passes with the fix. The full `tests/Framework/TnefDecoderTest.php` suite (5 tests, 51 assertions) passes, and phpstan (level 4) reports no new errors on the changed file.