### PR TITLE
Fix bug where toolbar was hidden after resizing the window from small to normal/large mode (#9085)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file includes only changes we consider noteworthy for users, admins and plu
 
 ## Unreleased
 
+- Fix bug where toolbar was hidden after resizing the window from small to normal/large mode (#9085)
 - Preserve the original message date on import of EML messages (#5559, #10251)
 - OAuth: Validate JWT token signature (#10210)
 - Use `X-Content-Type-Options:nosniff` for attachment previews and downloads (#10308)

--- a/skins/elastic/ui.js
+++ b/skins/elastic/ui.js
@@ -1878,7 +1878,7 @@ function rcube_elastic_ui() {
         buttons.back_list.filter(function () {
             return $(this).parents('#layout-sidebar').length == 0;
         }).hide();
-        $('ul.menu.popupmenu').removeClass('popupmenu');
+        $('ul.menu.popupmenu').removeClass('popupmenu hidden');
     }
 
     function show_content(unsticky) {


### PR DESCRIPTION
Fixes #9085

Closing a popup menu in small-screen mode adds the `hidden` class to the menu element (popup hide handler). When the window is then resized back to normal/large, `screen_resize_small_none()` removes `popupmenu` but not `hidden`, so the toolbar stays blank. Remove both classes.