### PR TITLE
Elastic: Show contact photo in recipient autocomplete list

### DIFF
--- a/program/actions/mail/autocomplete.php
+++ b/program/actions/mail/autocomplete.php
@@ -88,6 +88,19 @@ class rcmail_action_mail_autocomplete extends rcmail_action
                                 // groups with defined email address will not be expanded to its members' addresses
                                 if ($contact['type'] == 'group') {
                                     $contact['email'] = $email;
+                                } elseif (!empty($record['photo'])) {
+                                    $photo = is_array($record['photo']) ? $record['photo'][0] : $record['photo'];
+
+                                    // skip photos stored as an external URL to avoid triggering
+                                    // an automatic, silent request to a third-party host on every keystroke
+                                    if (!empty($photo) && !preg_match('!^https?://!i', $photo)) {
+                                        $contact['photo'] = $rcmail->url([
+                                            '_task' => 'addressbook',
+                                            '_action' => 'photo',
+                                            '_source' => $abook_id,
+                                            '_cid' => $record['ID'],
+                                        ]);
+                                    }
                                 }
 
                                 $name = !empty($contact['fields']['name']) ? $contact['fields']['name'] : $name;

--- a/program/js/app.js
+++ b/program/js/app.js
@@ -6266,7 +6266,7 @@ function rcube_webmail() {
         }
 
         // display search results
-        var i, id, len, ul, text, type, init,
+        var i, id, len, ul, text, type, photo, init,
             is_framed = this.is_framed(),
             value = this.ksearch_value,
             maxlen = this.env.autocomplete_max ? this.env.autocomplete_max : 15;
@@ -6341,9 +6341,10 @@ function rcube_webmail() {
                 text = typeof results[i] === 'object' ? (results[i].display || results[i].name) : results[i];
                 fields = typeof results[i] === 'object' && results[i].fields ? results[i].fields : { name: text };
                 type = typeof results[i] === 'object' ? results[i].type : '';
+                photo = typeof results[i] === 'object' ? results[i].photo : null;
                 id = i + this.env.contacts.length;
                 $('<li>').attr({ id: 'rcmkSearchItem' + id, role: 'option' })
-                    .html(this.ksearch_results_display(fields, value))
+                    .html(this.ksearch_results_display(fields, value, photo))
                     .addClass(type || '')
                     .appendTo(ul)
                     .mouseover(function () {
@@ -6379,8 +6380,10 @@ function rcube_webmail() {
         }
     };
 
-    this.ksearch_results_display = function (fields, search_term) {
-        line = "<i class='icon'></i>{name} &lt;{email}&gt;";
+    this.ksearch_results_display = function (fields, search_term, photo) {
+        var icon = photo ? '<img class="icon contact-photo" src="' + this.quote_html(photo) + '" alt="" />' : "<i class='icon'></i>";
+
+        line = icon + '{name} &lt;{email}&gt;';
 
         $.each(fields, function (key, data) {
             line = line.replace('{' + key + '}', data ? ref.ksearch_results_highlight(data, search_term) : '');

--- a/skins/elastic/styles/widgets/lists.less
+++ b/skins/elastic/styles/widgets/lists.less
@@ -340,6 +340,12 @@ html.touch {
     &.group > i:before {
         content: @fa-var-users;
     }
+    & > img.contact-photo {
+        max-width: @listing-line-height;
+        max-height: @listing-line-height;
+        margin-left: .5rem;
+        margin-right: .25rem;
+    }
 }
 
 #rcmKSearchpane > ul > li {

--- a/skins/elastic/ui.js
+++ b/skins/elastic/ui.js
@@ -4454,9 +4454,11 @@ if (window.rcmail) {
     /**
      * Elastic version of ksearch_results_display with small screen support
      */
-    rcmail.ksearch_results_display = function (fields, search_term) {
+    rcmail.ksearch_results_display = function (fields, search_term, photo) {
         var line = $('<li>')
-            .append($('<i>').addClass('icon'))
+            .append(photo
+                ? $('<img>').addClass('icon contact-photo').attr({ src: photo, alt: '' })
+                : $('<i>').addClass('icon'))
             .append($('<span>').addClass('fields'));
 
         $.each(fields, function (key, data) {


### PR DESCRIPTION
## Summary
- Shows the contact's vCard photo instead of the generic person icon in the To/Cc/Bcc recipient autocomplete dropdown when composing, when a photo is available.
- The photo is already parsed on every autocomplete search (`rcube_contacts::search()` always reads the vCard), so this adds no extra query cost - `autocomplete.php` just exposes a URL to the existing `contacts/photo` action per matching contact.
- Photos stored as external `http(s)://` URLs are intentionally excluded: `contacts/photo.php` 302-redirects the browser to those, and attaching one here would fire a silent third-party request on every keystroke for any matching contact, rather than only when a contact/email is deliberately opened.
- Both `ksearch_results_display()` in `app.js` and Elastic's own override of it in `ui.js` (used for its small-screen layout) needed updating, since the skin's override completely replaces the base implementation.
- The photo is capped to the existing `.listing` row height (`@listing-line-height`) and keeps its natural aspect ratio rather than being cropped to a circle, consistent with how photos are shown elsewhere in the app (Contacts page, sender photo in message preview).
- Contacts without a photo, and group/distribution-list entries, keep the existing icon unchanged.

## Test plan
- [x] Verified via `php -l` and the project's `.php-cs-fixer.dist.php` config (0 fixable issues) for `autocomplete.php`
- [x] Verified via `eslint` (project config) for `app.js` and `ui.js`
- [x] Verified the `.less` change compiles cleanly via `lessc` against the full `styles.less` entry point
- [x] Manually tested end-to-end on a live instance: composing a message and searching for a contact with a vCard photo shows the photo in the dropdown; contacts without a photo and group entries still show the default icon
- [ ] Automated test coverage - none added; happy to add if maintainers want it