### PR TITLE
Fix bug where printing with scaling above 120% was cutting off text (#10298)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file includes only changes we consider noteworthy for users, admins and plu
 
 ## Unreleased
 
+- Fix bug where printing with scaling above 120% was cutting off text (#10298)
 - Preserve the original message date on import of EML messages (#5559, #10251)
 - OAuth: Validate JWT token signature (#10210)
 - Use `X-Content-Type-Options:nosniff` for attachment previews and downloads (#10308)

--- a/skins/elastic/styles/print.less
+++ b/skins/elastic/styles/print.less
@@ -11,9 +11,16 @@
 
 /*** Additional styles for printouts ***/
 
+// Bootstrap's print styles set @page size to a3 and body min-width to 992px,
+// which breaks printing with scaling above 120% (text is cut off) (#10298)
+@page {
+    size: auto;
+}
+
 body {
     overflow: auto;
     height: auto;
+    min-width: 0 !important;
 }
 
 #print-layout {


### PR DESCRIPTION
Fixes #10298

Bootstrap's print styles force `@page { size: a3 }` and `body { min-width: 992px !important }`, so the browser pre-scales the A3 layout onto the paper and above ~120% scaling the 992px minimum makes text overflow and get cut off instead of wrapping. Override both in Elastic's print styles (`size: auto`, `min-width: 0 !important`) instead of users patching bootstrap.min.css by hand on every update.