### PR TITLE
Password: Fix Zxcvbn class import in release-1.6

### DIFF
--- a/plugins/password/drivers/zxcvbn.php
+++ b/plugins/password/drivers/zxcvbn.php
@@ -1,5 +1,7 @@
 <?php
 
+use ZxcvbnPhp\Zxcvbn;
+
 /**
  * Zxcvb Password Strength Driver
  *


### PR DESCRIPTION
Fixes #10274

This backports the `ZxcvbnPhp\Zxcvbn` import already present in `master`
to `release-1.6`.

Without the import, the zxcvbn strength driver checks for the namespaced
class but instantiates `new Zxcvbn()`, causing a fatal error before the
password backend is reached.

The equivalent fully qualified instantiation was validated on Roundcube
1.6.17:

- PHP lint passed.
- The zxcvbn dependency loaded successfully.
- A password change returned HTTP 200 instead of HTTP 500.
- No PHP fatal, database error, or SQLSTATE error was logged.