### PR TITLE
Fix extra <div> tags accumulating on 'Edit as New' for HTML messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This file includes only changes we consider noteworthy for users, admins and plu
 - Fix bug where the php session driver practically disabled session.lazy_write optimization (#9885, #10248)
 - Fix bug where dates could get displayed shifted back one day in some places (#9403)
 - Fix regression where it wasn't possible to hide a skin logo image anymore (#10254)
+- Fix extra `<div>` tags accumulating in the HTML body on every "Edit as New" cycle (#9919)
 
 ## Release 1.7.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This file includes only changes we consider noteworthy for users, admins and plu
 - Preserve the original message date on import of EML messages (#5559, #10251)
 - OAuth: Validate JWT token signature (#10210)
 - Installer: Add possibility to detsroy the installer session/cookie
+- Fix extra `<div>` tags accumulating in the HTML body on every "Edit as New" cycle (#9919)
 
 ## Release 1.7.4
 

--- a/program/actions/mail/compose.php
+++ b/program/actions/mail/compose.php
@@ -998,10 +998,14 @@ class rcmail_action_mail_compose extends rcmail_action_mail_index
             'add_comments' => false,
         ];
 
-        if (self::$COMPOSE['mode'] == rcmail_sendmail::MODE_DRAFT) {
+        if (self::$COMPOSE['mode'] == rcmail_sendmail::MODE_DRAFT
+            || self::$COMPOSE['mode'] == rcmail_sendmail::MODE_EDIT
+        ) {
             // convert TinyMCE's empty-line sequence (#1490463)
             $body = preg_replace('/<p>\xC2\xA0<\/p>/', '<p><br /></p>', $body);
             // remove <body> tags (not their content)
+            // Note: do not wrap the body in a container element here, otherwise
+            // an extra <div> would accumulate on every edit/send cycle (#9919)
             $wash_params['ignore_elements'] = ['body'];
         } else {
             $wash_params['container_id'] = $container_id;

--- a/program/actions/mail/compose.php
+++ b/program/actions/mail/compose.php
@@ -1005,8 +1005,12 @@ class rcmail_action_mail_compose extends rcmail_action_mail_index
             $body = preg_replace('/<p>\xC2\xA0<\/p>/', '<p><br /></p>', $body);
             // remove <body> tags (not their content)
             // Note: do not wrap the body in a container element here, otherwise
-            // an extra <div> would accumulate on every edit/send cycle (#9919)
+            // an extra <div> would accumulate on every edit/send cycle (#9919).
+            // The body callback must be skipped too, otherwise it still wraps the
+            // (possibly style-carrying) <body> tag in a new <div> regardless of
+            // ignore_elements, since a registered callback takes precedence.
             $wash_params['ignore_elements'] = ['body'];
+            $wash_params['skip_washer_body_callback'] = true;
         } else {
             $wash_params['container_id'] = $container_id;
         }

--- a/program/actions/mail/index.php
+++ b/program/actions/mail/index.php
@@ -973,7 +973,9 @@ class rcmail_action_mail_index extends rcmail_action
         self::$wash_html_body_attrs = [];
 
         if (!empty($p['inline_html'])) {
-            $washer->add_callback('body', 'rcmail_action_mail_index::washtml_callback');
+            if (empty($p['skip_washer_body_callback'])) {
+                $washer->add_callback('body', 'rcmail_action_mail_index::washtml_callback');
+            }
 
             if ($wash_opts['body_class']) {
                 self::$wash_html_body_attrs['class'] = $wash_opts['body_class'];

--- a/tests/Actions/Mail/ComposeTest.php
+++ b/tests/Actions/Mail/ComposeTest.php
@@ -80,4 +80,23 @@ class ComposeTest extends ActionTestCase
         $this->assertStringContainsString('replybody', $result);
         $this->assertStringContainsString('Hello world', $result);
     }
+
+    /**
+     * Test that "Edit as New" (MODE_EDIT) does not wrap the body in a <div> even
+     * when the stored message's <body> tag carries a style attribute (as added by
+     * send.php's default_font/default_font_size wrapping on every send). Without
+     * this, the body callback still forwards the style attribute into a new <div>
+     * on every edit/send cycle, so the accumulation from #9919 continues, just
+     * without the "editbody" id (#9919).
+     */
+    public function test_prepare_html_body_edit_mode_strips_body_style()
+    {
+        $body = '<html><head></head><body style="font-size: 10pt; font-family: Verdana,Geneva,sans-serif;">'
+            . "\r\n<p>Hello world</p></body></html>";
+
+        $result = $this->invoke_prepare_html_body(\rcmail_sendmail::MODE_EDIT, $body);
+
+        $this->assertStringNotContainsString('<div', $result);
+        $this->assertStringContainsString('Hello world', $result);
+    }
 }

--- a/tests/Actions/Mail/ComposeTest.php
+++ b/tests/Actions/Mail/ComposeTest.php
@@ -4,6 +4,9 @@ namespace Roundcube\Tests\Actions\Mail;
 
 use Roundcube\Tests\ActionTestCase;
 
+use function Roundcube\Tests\invokeMethod;
+use function Roundcube\Tests\setProperty;
+
 /**
  * Test class to test rcmail_action_mail_compose
  */
@@ -37,5 +40,44 @@ class ComposeTest extends ActionTestCase
         $expected = ">> test1\n>> test2";
 
         $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Invoke prepare_html_body() with a given compose mode and HTML body
+     */
+    private function invoke_prepare_html_body($mode, $body)
+    {
+        $object = new \rcmail_action_mail_compose();
+
+        setProperty($object, 'COMPOSE', ['mode' => $mode], \rcmail_action_mail_compose::class);
+        setProperty($object, 'MESSAGE', (object) ['is_safe' => true], \rcmail_action_mail_compose::class);
+        setProperty($object, 'CID_MAP', [], \rcmail_action_mail_compose::class);
+
+        return invokeMethod($object, 'prepare_html_body', [$body], \rcmail_action_mail_compose::class);
+    }
+
+    /**
+     * Test that "Edit as New" (MODE_EDIT) does not wrap the body in a container
+     * element. Wrapping accumulates extra <div> tags on every edit/send cycle (#9919).
+     */
+    public function test_prepare_html_body_edit_mode_has_no_container()
+    {
+        $result = $this->invoke_prepare_html_body(\rcmail_sendmail::MODE_EDIT, '<p>Hello world</p>');
+
+        $this->assertStringNotContainsString('editbody', $result);
+        $this->assertStringNotContainsString('<div', $result);
+        $this->assertStringContainsString('Hello world', $result);
+    }
+
+    /**
+     * Test that reply mode still wraps the (quoted) body in a container element,
+     * so the #9919 fix does not regress style isolation for replies.
+     */
+    public function test_prepare_html_body_reply_mode_has_container()
+    {
+        $result = $this->invoke_prepare_html_body(\rcmail_sendmail::MODE_REPLY, '<p>Hello world</p>');
+
+        $this->assertStringContainsString('replybody', $result);
+        $this->assertStringContainsString('Hello world', $result);
     }
 }

--- a/tests/Actions/Mail/ComposeTest.php
+++ b/tests/Actions/Mail/ComposeTest.php
@@ -135,4 +135,23 @@ class ComposeTest extends ActionTestCase
         $this->assertStringContainsString('replybody', $result);
         $this->assertStringContainsString('Hello world', $result);
     }
+
+    /**
+     * Test that "Edit as New" (MODE_EDIT) does not wrap the body in a <div> even
+     * when the stored message's <body> tag carries a style attribute (as added by
+     * send.php's default_font/default_font_size wrapping on every send). Without
+     * this, the body callback still forwards the style attribute into a new <div>
+     * on every edit/send cycle, so the accumulation from #9919 continues, just
+     * without the "editbody" id (#9919).
+     */
+    public function test_prepare_html_body_edit_mode_strips_body_style()
+    {
+        $body = '<html><head></head><body style="font-size: 10pt; font-family: Verdana,Geneva,sans-serif;">'
+            . "\r\n<p>Hello world</p></body></html>";
+
+        $result = $this->invoke_prepare_html_body(\rcmail_sendmail::MODE_EDIT, $body);
+
+        $this->assertStringNotContainsString('<div', $result);
+        $this->assertStringContainsString('Hello world', $result);
+    }
 }

--- a/tests/Actions/Mail/ComposeTest.php
+++ b/tests/Actions/Mail/ComposeTest.php
@@ -5,6 +5,7 @@ namespace Roundcube\Tests\Actions\Mail;
 use Roundcube\Tests\ActionTestCase;
 use Roundcube\Tests\MessageMock;
 
+use function Roundcube\Tests\invokeMethod;
 use function Roundcube\Tests\setProperty;
 
 /**
@@ -94,5 +95,44 @@ class ComposeTest extends ActionTestCase
         $part = $set_part('*test* it!<img src=x onerror=\'alert("vulnerable!")\'/>');
         $result = $action->compose_part_body($part, false);
         $this->assertSame('_test_ it!', $result);
+    }
+
+    /**
+     * Invoke prepare_html_body() with a given compose mode and HTML body
+     */
+    private function invoke_prepare_html_body($mode, $body)
+    {
+        $object = new \rcmail_action_mail_compose();
+
+        setProperty($object, 'COMPOSE', ['mode' => $mode], \rcmail_action_mail_compose::class);
+        setProperty($object, 'MESSAGE', (object) ['is_safe' => true], \rcmail_action_mail_compose::class);
+        setProperty($object, 'CID_MAP', [], \rcmail_action_mail_compose::class);
+
+        return invokeMethod($object, 'prepare_html_body', [$body], \rcmail_action_mail_compose::class);
+    }
+
+    /**
+     * Test that "Edit as New" (MODE_EDIT) does not wrap the body in a container
+     * element. Wrapping accumulates extra <div> tags on every edit/send cycle (#9919).
+     */
+    public function test_prepare_html_body_edit_mode_has_no_container()
+    {
+        $result = $this->invoke_prepare_html_body(\rcmail_sendmail::MODE_EDIT, '<p>Hello world</p>');
+
+        $this->assertStringNotContainsString('editbody', $result);
+        $this->assertStringNotContainsString('<div', $result);
+        $this->assertStringContainsString('Hello world', $result);
+    }
+
+    /**
+     * Test that reply mode still wraps the (quoted) body in a container element,
+     * so the #9919 fix does not regress style isolation for replies.
+     */
+    public function test_prepare_html_body_reply_mode_has_container()
+    {
+        $result = $this->invoke_prepare_html_body(\rcmail_sendmail::MODE_REPLY, '<p>Hello world</p>');
+
+        $this->assertStringContainsString('replybody', $result);
+        $this->assertStringContainsString('Hello world', $result);
     }
 }

--- a/tests/Actions/Mail/ComposeTest.php
+++ b/tests/Actions/Mail/ComposeTest.php
@@ -154,4 +154,33 @@ class ComposeTest extends ActionTestCase
         $this->assertStringNotContainsString('<div', $result);
         $this->assertStringContainsString('Hello world', $result);
     }
+
+    /**
+     * Test that reopening a saved draft (MODE_DRAFT) does not wrap the body in a
+     * <div> either, mirroring MODE_EDIT - a draft can be saved and reopened
+     * repeatedly just like Edit-as-New resends, so it is susceptible to the same
+     * accumulation (#9919).
+     */
+    public function test_prepare_html_body_draft_mode_strips_body_style()
+    {
+        $body = '<html><head></head><body style="font-size: 10pt; font-family: Verdana,Geneva,sans-serif;">'
+            . "\r\n<p>Hello world</p></body></html>";
+
+        $result = $this->invoke_prepare_html_body(\rcmail_sendmail::MODE_DRAFT, $body);
+
+        $this->assertStringNotContainsString('<div', $result);
+        $this->assertStringContainsString('Hello world', $result);
+    }
+
+    /**
+     * Test that forward mode still wraps the body in a container element,
+     * so the #9919 fix does not regress style isolation for forwards.
+     */
+    public function test_prepare_html_body_forward_mode_has_container()
+    {
+        $result = $this->invoke_prepare_html_body(\rcmail_sendmail::MODE_FORWARD, '<p>Hello world</p>');
+
+        $this->assertStringContainsString('forwardbody', $result);
+        $this->assertStringContainsString('Hello world', $result);
+    }
 }


