### PR TITLE
Fix bug where labels in the compose form headers were too far from inputs on wide screens (#8913)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file includes only changes we consider noteworthy for users, admins and plu
 
 ## Unreleased
 
+- Fix bug where labels in the compose form headers were too far from inputs on wide screens (#8913)
 - Preserve the original message date on import of EML messages (#5559, #10251)
 - OAuth: Validate JWT token signature (#10210)
 - Use `X-Content-Type-Options:nosniff` for attachment previews and downloads (#10308)

--- a/skins/elastic/styles/styles.less
+++ b/skins/elastic/styles/styles.less
@@ -434,6 +434,21 @@ body.task-error-login #layout {
     margin: 1rem 1rem 0 1rem;
 }
 
+// Fix compose headers label column width (#8913). Bootstrap's col-2 (16.66%)
+// makes the labels too far from inputs when the content area is wide.
+#compose-headers {
+    @media screen and (min-width: (@screen-width-small + 1px)) {
+        .col-2 {
+            max-width: 110px;
+        }
+
+        .col-10 {
+            max-width: 100%;
+            flex: 1;
+        }
+    }
+}
+
 .suspicious-address-warning:before {
     .font-icon-class();
     float: none;


### PR DESCRIPTION
Fixes #8913

The compose header labels use Bootstrap's `col-2` (16.67% of the row), which grows with the content area and leaves a large gap between label and input on wide screens. Cap the label column at 110px and let the input column fill the rest, as proposed in the issue.