### PR TITLE
Wrap html2text-converted text in plain message-part, not html

### DIFF
--- a/program/actions/mail/show.php
+++ b/program/actions/mail/show.php
@@ -672,7 +672,7 @@ class rcmail_action_mail_show extends rcmail_action_mail_index
                         ['part' => $part, 'prefix' => '', 'message' => self::$MESSAGE]);
 
                     // Set attributes of the part container
-                    $container_class = $part->ctype_secondary == 'html' ? 'message-htmlpart' : 'message-part';
+                    $container_class = ($part->ctype_secondary == 'html' && $rcmail->config->get('prefer_html')) ? 'message-htmlpart' : 'message-part';
                     $container_id = $container_class . (++$part_no);
                     $container_attrib = ['class' => $container_class, 'id' => $container_id];
 


### PR DESCRIPTION
When user has "prefer_html" option, we display output of html2text (can be noticed by presence of [1], [2] links), which should be rendered as plain text (fixed-width font and dark background if dark mode is enabled)

"before" and "after" screenshots:

<img width="300" alt="before: variable width font, white background in dark mode" src="https://github.com/user-attachments/assets/3c063df9-912a-4e29-b856-b9c8feca4b07" />
<img width="300" alt="after: fixed width font, dark background in dark mode" src="https://github.com/user-attachments/assets/7428fae9-f520-40a4-b5e9-5c1c1c3bf03e" />
