### PR TITLE
Remove unused variable n

### DIFF
--- a/program/js/app.js
+++ b/program/js/app.js
@@ -1460,7 +1460,7 @@ function rcube_webmail() {
                 return this.qsearch(props);
             // reset quicksearch
             case 'reset-search':
-                var n, s = this.env.search_request || this.env.qsearch;
+                var s = this.env.search_request || this.env.qsearch;
 
                 this.reset_qsearch(true);
 


### PR DESCRIPTION
The variable `n` here in [app.js](https://github.com/roundcube/roundcubemail/blob/master/program/js/app.js#L1462-L1479), is never set and never accessed and can be safely removed. Unnecessary unused bloat and variables hurts readability and maintainability of the code.