### PR TITLE
Fix vCard import silently dropping properties with a non-item group prefix

### DIFF
--- a/program/lib/Roundcube/rcube_vcard.php
+++ b/program/lib/Roundcube/rcube_vcard.php
@@ -605,7 +605,7 @@ class rcube_vcard
                 // convert special types (like Skype) to normal type='skype' classes with this simple regex ;)
                 '/item(\d+)\.(TEL|EMAIL|URL)([^:]*?):(.*?)item\1.X-ABLabel:(?:_\$!<)?([\w() -]*)(?:>!\$_)?./si',
                 '/^item\d*\.X-AB.*$/mi',  // remove cruft like item1.X-AB*
-                '/^item\d*\./mi',         // remove item1.ADR instead of ADR
+                '/^[a-z0-9-]+\./mi',      // strip RFC 6350 group prefix, e.g. item1.ADR or HOME.EMAIL becomes ADR/EMAIL
                 '/\n+/',                  // remove empty lines
                 '/^(N:[^;\r\n]*)$/m',     // if N doesn't have any semicolons, add some
             ],

--- a/tests/Framework/VCardTest.php
+++ b/tests/Framework/VCardTest.php
@@ -103,6 +103,30 @@ class VCardTest extends TestCase
     }
 
     /**
+     * RFC 6350 allows any group name as a 'group.' prefix on properties
+     * (e.g. HOME.EMAIL or group1.TEL), not only the Apple-style 'item\d.'
+     * prefix. Such grouped properties must be parsed, not silently dropped.
+     */
+    public function test_parse_group_prefix()
+    {
+        $vcard = new \rcube_vcard("BEGIN:VCARD\n"
+            . "VERSION:3.0\n"
+            . "N:Doe;Jane;;;\n"
+            . "FN:Jane Doe\n"
+            . "HOME.EMAIL:jane@example.com\n"
+            . "group1.TEL:+1234567890\n"
+            . 'END:VCARD'
+        );
+
+        $this->assertSame('jane@example.com', $vcard->email[0], 'Parse group-prefixed EMAIL');
+
+        $result = $vcard->get_assoc();
+
+        $this->assertSame('jane@example.com', $result['email:other'][0], 'Group-prefixed EMAIL in assoc data');
+        $this->assertSame('+1234567890', $result['phone:other'][0], 'Group-prefixed TEL in assoc data');
+    }
+
+    /**
      * Extra whitespace at start of continuation line (#9593/1).
      */
     public function test_parse_continuation_line_with_initial_whitespace()


### PR DESCRIPTION
## Problem

RFC 6350 permits any group name as a `group.` prefix on a vCard property (e.g. `HOME.EMAIL:...`, `group1.TEL:...`). Roundcube only recognized Apple's `item\d.` prefix, so a property carrying any other group prefix was silently dropped on import: the email/phone/etc. never appeared in the parsed record.

## Root cause

`rcube_vcard::cleanup()` (program/lib/Roundcube/rcube_vcard.php:608) stripped only the `item\d*.` prefix from property lines. Any surviving `group.` prefix (e.g. `HOME.EMAIL`) was carried into `vcard_decode()`, which then keyed the value under the literal field name `HOME.EMAIL` instead of `EMAIL`. Since that field is not in the fieldmap, the value was discarded.

## Fix

Generalize the prefix-stripping regex in `cleanup()` from `/^item\d*\./mi` to `/^[a-z0-9-]+\./mi`, so any RFC 6350 group prefix at the start of a line is removed before decoding. This runs after the existing Apple-specific `X-ABRELATEDNAMES` / `X-ABLabel` handling and after the `item\d*.X-AB*` cruft removal, so item-prefixed Apple label pairing is unaffected. Group names never contain dots and continuation lines begin with whitespace, so the pattern only matches genuine group prefixes.

## Testing

Added `test_parse_group_prefix` in tests/Framework/VCardTest.php, importing a vCard with `HOME.EMAIL:` and `group1.TEL:` and asserting both are parsed into the record (`$vcard->email[0]`, and `email:other` / `phone:other` in `get_assoc()`). The test fails on unmodified code and passes after the fix. The full VCardTest suite (15 tests, incl. the existing `ITEM1.`-prefixed address case) passes, and phpstan level 4 reports no new errors.