### PR TITLE
Fix bug where the refresh interval setting was displayed as "never" and could get overwritten on save for values outside the options list (#10292)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file includes only changes we consider noteworthy for users, admins and plu
 
 ## Unreleased
 
+- Fix bug where the refresh interval setting was displayed as "never" and could get overwritten on save for values outside the options list (#10292)
 - Preserve the original message date on import of EML messages (#5559, #10251)
 - OAuth: Validate JWT token signature (#10210)
 - Use `X-Content-Type-Options:nosniff` for attachment previews and downloads (#10308)

--- a/program/actions/settings/index.php
+++ b/program/actions/settings/index.php
@@ -298,17 +298,35 @@ class rcmail_action_settings_index extends rcmail_action
                             'class' => 'custom-select',
                         ]);
 
-                        $select->add($rcmail->gettext('never'), 0);
+                        $interval = (int) $config['refresh_interval'];
+                        $intervals = [0];
+
                         foreach ([1, 3, 5, 10, 15, 30, 60] as $min) {
                             if (!$config['min_refresh_interval'] || $config['min_refresh_interval'] <= $min * 60) {
-                                $label = $rcmail->gettext(['name' => 'everynminutes', 'vars' => ['n' => $min]]);
-                                $select->add($label, $min);
+                                $intervals[] = $min * 60;
+                            }
+                        }
+
+                        // add the current interval to the list of options,
+                        // so the current setting is displayed correctly (#10292)
+                        if ($interval && !in_array($interval, $intervals)) {
+                            $intervals[] = $interval;
+                            sort($intervals);
+                        }
+
+                        foreach ($intervals as $opt) {
+                            if (!$opt) {
+                                $select->add($rcmail->gettext('never'), 0);
+                            } elseif (!($opt % 60)) {
+                                $select->add($rcmail->gettext(['name' => 'everynminutes', 'vars' => ['n' => $opt / 60]]), $opt);
+                            } else {
+                                $select->add($rcmail->gettext(['name' => 'everynseconds', 'vars' => ['n' => $opt]]), $opt);
                             }
                         }
 
                         $blocks['main']['options']['refresh_interval'] = [
                             'title' => html::label($field_id, rcube::Q($rcmail->gettext('refreshinterval'))),
-                            'content' => $select->show($config['refresh_interval'] / 60),
+                            'content' => $select->show($interval),
                         ];
                     }
 

--- a/program/actions/settings/prefs_save.php
+++ b/program/actions/settings/prefs_save.php
@@ -46,7 +46,7 @@ class rcmail_action_settings_prefs_save extends rcmail_action
                     'time_format' => self::prefs_input('time_format', '/^[a-zA-Z0-9: ]+$/'),
                     'prettydate' => isset($_POST['_pretty_date']),
                     'display_next' => isset($_POST['_display_next']),
-                    'refresh_interval' => self::prefs_input_int('refresh_interval') * 60,
+                    'refresh_interval' => self::prefs_input_int('refresh_interval'),
                     'standard_windows' => isset($_POST['_standard_windows']),
                     'skin' => self::prefs_input('skin', '/^[a-zA-Z0-9_.-]+$/'),
                 ];

--- a/program/localization/en_US/labels.inc
+++ b/program/localization/en_US/labels.inc
@@ -578,6 +578,7 @@ $labels['alwaysbutplain'] = 'always, except when replying to plain text';
 $labels['showinlineimages'] = 'Display attached images below the message';
 $labels['autosavedraft'] = 'Automatically save draft';
 $labels['everynminutes'] = 'every $n minute(s)';
+$labels['everynseconds'] = 'every $n second(s)';
 $labels['refreshinterval'] = 'Refresh (check for new messages, etc.)';
 $labels['never'] = 'never';
 $labels['immediately'] = 'immediately';

--- a/tests/Actions/Settings/IndexTest.php
+++ b/tests/Actions/Settings/IndexTest.php
@@ -48,6 +48,32 @@ class IndexTest extends ActionTestCase
     }
 
     /**
+     * Test user_prefs() output for refresh_interval values that are not
+     * in the standard options list (#10292)
+     */
+    public function test_user_prefs_refresh_interval()
+    {
+        $rcmail = \rcube::get_instance();
+        $rcmail->config->set('refresh_interval', 30);
+
+        $result = \rcmail_action_settings_index::user_prefs('general');
+        $content = $result[0]['general']['blocks']['main']['options']['refresh_interval']['content'];
+
+        // the current sub-minute interval must be offered and selected
+        $this->assertStringContainsString('<option value="30" selected="selected">every 30 second(s)</option>', $content);
+
+        $rcmail->config->set('refresh_interval', 120);
+
+        $result = \rcmail_action_settings_index::user_prefs('general');
+        $content = $result[0]['general']['blocks']['main']['options']['refresh_interval']['content'];
+
+        // the same for an unlisted whole-minute interval
+        $this->assertStringContainsString('<option value="120" selected="selected">every 2 minute(s)</option>', $content);
+
+        $rcmail->config->set('refresh_interval', 60);
+    }
+
+    /**
      * Test get_skins() method
      */
     public function test_get_skins()