### PR DESCRIPTION
## Summary
Fixes #9919 — repeatedly using "Edit as New" on an HTML message caused extra `<div>` wrappers to accumulate in the message body on every cycle. This turned out to have two independent causes, both fixed here:

1. `prepare_html_body()` only skipped the container-id wrapper (`<div id="editbody...">`) for `MODE_DRAFT`, not `MODE_EDIT` ("Edit as New"). Since Edit-as-New reloads/resends the message like a draft, the wrapper was saved and re-added on every cycle.
2. Setting `ignore_elements => ['body']` for `MODE_DRAFT`/`MODE_EDIT` had no effect, because `wash_html()` unconditionally registers a callback for the `body` tag, and a registered callback takes precedence over `ignore_elements` in `rcube_washtml::dumpHtml()`. That callback unconditionally wraps the body (and its `style` attribute, e.g. the `font-size`/`font-family` added by `send.php` on every send) in a new `<div>` — so the accumulation continued even after fix #1, just without an `id`. Added a `skip_washer_body_callback` option (mirroring the existing `skip_washer_form_callback`/`skip_washer_style_callback` pattern) and set it for `MODE_DRAFT`/`MODE_EDIT` so the body tag and its attributes are dropped entirely, keeping only its content.

## Test plan
- [x] Unit tests in `tests/Actions/Mail/ComposeTest.php` covering `MODE_EDIT`, `MODE_DRAFT` (both must not wrap the body, including when the stored `<body>` tag carries a style attribute), and regression coverage for `MODE_REPLY`/`MODE_FORWARD` (must still wrap in a container)
- [x] Full PHPUnit suite run against this branch; the only remaining failures/errors (`ImapTest::test_sort_folder_list`, `ImageTest`, `SearchTest`, `InstallTest::test_check_mime_extensions`) were confirmed to pre-exist identically on unpatched `upstream/master` in a side-by-side worktree comparison — no regressions introduced
- [x] Manual side-by-side comparison of two live instances (pre-fix vs. patched), repeating "Edit as New" + Send 3-4x on an HTML message: pre-fix accumulates nested `<div>` wrappers (with growing ids, then style-only once fix #1 alone was applied); patched instance shows no wrapper at all, regardless of cycle count
- [x] Manual regression check of adjacent compose flows on the patched instance: save draft → reopen (no wrapper, as intended), Reply (still wraps in `<div id="replybody...">`, unaffected), Forward (still wraps in `<div id="forwardbody...">`, unaffected)