### PR TITLE
Fix an inaccurate copy-pasted comment and the concat() PHPDoc

### DIFF
--- a/program/actions/mail/mark.php
+++ b/program/actions/mail/mark.php
@@ -116,7 +116,7 @@ class rcmail_action_mail_mark extends rcmail_action_mail_index
             } else {
                 $search_request = rcube_utils::get_input_value('_search', rcube_utils::INPUT_GPC);
 
-                // refresh saved search set after moving some messages
+                // refresh saved search set after marking some messages as deleted
                 if ($search_request && $rcmail->storage->get_search_set()) {
                     $_SESSION['search'] = $rcmail->storage->refresh_search();
                 }

--- a/program/lib/Roundcube/db/mysql.php
+++ b/program/lib/Roundcube/db/mysql.php
@@ -41,7 +41,9 @@ class rcube_db_mysql extends rcube_db
     /**
      * Abstract SQL statement for value concatenation
      *
-     * @return string ...$args Values to concatenate
+     * @param string ...$args Values to concatenate
+     *
+     * @return string
      */
     #[\Override]
     public function concat(...$args)


### PR DESCRIPTION
## Summary

Two small correctness fixes in comments/PHPDoc. Base branch is `master`.

- **program/actions/mail/mark.php:119** - `// refresh saved search set after moving some messages` -> `// refresh saved search set after marking some messages as deleted`

  Nothing is moved in the mark action; it only sets and clears IMAP flags. The branch this comment sits in is `$flag == 'DELETED' && $skip_deleted`, i.e. messages disappearing from the list because they were flagged deleted. The identical line exists verbatim in `program/actions/mail/move.php:87`, where it is accurate, which is where it was copied from.

- **program/lib/Roundcube/db/mysql.php:44** - `@return string ...$args Values to concatenate` -> `@param string ...$args Values to concatenate` plus a bare `@return string`

  `...$args` is the parameter list, not the return value; the method returns the `CONCAT(...)` string. The new layout matches the `@param` / blank / `@return` shape already used elsewhere in the same file (e.g. `dsn_string()` at lines 59-61).

### Two related occurrences I deliberately did not touch

Say the word and I will fold either in:

- `program/actions/mail/delete.php:71` carries the same copy-pasted "after moving" comment.
- `program/lib/Roundcube/rcube_db.php:1088` - the abstract parent of the method above - has the same `@return string ...$args` mistake.

No functional changes: comments and PHPDoc only. No CHANGELOG entry, since neither change is noteworthy for users, admins or plugin authors.