--- a/tests/Actions/Settings/IndexTest.php
+++ b/tests/Actions/Settings/IndexTest.php
@@ -54,23 +54,27 @@ class IndexTest extends ActionTestCase
     public function test_user_prefs_refresh_interval()
     {
         $rcmail = \rcube::get_instance();
-        $rcmail->config->set('refresh_interval', 30);
+        $interval = $rcmail->config->get('refresh_interval');
 
-        $result = \rcmail_action_settings_index::user_prefs('general');
-        $content = $result[0]['general']['blocks']['main']['options']['refresh_interval']['content'];
+        try {
+            $rcmail->config->set('refresh_interval', 30);
 
-        // the current sub-minute interval must be offered and selected
-        $this->assertStringContainsString('<option value="30" selected="selected">every 30 second(s)</option>', $content);
+            $result = \rcmail_action_settings_index::user_prefs('general');
+            $content = $result[0]['general']['blocks']['main']['options']['refresh_interval']['content'];
 
-        $rcmail->config->set('refresh_interval', 120);
+            // the current sub-minute interval must be offered and selected
+            $this->assertStringContainsString('<option value="30" selected="selected">every 30 second(s)</option>', $content);
 
-        $result = \rcmail_action_settings_index::user_prefs('general');
-        $content = $result[0]['general']['blocks']['main']['options']['refresh_interval']['content'];
+            $rcmail->config->set('refresh_interval', 120);
 
-        // the same for an unlisted whole-minute interval
-        $this->assertStringContainsString('<option value="120" selected="selected">every 2 minute(s)</option>', $content);
+            $result = \rcmail_action_settings_index::user_prefs('general');
+            $content = $result[0]['general']['blocks']['main']['options']['refresh_interval']['content'];
 
-        $rcmail->config->set('refresh_interval', 60);
+            // the same for an unlisted whole-minute interval
+            $this->assertStringContainsString('<option value="120" selected="selected">every 2 minute(s)</option>', $content);
+        } finally {
+            $rcmail->config->set('refresh_interval', $interval);
+        }
     }
 
     /**

--- a/tests/Actions/Settings/PrefsSaveTest.php
+++ b/tests/Actions/Settings/PrefsSaveTest.php
@@ -22,11 +22,13 @@ class PrefsSaveTest extends ActionTestCase
 
         // TODO: Test all sections
         $_POST['_section'] = 'general';
+        $_POST['_refresh_interval'] = '300';
 
         $action->run();
 
         $this->assertSame('edit-prefs', \rcmail::get_instance()->action);
         $this->assertSame('successfullysaved', $output->getProperty('message'));
+        $this->assertSame(300, \rcmail::get_instance()->user->get_prefs()['refresh_interval']);
     }
 
     /**

--- a/tests/Browser/Settings/Preferences/GeneralTest.php
+++ b/tests/Browser/Settings/Preferences/GeneralTest.php
@@ -77,7 +77,7 @@ class GeneralTest extends TestCase
 
                     $browser->assertSeeIn('label[for=rcmfd_refresh_interval]', 'Refresh');
                     $browser->assertVisible('select[name=_refresh_interval]');
-                    $browser->assertSelected('select[name=_refresh_interval]', $this->app->config->get('refresh_interval') / 60);
+                    $browser->assertSelected('select[name=_refresh_interval]', $this->app->config->get('refresh_interval'));
                 });
 
                 // TODO: Interface Skin fieldset
@@ -113,7 +113,7 @@ class GeneralTest extends TestCase
             'timezone' => 'Pacific/Midway',
             'time_format' => 'h:i A',
             'date_format' => 'd-m-Y',
-            'refresh_interval' => 60,
+            'refresh_interval' => 300,
             'pretty_date' => !boolval($this->app->config->get('prettydate')),
             'display_next' => !boolval($this->app->config->get('display_next')),
             'standard_windows' => !boolval($this->app->config->get('standard_windows')),
@@ -165,6 +165,6 @@ class GeneralTest extends TestCase
         }
 
         $this->assertSame($this->settings['pretty_date'], $prefs['prettydate']);
-        $this->assertSame($this->settings['refresh_interval'], $prefs['refresh_interval'] / 60);
+        $this->assertSame($this->settings['refresh_interval'], $prefs['refresh_interval']);
     }
 }


### PR DESCRIPTION
Fixes #10292

The select only offered 0 (never) and whole minutes [1,3,5,10,15,30,60], so values like 30 seconds or 2 minutes rendered as "never", and saving the form stored 0, wiping the setting. Make the select seconds-based (same pattern as draft_autosave in the same function), add the current interval as an extra option when it's not in the list, and store the posted value as-is. Adds an everynseconds label for sub-minute values.