### PR TITLE
Elastic: Fix dark mode special-buttons background, add dedicated color variables (#9612)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This file includes only changes we consider noteworthy for users, admins and plu
 
 ## Unreleased
 
-- Elastic: Fix bug where dark mode special-buttons in the task menu ignored hover/selected states and theming, add dedicated color variables (#9612)
+- Elastic: Fix bug where dark mode task menu special-buttons ignored hover/selected states, and make the background themable via dedicated color variables (#9612)
 - Preserve the original message date on import of EML messages (#5559, #10251)
 - OAuth: Validate JWT token signature (#10210)
 - Use `X-Content-Type-Options:nosniff` for attachment previews and downloads (#10308)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file includes only changes we consider noteworthy for users, admins and plu
 
 ## Unreleased
 
+- Elastic: Fix bug where dark mode special-buttons in the task menu ignored hover/selected states and theming, add dedicated color variables (#9612)
 - Preserve the original message date on import of EML messages (#5559, #10251)
 - OAuth: Validate JWT token signature (#10210)
 - Use `X-Content-Type-Options:nosniff` for attachment previews and downloads (#10308)

--- a/skins/elastic/styles/colors.less
+++ b/skins/elastic/styles/colors.less
@@ -39,6 +39,7 @@
 
 // Task menu
 @color-taskmenu-background:                     #2f3a3f;
+@color-taskmenu-special-buttons-background:     @color-taskmenu-background;
 @color-taskmenu-button:                         #fff;
 @color-taskmenu-button-selected:                @color-taskmenu-button;
 @color-taskmenu-button-action:                  @color-main;
@@ -224,6 +225,7 @@
 // Dark mode colors
 @color-dark-main:           darken(@color-main, 30%);
 @color-dark-background:     #21292c;
+@color-dark-taskmenu-special-buttons-background: @color-dark-background;
 @color-dark-font:           #c5d1d3;
 @color-dark-border:         #4d6066;
 @color-dark-hint:           darken(@color-dark-font, 20%);

--- a/skins/elastic/styles/dark.less
+++ b/skins/elastic/styles/dark.less
@@ -65,9 +65,14 @@ html.dark-mode {
         background: unset;
         border-right: 1px solid @color-dark-border;
 
-        .popover-header,
-        .special-buttons {
+        .popover-header {
             background: transparent !important;
+        }
+
+        @media screen and (min-width: (@screen-width-xs + 1px)) {
+            .special-buttons {
+                background: @color-dark-taskmenu-special-buttons-background;
+            }
         }
 
         @media screen and (max-width: @screen-width-xs) {
@@ -76,10 +81,6 @@ html.dark-mode {
             .popover-header {
                 border-bottom: 1px solid @color-dark-border;
             }
-        }
-
-        .special-buttons a:not(:focus) {
-            background: @color-dark-background;
         }
     }
 

--- a/skins/elastic/styles/widgets/menu.less
+++ b/skins/elastic/styles/widgets/menu.less
@@ -890,7 +890,7 @@ a.toolbar-button {
             position: absolute;
             bottom: 0;
             left: 0;
-            background-color: @color-taskmenu-background;
+            background-color: @color-taskmenu-special-buttons-background;
         }
 
         .action-buttons {


### PR DESCRIPTION
Fixes #9612

Dark mode made the special-buttons container transparent and repainted its anchors via a high-specificity `a:not(:focus)` rule, which suppressed the hover/selected highlight states on those buttons and mismatched the phone layout menu background. Paint the container instead (scoped like the light-mode rule) and drop the anchor rule. The light and dark special-buttons backgrounds are now driven by dedicated color variables, so they can be themed independently.