### PR TITLE
Fix out-of-bounds read in vCard QUOTED-PRINTABLE soft-line-break handling

### DIFF
--- a/program/lib/Roundcube/rcube_vcard.php
+++ b/program/lib/Roundcube/rcube_vcard.php
@@ -755,7 +755,7 @@ class rcube_vcard
                             $value = strtoupper($value);
                             // add next line(s) to value string if QP line end detected
                             if ($value == 'QUOTED-PRINTABLE') {
-                                while (preg_match('/=$/', $lines[$i])) {
+                                while (isset($lines[$i]) && preg_match('/=$/', $lines[$i]) && isset($lines[$i + 1])) {
                                     $data .= "\n" . $lines[++$i];
                                 }
                             }
@@ -1049,7 +1049,7 @@ class rcube_vcard
                 $enc = $matches ? strtoupper($matches[1]) : 'BASE64';
                 // add next line(s) to value string if QP line end detected
                 if ($enc == 'QUOTED-PRINTABLE') {
-                    while (preg_match('/=$/', $lines[$i])) {
+                    while (isset($lines[$i]) && preg_match('/=$/', $lines[$i]) && isset($lines[$i + 1])) {
                         $data .= "\n" . $lines[++$i];
                     }
                 }

--- a/tests/Framework/VCardTest.php
+++ b/tests/Framework/VCardTest.php
@@ -103,6 +103,36 @@ class VCardTest extends TestCase
     }
 
     /**
+     * A QUOTED-PRINTABLE soft-line-break ('=') on the very last line must not
+     * cause reading past the end of the internal lines array.
+     */
+    public function test_parse_qp_soft_break_on_last_line()
+    {
+        $errors = [];
+        set_error_handler(static function ($errno, $errstr) use (&$errors) {
+            $errors[] = $errstr;
+
+            return true;
+        });
+
+        try {
+            // Last line ends with '=' (QP soft line break) with no following line
+            $vcard_string = "BEGIN:VCARD\r\n"
+                . "VERSION:3.0\r\n"
+                . "FN:Test\r\n"
+                . 'NOTE;ENCODING=QUOTED-PRINTABLE:Hello=';
+
+            $vcard = new \rcube_vcard($vcard_string, null, true);
+            $result = $vcard->get_assoc();
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame([], $errors, 'No PHP warnings/errors while decoding');
+        $this->assertSame('Hello', $result['notes'][0], 'Best-effort QP decode of the dangling line');
+    }
+
+    /**
      * Extra whitespace at start of continuation line (#9593/1).
      */
     public function test_parse_continuation_line_with_initial_whitespace()


### PR DESCRIPTION
## Problem

Parsing a vCard whose final line uses a QUOTED-PRINTABLE soft line break (a line ending with `=`) triggers PHP "Undefined array key" warnings and a downstream `preg_match(): Passing null` deprecation. Under the test suite's `failOnWarning`/`failOnNotice` settings this is an outright failure; in production it emits warnings on untrusted input.

## Root cause

`program/lib/Roundcube/rcube_vcard.php` has two QUOTED-PRINTABLE continuation loops that append the next line while the current line ends with `=`:

- `vcard_decode()` at line 758
- `detect_encoding()` at line 1052

Both were written as `while (preg_match('/=$/', $lines[$i])) { $data .= "\n" . $lines[++$i]; }`. When the last element of `$lines` ends with `=`, `$lines[++$i]` reads past the end of the array. The loop also re-checks `$lines[$i]` (now unset) on the next iteration, producing repeated warnings and passing `null` to `preg_match`.

## Fix

Bound both loops so they never advance past the last element:

```php
while (isset($lines[$i]) && preg_match('/=$/', $lines[$i]) && isset($lines[$i + 1])) {
    $data .= "\n" . $lines[++$i];
}
```

This keeps the existing best-effort decode behaviour (a dangling `=` on the last line is simply left as the end of the value) while eliminating the out-of-bounds access. The same guard is applied in both `vcard_decode()` and `detect_encoding()`.

## Testing

Added `test_parse_qp_soft_break_on_last_line` in `tests/Framework/VCardTest.php`, which decodes a vCard whose final QUOTED-PRINTABLE line ends with `=`, asserts no PHP warnings/errors are raised (via a temporary error handler), and checks the best-effort decoded value. The test fails on unmodified code (three PHP diagnostics) and passes with the fix. The full `VCardTest` file (15 tests, 40 assertions) passes, and phpstan level 4 reports no errors on the changed file.